### PR TITLE
Implement pg_autoctl show ipaddr|cidr.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Once the building and installation is done, follow those steps:
 
      ~~~ bash
      $ pg_autoctl create monitor --pgdata /path/to/pgdata     \
-                                 --nodename `hostname --fqdn`
+                                 --nodename `pg_autoctl show ipaddr`
      ~~~
 
      Once this command is done, you should have a running PostgreSQL
@@ -97,7 +97,7 @@ Once the building and installation is done, follow those steps:
 
      ~~~ bash
      $ pg_autoctl create postgres --pgdata /path/to/pgdata     \
-                                  --nodename `hostname --fqdn`  \
+                                  --nodename `pg_autoctl show ipaddr`  \
                                   --monitor postgres://autoctl_node@host/pg_auto_failover
      ~~~
 
@@ -153,7 +153,7 @@ Once the building and installation is done, follow those steps:
 
      ~~~ bash
      $ pg_autoctl create postgres --pgdata /path/to/pgdata     \
-                                  --nodename `hostname -fqdn`  \
+                                  --nodename `pg_autoctl show ipaddr`  \
                                   --monitor postgres://autoctl_node@host/pg_auto_failover
      ~~~
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -53,7 +53,7 @@ distinctive port (6000):
    pg_autoctl create monitor   \
      --pgdata ./monitor     \
      --pgport 6000          \
-     --nodename `hostname --fqdn`
+     --nodename `pg_autoctl show ipaddr`
 
 This command initializes a PostgreSQL cluster at the location pointed
 by the ``--pgdata`` option. When ``--pgdata`` is omitted, ``pg_autoctl``

--- a/docs/ref/reference.rst
+++ b/docs/ref/reference.rst
@@ -56,6 +56,8 @@ keeper::
       uri     Show the postgres uri to use to connect to pg_auto_failover nodes
       events  Prints monitor's state of nodes in a given formation and group
       state   Prints monitor's state of nodes in a given formation and group
+      ipaddr  Print this node's IP address information
+      cidr    Print this node's CIDR information
 
     pg_autoctl enable
       secondary  Enable secondary nodes on a formation
@@ -206,6 +208,21 @@ commands can be used, from any node in the setup.
 
     For details about the options to the command, see above in the ``pg_autoctl
     show events`` command.
+
+  - ``pg_autoctl show ipaddr``
+
+    This command outputs the Local Area Network IP address of the current
+    host, as discoverd by ``pg_autoctl`` and used to compute the CIDR to
+    open in the Postgres HBA file.
+
+    This command can be used to register the ``--nodename`` of the current
+    node to the monitor at ``pg_autoctl create`` time.
+
+  - ``pg_autoctl show cidr``
+
+    This command outputs the local network CIDR address range as discovered
+    by ``pg_autoctl`` and used when computing the connection privileges to
+    grant in the Postgres HBA file.
 
 pg_auto_failover Postgres Node Initialization
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/bin/pg_autoctl/cli_common.h
+++ b/src/bin/pg_autoctl/cli_common.h
@@ -84,6 +84,8 @@ extern CommandLine service_reload_command;
 extern CommandLine show_uri_command;
 extern CommandLine show_events_command;
 extern CommandLine show_state_command;
+extern CommandLine show_ipaddr_command;
+extern CommandLine show_cidr_command;
 
 
 int cli_create_node_getopts(int argc, char **argv,

--- a/src/bin/pg_autoctl/cli_root.c
+++ b/src/bin/pg_autoctl/cli_root.c
@@ -37,6 +37,8 @@ CommandLine *show_subcommands[] = {
 	&show_uri_command,
 	&show_events_command,
 	&show_state_command,
+	&show_ipaddr_command,
+	&show_cidr_command,
 	NULL
 };
 

--- a/src/bin/pg_autoctl/cli_show.c
+++ b/src/bin/pg_autoctl/cli_show.c
@@ -33,6 +33,8 @@ static int eventCount = 10;
 static int cli_show_state_getopts(int argc, char **argv);
 static void cli_show_state(int argc, char **argv);
 static void cli_show_events(int argc, char **argv);
+static void cli_show_ipaddr(int argc, char **argv);
+static void cli_show_cidr(int argc, char **argv);
 
 static int cli_show_uri_getopts(int argc, char **argv);
 static void cli_show_uri(int argc, char **argv);
@@ -69,7 +71,15 @@ CommandLine show_state_command =
 				 cli_show_state_getopts,
 				 cli_show_state);
 
+CommandLine show_ipaddr_command =
+	make_command("ipaddr",
+				 "Print this node's IP address information", "", "",
+				 NULL, cli_show_ipaddr);
 
+CommandLine show_cidr_command =
+	make_command("cidr",
+				 "Print this node's CIDR information", "", "",
+				 NULL, cli_show_cidr);
 
 /*
  * keeper_cli_monitor_state_getopts parses the command line options for the
@@ -425,4 +435,50 @@ cli_show_monitor_uri(int argc, char **argv)
 			exit(EXIT_CODE_INTERNAL_ERROR);
 		}
 	}
+}
+
+
+/*
+ * cli_show_ipaddr displays the LAN IP address of the current node, as used
+ * when computing the CIDR address range to open in the HBA file.
+ */
+static void
+cli_show_ipaddr(int argc, char **argv)
+{
+	char ipAddr[BUFSIZE];
+
+	if (!fetchLocalIPAddress(ipAddr, BUFSIZE))
+	{
+		log_warn("Failed to determine network configuration.");
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+
+	fprintf(stdout, "%s\n", ipAddr);
+}
+
+
+/*
+ * cli_show_cidr displays the LAN CIDR that pg_autoctl grants connections to in
+ * the HBA file for setting up Postgres streaming replication and connections
+ * to the monitor.
+ */
+static void
+cli_show_cidr(int argc, char **argv)
+{
+	char ipAddr[BUFSIZE];
+	char cidr[BUFSIZE];
+
+	if (!fetchLocalIPAddress(ipAddr, BUFSIZE))
+	{
+		log_warn("Failed to determine network configuration.");
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+
+	if (!fetchLocalCIDR(ipAddr, cidr, BUFSIZE))
+	{
+		log_warn("Failed to determine network configuration.");
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+
+	fprintf(stdout, "%s\n", cidr);
 }


### PR DESCRIPTION
Rather than using `hostname -fqdn` we introduce new commands `show ipaddr`
which displays the discovered LAN ip address, and `show cidr` which allows
for debugging pg_autoctl HBA edits.

Those commands would be nice additions to the PG_AUTOCTL_DEBUG mode for the
command line, but it seems that in some environments with broken reverse DNS
we need an easy way to discover the LAN IP address from the command line. A
quick search shows it's pretty hard to do that with classic OS tooling in a
portable way, and we already have had to write code for that feature in
pg_auto_failover anyway. This patch exposes the feature to the end users.

See #6.