### PR TITLE
Use "pg_auto_failover monitor" for name of the background worker

### DIFF
--- a/src/monitor/health_check_worker.c
+++ b/src/monitor/health_check_worker.c
@@ -228,7 +228,7 @@ HealthCheckWorkerLauncherMain(Datum arg)
 	BackgroundWorkerInitializeConnection(NULL, NULL, 0);
 
 	/* Make background worker recognisable in pg_stat_activity */
-	pgstat_report_appname("pg_auto_failover health check launcher");
+	pgstat_report_appname("pg_auto_failover monitor launcher");
 
 	launcherContext = AllocSetContextCreateExtended(CurrentMemoryContext,
 													"Health Check Launcher Context",
@@ -329,7 +329,7 @@ StartHealthCheckWorker(DatabaseListEntry *db)
 	snprintf(worker.bgw_library_name, BGW_MAXLEN, "pgautofailover");
 	snprintf(worker.bgw_function_name, BGW_MAXLEN, "HealthCheckWorkerMain");
 	snprintf(worker.bgw_name, BGW_MAXLEN,
-			 "pg_auto_failover_health_checker worker");
+			 "pg_auto_failover monitor worker");
 
 	if (!RegisterDynamicBackgroundWorker(&worker, &handle))
 	{

--- a/src/monitor/pg_auto_failover.c
+++ b/src/monitor/pg_auto_failover.c
@@ -139,7 +139,7 @@ StartMonitorNode(void)
 	worker.bgw_main_arg = Int32GetDatum(0);
 	worker.bgw_notify_pid = 0;
 	sprintf(worker.bgw_library_name, "pgautofailover");
-	snprintf(worker.bgw_name, BGW_MAXLEN, "pgautofailover_health_checker");
+	snprintf(worker.bgw_name, BGW_MAXLEN, "pg_auto_failover monitor");
 	sprintf(worker.bgw_function_name, "HealthCheckWorkerLauncherMain");
 
 	RegisterBackgroundWorker(&worker);


### PR DESCRIPTION
Previously this was inconsistent, and I think we can use "monitor" here for clarity.

For context, this is how it looked like in the process list:

```
postgres  7018  0.0  0.6 324708 26212 ?        S    05:33   0:00 /usr/lib/postgresql/11/bin/postgres -D /data -p 5432 -h *
postgres  7021  0.0  0.1 324832  7604 ?        Ss   05:33   0:00 postgres: checkpointer   
postgres  7022  0.0  0.1 324708  5396 ?        Ss   05:33   0:00 postgres: background writer   
postgres  7023  0.0  0.2 324708 10044 ?        Ss   05:33   0:00 postgres: walwriter   
postgres  7024  0.0  0.1 325132  6480 ?        Ss   05:33   0:00 postgres: autovacuum launcher   
postgres  7025  0.0  0.1 179748  4436 ?        Ss   05:33   0:00 postgres: stats collector   
postgres  7026  0.0  0.1 325020  6740 ?        Ss   05:33   0:00 postgres: pgautofailover_health_checker   
postgres  7027  0.0  0.1 325020  6528 ?        Ss   05:33   0:00 postgres: logical replication launcher   
postgres  7028  0.0  0.2 325644 10812 ?        Ss   05:33   0:00 postgres: pg_auto_failover_health_checker worker   
postgres  7034  0.0  0.2 325660 12000 ?        Ss   05:33   0:00 postgres: pg_auto_failover_health_checker worker
```