### PR TITLE
Implement checking and upgrading of the pgautofailover extension.

### DIFF
--- a/docs/ref/reference.rst
+++ b/docs/ref/reference.rst
@@ -480,6 +480,7 @@ commands, only available in debug environments::
       active    Call in the pg_auto_failover Node Active protocol
       pause     Pause pg_auto_failover on this node
       resume    Resume pg_auto_failover on this node
+      version   Check that monitor version is 1.0; alter extension update if not
 
     pg_autoctl do monitor get
       primary      Get the primary node from pg_auto_failover in given formation/group

--- a/src/bin/pg_autoctl/cli_do_monitor.c
+++ b/src/bin/pg_autoctl/cli_do_monitor.c
@@ -116,7 +116,9 @@ static CommandLine monitor_resume_node_command =
 
 static CommandLine monitor_version_command =
 	make_command("version",
-				 "Check and display monitor's extension version",
+				 "Check that monitor version is "
+				 PG_AUTOCTL_EXTENSION_VERSION
+				 "; alter extension update if not",
 				 " [ --pgdata ]",
 				 KEEPER_CLI_PGDATA_OPTION,
 				 keeper_cli_getopt_pgdata,
@@ -574,7 +576,10 @@ cli_monitor_resume_node(int argc, char **argv)
 
 
 /*
- * cli_monitor_version checks and displays the monitor extension version.
+ * cli_monitor_version ensures that the version of the monitor is the one that
+ * is expected by pg_autoctl too. When that's not the case, the command issues
+ * an ALTER EXTENSION ... UPDATE TO ... to ensure that the monitor is now
+ * running the expected version number.
  */
 static void
 cli_monitor_version(int argc, char **argv)

--- a/src/bin/pg_autoctl/cli_do_monitor.c
+++ b/src/bin/pg_autoctl/cli_do_monitor.c
@@ -43,6 +43,7 @@ static void keeper_cli_monitor_register_node(int argc, char **argv);
 static void keeper_cli_monitor_node_active(int argc, char **argv);
 static void cli_monitor_pause_node(int argc, char **argv);
 static void cli_monitor_resume_node(int argc, char **argv);
+static void cli_monitor_version(int argc, char **argv);
 
 
 static CommandLine monitor_get_primary_command =
@@ -113,12 +114,21 @@ static CommandLine monitor_resume_node_command =
 				 keeper_cli_getopt_pgdata,
 				 cli_monitor_resume_node);
 
+static CommandLine monitor_version_command =
+	make_command("version",
+				 "Check and display monitor's extension version",
+				 " [ --pgdata ]",
+				 KEEPER_CLI_PGDATA_OPTION,
+				 keeper_cli_getopt_pgdata,
+				 cli_monitor_version);
+
 static CommandLine *monitor_subcommands[] = {
 	&monitor_get_command,
 	&monitor_register_command,
 	&monitor_node_active_command,
 	&monitor_pause_node_command,
 	&monitor_resume_node_command,
+	&monitor_version_command,
 	NULL
 };
 
@@ -560,4 +570,31 @@ cli_monitor_resume_node(int argc, char **argv)
 
 	log_info("Node %s:%d will exit from maintenance state soon",
 			 keeper.config.nodename, keeper.config.pgSetup.pgport);
+}
+
+
+/*
+ * cli_monitor_version checks and displays the monitor extension version.
+ */
+static void
+cli_monitor_version(int argc, char **argv)
+{
+	KeeperConfig config = keeperOptions;
+	Monitor monitor = { 0 };
+	MonitorExtensionVersion version = { 0 };
+
+	if (!monitor_init_from_pgsetup(&monitor, &config.pgSetup))
+	{
+		/* errors have already been logged */
+		exit(EXIT_CODE_BAD_ARGS);
+	}
+
+	/* Check version compatibility */
+	if (!monitor_ensure_extension_version(&monitor, &version))
+	{
+		/* errors have already been logged */
+		exit(EXIT_CODE_MONITOR);
+	}
+
+	fprintf(stdout, "%s\n", version.installedVersion);
 }

--- a/src/bin/pg_autoctl/cli_service.c
+++ b/src/bin/pg_autoctl/cli_service.c
@@ -140,6 +140,12 @@ cli_keeper_run(int argc, char **argv)
 		exit(EXIT_CODE_PGCTL);
 	}
 
+	if (!keeper_check_monitor_extension_version(&keeper))
+	{
+		/* errors have already been logged */
+		exit(EXIT_CODE_MONITOR);
+	}
+
 	keeper_service_run(&keeper, &pid);
 }
 
@@ -195,6 +201,14 @@ cli_monitor_run(int argc, char **argv)
 	log_info("PostgreSQL is running in \"%s\" on port %d",
 			 mconfig.pgSetup.pgdata, mconfig.pgSetup.pgport);
 
+	/* Check version compatibility */
+	if (!monitor_ensure_extension_version(&monitor))
+	{
+		/* errors have already been logged */
+		exit(EXIT_CODE_MONITOR);
+	}
+
+	/* Now get the the Monitor URI to display it to the user, and move along */
 	if (monitor_config_get_postgres_uri(&mconfig, postgresUri, MAXCONNINFO))
 	{
 		log_info("pg_auto_failover monitor is ready at %s", postgresUri);

--- a/src/bin/pg_autoctl/cli_service.c
+++ b/src/bin/pg_autoctl/cli_service.c
@@ -161,7 +161,9 @@ cli_monitor_run(int argc, char **argv)
 	char configFilePath[MAXPGPATH];
 	KeeperConfig kconfig = keeperOptions;
 	MonitorConfig mconfig = { 0 };
+
 	Monitor monitor = { 0 };
+	MonitorExtensionVersion version = { 0 };
 	char postgresUri[MAXCONNINFO];
 
 	PostgresSetup existingPgSetup = { 0 };
@@ -202,7 +204,7 @@ cli_monitor_run(int argc, char **argv)
 			 mconfig.pgSetup.pgdata, mconfig.pgSetup.pgport);
 
 	/* Check version compatibility */
-	if (!monitor_ensure_extension_version(&monitor))
+	if (!monitor_ensure_extension_version(&monitor, &version))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_MONITOR);

--- a/src/bin/pg_autoctl/defaults.h
+++ b/src/bin/pg_autoctl/defaults.h
@@ -16,6 +16,9 @@
 /* additional version information for printing version on CLI */
 #define PG_AUTOCTL_VERSION "1.0.2"
 
+/* version of the extension that we requite to talk to on the monitor */
+#define PG_AUTOCTL_EXTENSION_VERSION "1.0"
+
 /* environment variable to use to make DEBUG facilities available */
 #define PG_AUTOCTL_DEBUG "PG_AUTOCTL_DEBUG"
 

--- a/src/bin/pg_autoctl/defaults.h
+++ b/src/bin/pg_autoctl/defaults.h
@@ -21,6 +21,7 @@
 
 /* environment variable to use to make DEBUG facilities available */
 #define PG_AUTOCTL_DEBUG "PG_AUTOCTL_DEBUG"
+#define PG_AUTOCTL_EXTENSION_VERSION_VAR "PG_AUTOCTL_EXTENSION_VERSION"
 
 /* default values for the pg_autoctl settings */
 #define POSTGRES_PORT 5432

--- a/src/bin/pg_autoctl/keeper.h
+++ b/src/bin/pg_autoctl/keeper.h
@@ -40,6 +40,7 @@ bool keeper_ensure_current_state(Keeper *keeper);
 bool keeper_update_pg_state(Keeper *keeper);
 bool ReportPgIsRunning(Keeper *keeper);
 bool keeper_remove(Keeper *keeper, KeeperConfig *config);
+bool keeper_check_monitor_extension_version(Keeper *keeper);
 
 bool keeper_init_state_write(Keeper *keeper);
 bool keeper_init_state_read(Keeper *keeper, KeeperStateInit *initState);

--- a/src/bin/pg_autoctl/monitor.c
+++ b/src/bin/pg_autoctl/monitor.c
@@ -1252,7 +1252,7 @@ parseExtensionVersion(void *ctx, PGresult *result)
 		(MonitorExtensionVersionParseContext *) ctx;
 
 	char *value = NULL;
-	int length;
+	int length = -1;
 
 	/* we have rows: we accept only one */
 	if (PQntuples(result) != 1)

--- a/src/bin/pg_autoctl/monitor.h
+++ b/src/bin/pg_autoctl/monitor.h
@@ -40,6 +40,11 @@ typedef struct StateNotification
 	int			nodePort;
 } StateNotification;
 
+typedef struct MonitorExtensionVersion
+{
+	char defaultVersion[BUFSIZE];
+	char installedVersion[BUFSIZE];
+} MonitorExtensionVersion;
 
 bool monitor_init(Monitor *monitor, char *url);
 void monitor_finish(Monitor *monitor);
@@ -76,5 +81,10 @@ bool monitor_start_maintenance(Monitor *monitor, char *host, int port);
 bool monitor_stop_maintenance(Monitor *monitor, char *host, int port);
 
 bool monitor_get_notifications(Monitor *monitor);
+
+bool monitor_get_extension_version(Monitor *monitor,
+								   MonitorExtensionVersion *version);
+bool monitor_extension_update(Monitor *monitor, char *targetVersion);
+bool monitor_ensure_extension_version(Monitor *monitor);
 
 #endif /* MONITOR_H */

--- a/src/bin/pg_autoctl/monitor.h
+++ b/src/bin/pg_autoctl/monitor.h
@@ -84,7 +84,8 @@ bool monitor_get_notifications(Monitor *monitor);
 
 bool monitor_get_extension_version(Monitor *monitor,
 								   MonitorExtensionVersion *version);
-bool monitor_extension_update(Monitor *monitor, char *targetVersion);
-bool monitor_ensure_extension_version(Monitor *monitor);
+bool monitor_extension_update(Monitor *monitor, const char *targetVersion);
+bool monitor_ensure_extension_version(Monitor *monitor,
+									  MonitorExtensionVersion *version);
 
 #endif /* MONITOR_H */

--- a/src/bin/pg_autoctl/pgsql.c
+++ b/src/bin/pg_autoctl/pgsql.c
@@ -1374,6 +1374,7 @@ bool
 pgsql_alter_extension_update_to(PGSQL *pgsql,
 								const char *extname, const char *version)
 {
+	int n = 0;
 	char command[BUFSIZE];
 	char *escapedIdentifier, *escapedVersion;
 	PGconn *connection = NULL;
@@ -1409,8 +1410,16 @@ pgsql_alter_extension_update_to(PGSQL *pgsql,
 	}
 
 	/* now build the SQL command */
-	snprintf(command, BUFSIZE, "ALTER EXTENSION %s UPDATE TO %s",
-			 escapedIdentifier, escapedVersion);
+	n = snprintf(command, BUFSIZE, "ALTER EXTENSION %s UPDATE TO %s",
+				 escapedIdentifier, escapedVersion);
+
+	if (n >= BUFSIZE)
+	{
+		log_error("BUG: pg_autoctl only supports SQL string up to %d bytes, "
+				  "a SQL string of %d bytes is needed to "
+				  "update the \"%s\" extension.",
+				  BUFSIZE, n, extname);
+	}
 
 	PQfreemem(escapedIdentifier);
 	PQfreemem(escapedVersion);

--- a/src/bin/pg_autoctl/pgsql.c
+++ b/src/bin/pg_autoctl/pgsql.c
@@ -1365,3 +1365,74 @@ pgsql_listen(PGSQL *pgsql, char *channels[])
 
 	return true;
 }
+
+
+/*
+ * pgsql_alter_extension_update_to executes ALTER EXTENSION ... UPDATE TO ...
+ */
+bool
+pgsql_alter_extension_update_to(PGSQL *pgsql,
+								const char *extname, const char *version)
+{
+	char command[BUFSIZE];
+	char *escapedIdentifier, *escapedVersion;
+	PGconn *connection = NULL;
+	PGresult *result = NULL;
+
+	/* open a connection upfront since it is needed by PQescape functions */
+	connection = pgsql_open_connection(pgsql);
+	if (connection == NULL)
+	{
+		/* error message was logged in pgsql_open_connection */
+		return false;
+	}
+
+	/* escape the extname */
+	escapedIdentifier = PQescapeIdentifier(connection, extname, strlen(extname));
+	if (escapedIdentifier == NULL)
+	{
+		log_error("Failed to update extension \"%s\": %s", extname,
+				  PQerrorMessage(connection));
+		pgsql_finish(pgsql);
+		return false;
+	}
+
+	/* escape the version */
+	escapedVersion = PQescapeIdentifier(connection, version, strlen(version));
+	if (escapedIdentifier == NULL)
+	{
+		log_error("Failed to update extension \"%s\" to version \"%s\": %s",
+				  extname, version,
+				  PQerrorMessage(connection));
+		pgsql_finish(pgsql);
+		return false;
+	}
+
+	/* now build the SQL command */
+	snprintf(command, BUFSIZE, "ALTER EXTENSION %s UPDATE TO %s",
+			 escapedIdentifier, escapedVersion);
+
+	PQfreemem(escapedIdentifier);
+	PQfreemem(escapedVersion);
+
+	log_debug("Running command on Postgres: %s;", command);
+
+	result = PQexec(connection, command);
+
+	if (!is_response_ok(result))
+	{
+		char *sqlstate = PQresultErrorField(result, PG_DIAG_SQLSTATE);
+
+		log_error("Error %s while running Postgres query: %s: %s",
+				  sqlstate, command, PQerrorMessage(connection));
+		PQclear(result);
+		clear_results(connection);
+		pgsql_finish(pgsql);
+		return false;
+	}
+
+	PQclear(result);
+	clear_results(connection);
+
+	return true;
+}

--- a/src/bin/pg_autoctl/pgsql.h
+++ b/src/bin/pg_autoctl/pgsql.h
@@ -149,4 +149,7 @@ bool pgsql_get_wal_lag_from_standby(PGSQL *pgsql, int64_t *walLag);
 
 bool pgsql_listen(PGSQL *pgsql, char *channels[]);
 
+bool pgsql_alter_extension_update_to(PGSQL *pgsql,
+									 const char *extname, const char *version);
+
 #endif /* PGSQL_H */

--- a/src/monitor/Makefile
+++ b/src/monitor/Makefile
@@ -14,7 +14,7 @@ MODULE_big = $(EXTENSION)
 OBJS = $(patsubst ${SRC_DIR}%.c,%.o,$(wildcard ${SRC_DIR}*.c))
 PG_CPPFLAGS = -std=c99 -Wall -Werror -Wno-unused-parameter -Iinclude -I$(libpq_srcdir)
 SHLIB_LINK = $(libpq)
-REGRESS = create_extension monitor
+REGRESS = create_extension monitor dummy_update drop_extension
 
 PG_CONFIG ?= pg_config
 PGXS = $(shell $(PG_CONFIG) --pgxs)

--- a/src/monitor/expected/drop_extension.out
+++ b/src/monitor/expected/drop_extension.out
@@ -1,0 +1,3 @@
+-- Copyright (c) Microsoft Corporation. All rights reserved.
+-- Licensed under the PostgreSQL License.
+drop extension pgautofailover;

--- a/src/monitor/expected/dummy_update.out
+++ b/src/monitor/expected/dummy_update.out
@@ -1,0 +1,23 @@
+-- Copyright (c) Microsoft Corporation. All rights reserved.
+-- Licensed under the PostgreSQL License.
+select version
+  from pg_available_extension_versions
+ where name = 'pgautofailover' and version = 'dummy';
+ version 
+---------
+ dummy
+(1 row)
+
+alter extension pgautofailover update to dummy;
+select installed_version
+  from pg_available_extensions where name = 'pgautofailover';
+ installed_version 
+-------------------
+ dummy
+(1 row)
+
+-- should error because installed extension isn't compatible with .so
+select * from pgautofailover.get_primary('unknown formation');
+ERROR:  loaded "pgautofailover" library version differs from installed extension version
+DETAIL:  Loaded library requires 1.0, but the installed extension version is dummy.
+HINT:  Run ALTER EXTENSION pgautofailover UPDATE and try again.

--- a/src/monitor/metadata.c
+++ b/src/monitor/metadata.c
@@ -196,6 +196,11 @@ checkPgAutoFailoverVersion()
 		"SELECT default_version, installed_version "
 		"FROM pg_catalog.pg_available_extensions WHERE name = $1;";
 
+	if (!EnableVersionChecks)
+	{
+		return true;
+	}
+
 	SPI_connect();
 
 	spiStatus = SPI_execute_with_args(selectQuery, argCount, argTypes, argValues,

--- a/src/monitor/metadata.h
+++ b/src/monitor/metadata.h
@@ -15,6 +15,7 @@
 
 #include "storage/lockdefs.h"
 
+#define AUTO_FAILOVER_EXTENSION_VERSION "1.0"
 #define AUTO_FAILOVER_EXTENSION_NAME "pgautofailover"
 #define AUTO_FAILOVER_SCHEMA_NAME "pgautofailover"
 #define AUTO_FAILOVER_FORMATION_TABLE "pgautofailover.formation"
@@ -34,6 +35,8 @@ typedef enum AutoFailoverHALocktagClass
 	ADV_LOCKTAG_CLASS_AUTO_FAILOVER_NODE_GROUP = 11
 } AutoFailoverHALocktagClass;
 
+/* GUC variable for version checks, true by default */
+extern bool EnableVersionChecks;
 
 /* public function declarations */
 extern Oid pgAutoFailoverRelationId(const char *relname);
@@ -41,3 +44,4 @@ extern Oid pgAutoFailoverSchemaId(void);
 extern Oid pgAutoFailoverExtensionOwner(void);
 extern void LockFormation(char *formationId, LOCKMODE lockMode);
 extern void LockNodeGroup(char *formationId, int groupId, LOCKMODE lockMode);
+extern bool checkPgAutoFailoverVersion(void);

--- a/src/monitor/node_active_protocol.c
+++ b/src/monitor/node_active_protocol.c
@@ -98,6 +98,8 @@ register_node(PG_FUNCTION_ARGS)
 	Datum values[3];
 	bool isNulls[3];
 
+	checkPgAutoFailoverVersion();
+
 	currentNodeState.nodeId = -1;
 	currentNodeState.groupId = currentGroupId;
 	currentNodeState.replicationState =
@@ -256,6 +258,8 @@ node_active(PG_FUNCTION_ARGS)
 	HeapTuple resultTuple = NULL;
 	Datum values[3];
 	bool isNulls[3];
+
+	checkPgAutoFailoverVersion();
 
 	currentNodeState.nodeId = currentNodeId;
 	currentNodeState.groupId = currentGroupId;
@@ -484,6 +488,8 @@ get_primary(PG_FUNCTION_ARGS)
 	Datum values[2];
 	bool isNulls[2];
 
+	checkPgAutoFailoverVersion();
+
 	primaryNode = GetWritableNode(formationId, groupId);
 	if (primaryNode == NULL)
 	{
@@ -569,6 +575,8 @@ get_other_node(PG_FUNCTION_ARGS)
 	Datum values[2];
 	bool isNulls[2];
 
+	checkPgAutoFailoverVersion();
+
 	activeNode = GetAutoFailoverNode(nodeName, nodePort);
 	if (activeNode == NULL)
 	{
@@ -614,6 +622,8 @@ remove_node(PG_FUNCTION_ARGS)
 
 	AutoFailoverNode *currentNode = NULL;
 	AutoFailoverNode *otherNode = NULL;
+
+	checkPgAutoFailoverVersion();
 
 	currentNode = GetAutoFailoverNode(nodeName, nodePort);
 	if (currentNode == NULL)
@@ -679,6 +689,8 @@ perform_failover(PG_FUNCTION_ARGS)
 										   REPLICATION_STATE_CATCHINGUP);
 
 	char message[BUFSIZE];
+
+	checkPgAutoFailoverVersion();
 
 	LockFormation(formationId, ShareLock);
 	LockNodeGroup(formationId, groupId, ExclusiveLock);
@@ -783,6 +795,8 @@ start_maintenance(PG_FUNCTION_ARGS)
 										 REPLICATION_STATE_WAIT_PRIMARY);
 	List *secondaryStates = list_make2_int(REPLICATION_STATE_SECONDARY,
 										   REPLICATION_STATE_CATCHINGUP);
+
+	checkPgAutoFailoverVersion();
 
 	currentNode = GetAutoFailoverNode(nodeName, nodePort);
 	if (currentNode == NULL)
@@ -892,6 +906,8 @@ stop_maintenance(PG_FUNCTION_ARGS)
 	AutoFailoverNode *otherNode = NULL;
 
 	char message[BUFSIZE];
+
+	checkPgAutoFailoverVersion();
 
 	currentNode = GetAutoFailoverNode(nodeName, nodePort);
 	if (currentNode == NULL)

--- a/src/monitor/pg_auto_failover.c
+++ b/src/monitor/pg_auto_failover.c
@@ -15,6 +15,7 @@
 /* these are internal headers */
 #include "health_check.h"
 #include "group_state_machine.h"
+#include "metadata.h"
 #include "version_compat.h"
 
 /* these are always necessary for a bgworker */
@@ -74,6 +75,11 @@ static void
 StartMonitorNode(void)
 {
 	BackgroundWorker worker;
+
+	DefineCustomBoolVariable("pgautofailover.enable_version_checks",
+							 "Enable extension version compatiblity checks",
+							 NULL, &EnableVersionChecks, true, PGC_SIGHUP,
+							 GUC_NO_SHOW_ALL, NULL, NULL, NULL);
 
 	DefineCustomBoolVariable("pgautofailover.enable_health_checks",
 							 "Enable background health checks",

--- a/src/monitor/pgautofailover--1.0--dummy.sql
+++ b/src/monitor/pgautofailover--1.0--dummy.sql
@@ -1,0 +1,6 @@
+--
+-- dummy extension update file that does nothing
+--
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "ALTER EXTENSION pgautofailover UPDATE TO dummy" to load this file. \quit
+

--- a/src/monitor/sql/drop_extension.sql
+++ b/src/monitor/sql/drop_extension.sql
@@ -1,0 +1,4 @@
+-- Copyright (c) Microsoft Corporation. All rights reserved.
+-- Licensed under the PostgreSQL License.
+
+drop extension pgautofailover;

--- a/src/monitor/sql/dummy_update.sql
+++ b/src/monitor/sql/dummy_update.sql
@@ -1,0 +1,15 @@
+-- Copyright (c) Microsoft Corporation. All rights reserved.
+-- Licensed under the PostgreSQL License.
+
+select version
+  from pg_available_extension_versions
+ where name = 'pgautofailover' and version = 'dummy';
+
+alter extension pgautofailover update to dummy;
+
+select installed_version
+  from pg_available_extensions where name = 'pgautofailover';
+
+-- should error because installed extension isn't compatible with .so
+select * from pgautofailover.get_primary('unknown formation');
+

--- a/tests/test_extension_update.py
+++ b/tests/test_extension_update.py
@@ -1,0 +1,30 @@
+import os
+
+import pgautofailover_utils as pgautofailover
+from nose.tools import *
+
+cluster = None
+
+def setup_module():
+    global cluster
+    cluster = pgautofailover.Cluster()
+
+def teardown_module():
+    cluster.destroy()
+
+def test_000_create_monitor():
+    cluster.create_monitor("/tmp/monitor")
+
+def test_001_update_extension():
+    os.environ["PG_AUTOCTL_DEBUG"] = '1'
+    os.environ["PG_AUTOCTL_EXTENSION_VERSION"] = 'dummy'
+    cluster.monitor.run()
+    results = cluster.monitor.run_sql_query(
+        """SELECT installed_version
+             FROM pg_available_extensions
+            WHERE name = 'pgautofailover'
+        """)
+    print(results)
+    assert results == [('dummy',)]
+
+

--- a/tests/test_extension_update.py
+++ b/tests/test_extension_update.py
@@ -11,6 +11,7 @@ def setup_module():
     cluster = pgautofailover.Cluster()
 
 def teardown_module():
+    cluster.monitor.stop_pg_autoctl()
     cluster.destroy()
 
 def test_000_create_monitor():

--- a/tests/test_extension_update.py
+++ b/tests/test_extension_update.py
@@ -1,4 +1,5 @@
 import os
+import time
 
 import pgautofailover_utils as pgautofailover
 from nose.tools import *
@@ -19,12 +20,16 @@ def test_001_update_extension():
     os.environ["PG_AUTOCTL_DEBUG"] = '1'
     os.environ["PG_AUTOCTL_EXTENSION_VERSION"] = 'dummy'
     cluster.monitor.run()
+
+    # we need to allow some time for the pg_autctl run command to start and
+    # execute ALTER EXTENSION ... UPDATE TO ...
+    time.sleep(1)
+
     results = cluster.monitor.run_sql_query(
         """SELECT installed_version
              FROM pg_available_extensions
             WHERE name = 'pgautofailover'
         """)
-    print(results)
     assert results == [('dummy',)]
 
 


### PR DESCRIPTION
The pg_autoctl tool embeds the version of the extension that it is
compatible with on the monitor. The idea is that those versions are kept in
sync at the source code and packaging level, and a given pg_autoctl command
line is compatible with a single version of the monitor.

At startup on the monitor the command `pg_autoctl run` checks the monitor's
version and if necessary runs a command `ALTER EXTENSION ... UPDATE TO ...`
the expected version. It is expected that the extension packaging provides
the necessary upgrade paths.

On the keeper, we check that the version number of the extension on the
monitor is compatible with our expectations, and exit before entering the
main loop when that's not the case. We refrain from doing "upgrade at a
distance" and tell the admin (who's reading the logs, maybe?) to please take
care of the situation on the monitor node.