### PR TITLE
Manually set LANG=C when running pg_controldata.

### DIFF
--- a/src/bin/pg_autoctl/pgctl.c
+++ b/src/bin/pg_autoctl/pgctl.c
@@ -86,6 +86,8 @@ pg_controldata(PostgresSetup *pgSetup, bool missing_ok)
 	path_in_same_directory(pgSetup->pg_ctl, "pg_controldata", pg_controldata);
 	log_debug("%s %s", pg_controldata, pgSetup->pgdata);
 
+	/* we parse the output of pg_controldata, make sure it's as expected */
+	setenv("LANG", "C", 1);
 	prog = run_program(pg_controldata, pgSetup->pgdata, NULL);
 
 	if (prog.returnCode == 0)


### PR DESCRIPTION
We parse the output of pg_controldata and expect English output. Force the
environment to be in C locale when calling pg_controldata so that we do not
depend on the user locale settings here.

The other output parsing we do is on pg_ctl --version, where we only parse
the version string. As that's only digits and dots ([[:digit:].]+), we don't
need to set the LANG=C in that case. I think. At least this patch does
nothing for this case.

Fix #26.