### PR TITLE
Add --auth option to configure authentication method

### DIFF
--- a/docs/operations.rst
+++ b/docs/operations.rst
@@ -19,6 +19,8 @@ environment variable, and checks whether PostgreSQL is already running. If
 Postgres is detected, the new node is registered in SINGLE mode, bypassing
 the monitor's role assignment policy.
 
+.. _pg_auto_failover_security:
+
 Security
 --------
 Connections between monitor and data nodes use *trust* authentication by
@@ -28,6 +30,15 @@ parameter when creating monitor or data Node. Any auth method supported by
 PostgreSQL could be used here. Please refer to
 https://www.postgresql.org/docs/current/auth-pg-hba-conf.html
 for available options.
+
+Security for following connections should be considered when setting up
+`.pgpass` file.
+  1. health check connection from monitor for `pgautofailover_monitor` user
+  2. connections for `pg_autoctl` command from data nodes to monitor for `autoctl_node` user
+  3. replication connections from secondary to primary data nodes for `replication` user.
+     Notice that primary and secondary nodes change during failover. Thus this setting
+     should be done on both primary and secondary nodes.
+  4. settings need to be updated after a new node is added.
 
 Operations
 ----------

--- a/docs/operations.rst
+++ b/docs/operations.rst
@@ -19,6 +19,16 @@ environment variable, and checks whether PostgreSQL is already running. If
 Postgres is detected, the new node is registered in SINGLE mode, bypassing
 the monitor's role assignment policy.
 
+Security
+--------
+Connections between monitor and data nodes use *trust* authentication by
+default. This lets accounts used by ``pg_auto_failover`` to connect to nodes
+without needing a password. Default behaviour could be changed using ``--auth``
+parameter when creating monitor or data Node. Any auth method supported by
+PostgreSQL could be used here. Please refer to
+https://www.postgresql.org/docs/current/auth-pg-hba-conf.html
+for available options.
+
 Operations
 ----------
 

--- a/docs/operations.rst
+++ b/docs/operations.rst
@@ -27,9 +27,10 @@ Connections between monitor and data nodes use *trust* authentication by
 default. This lets accounts used by ``pg_auto_failover`` to connect to nodes
 without needing a password. Default behaviour could be changed using ``--auth``
 parameter when creating monitor or data Node. Any auth method supported by
-PostgreSQL could be used here. Please refer to
-https://www.postgresql.org/docs/current/auth-pg-hba-conf.html
+PostgreSQL could be used here. Please refer to `PostgreSQL pg_hba documentation`__
 for available options.
+
+__ https://www.postgresql.org/docs/current/auth-pg-hba-conf.html
 
 Security for following connections should be considered when setting up
 `.pgpass` file.
@@ -39,6 +40,10 @@ Security for following connections should be considered when setting up
      Notice that primary and secondary nodes change during failover. Thus this setting
      should be done on both primary and secondary nodes.
   4. settings need to be updated after a new node is added.
+See `PostgreSQL documentation`__ on setting up `.pgpass` file.
+
+__ https://www.postgresql.org/docs/current/libpq-pgpass.html
+
 
 Operations
 ----------

--- a/docs/ref/reference.rst
+++ b/docs/ref/reference.rst
@@ -91,6 +91,7 @@ commands are dealing with the monitor:
         --pgdata      path to data directory
         --pgport      PostgreSQL's port number
         --nodename    hostname by which postgres is reachable
+        --auth        authentication method for connections from data nodes
 
      The ``--pgdata`` option is mandatory and default to the environment
      variable ``PGDATA``. The ``--pgport`` default value is 5432, and the
@@ -119,6 +120,11 @@ commands are dealing with the monitor:
      You may use the `--nodename` command line option to bypass the whole
      DNS lookup based process and force the local node name to a fixed
      value.
+     
+     The ``--auth`` option allows setting up authentication method to be used
+     for connections from data nodes with ``autoctl_node`` user.
+     If this option to be used, please make sure password is manually set on
+     the monitor, and appropriate setting is added to `.pgpass` file on data node.      
 
   - ``pg_autoctl run``
 
@@ -269,6 +275,7 @@ The other commands accept the same set of options.
     --nodename    pg_auto_failover node
     --formation   pg_auto_failover formation
     --monitor     pg_auto_failover Monitor Postgres URL
+    --auth        authentication method for connections from monitor
     --allow-removing-pgdata   Allow pg_autoctl to remove the database directory
 
 Three different modes of initialization are supported by this command,
@@ -320,6 +327,11 @@ prepare a new secondary system from scratch.
 When `--nodename` is omitted, it is computed as above (see
 :ref:`_pg_autoctl_create_monitor`), with the difference that step 1 uses the
 monitor IP and port rather than the public service 8.8.8.8:53.
+
+The ``--auth`` option allows setting up authentication method to be used when
+monitor node makes a connection to data node with `pgautofailover_monitor` user.
+If this option to be used, please make sure password is manually set on the data
+node, and appropriate setting is added to `.pgpass` file on monitor node.
 
 .. _pg_autoctl_configuration:
 

--- a/docs/ref/reference.rst
+++ b/docs/ref/reference.rst
@@ -123,8 +123,10 @@ commands are dealing with the monitor:
      
      The ``--auth`` option allows setting up authentication method to be used
      for connections from data nodes with ``autoctl_node`` user.
-     If this option to be used, please make sure password is manually set on
-     the monitor, and appropriate setting is added to `.pgpass` file on data node.      
+     If this option is used, please make sure password is manually set on
+     the monitor, and appropriate setting is added to `.pgpass` file on data node.
+     
+     See :ref:`pg_auto_failover_security` for notes on `.pgpass`
 
   - ``pg_autoctl run``
 
@@ -330,8 +332,10 @@ monitor IP and port rather than the public service 8.8.8.8:53.
 
 The ``--auth`` option allows setting up authentication method to be used when
 monitor node makes a connection to data node with `pgautofailover_monitor` user.
-If this option to be used, please make sure password is manually set on the data
+If this option is, please make sure password is manually set on the data
 node, and appropriate setting is added to `.pgpass` file on monitor node.
+
+See :ref:`pg_auto_failover_security` for notes on `.pgpass`
 
 .. _pg_autoctl_configuration:
 

--- a/src/bin/pg_autoctl/cli_common.c
+++ b/src/bin/pg_autoctl/cli_common.c
@@ -40,6 +40,7 @@ bool allowRemovingPgdata = false;
  *		{ "listen", required_argument, NULL, 'l' },
  *		{ "proxyport", required_argument, NULL, 'y' },
  *		{ "username", required_argument, NULL, 'U' },
+		{ "auth", required_argument, NULL, 'A' },
  *		{ "dbname", required_argument, NULL, 'd' },
  *		{ "nodename", required_argument, NULL, 'n' },
  *		{ "formation", required_argument, NULL, 'f' },
@@ -149,6 +150,13 @@ cli_create_node_getopts(int argc, char **argv,
 				break;
 			}
 
+			case 'A':
+			{
+				/* { "auth", required_argument, NULL, 'A' }, */
+				strlcpy(LocalOptionConfig.pgSetup.authMethod, optarg, NAMEDATALEN);
+				log_trace("--auth %s", LocalOptionConfig.pgSetup.authMethod);
+				break;
+			}
 			case 'd':
 			{
 				/* { "dbname", required_argument, NULL, 'd' } */

--- a/src/bin/pg_autoctl/cli_create_drop_node.c
+++ b/src/bin/pg_autoctl/cli_create_drop_node.c
@@ -72,6 +72,7 @@ CommandLine create_postgres_command =
 				 "  --nodename    pg_auto_failover node\n"
 				 "  --formation   pg_auto_failover formation\n"
 				 "  --monitor     pg_auto_failover Monitor Postgres URL\n"
+				 "  --auth        pg_auto_failover authentication method"
 				 KEEPER_CLI_ALLOW_RM_PGDATA_OPTION,
 				 cli_create_postgres_getopts,
 				 cli_create_postgres);
@@ -195,6 +196,7 @@ cli_create_postgres_getopts(int argc, char **argv)
 		{ "pgport", required_argument, NULL, 'p' },
 		{ "listen", required_argument, NULL, 'l' },
 		{ "username", required_argument, NULL, 'U' },
+		{ "auth", required_argument, NULL, 'A' },
 		{ "dbname", required_argument, NULL, 'd' },
 		{ "nodename", required_argument, NULL, 'n' },
 		{ "formation", required_argument, NULL, 'f' },
@@ -206,7 +208,7 @@ cli_create_postgres_getopts(int argc, char **argv)
 
 	int optind =
 		cli_create_node_getopts(argc, argv,
-								long_options, "C:D:h:p:l:U:d:n:f:m:R",
+								long_options, "C:D:h:p:l:U:A:d:n:f:m:R",
 								&options);
 
 	/* publish our option parsing in the global variable */
@@ -262,6 +264,7 @@ cli_create_monitor_getopts(int argc, char **argv)
 		{ "pgport", required_argument, NULL, 'p' },
 		{ "nodename", required_argument, NULL, 'n' },
 		{ "listen", required_argument, NULL, 'l' },
+		{ "auth", required_argument, NULL, 'A' },
 		{ "help", no_argument, NULL, 0 },
 		{ NULL, 0, NULL, 0 }
 	};
@@ -271,7 +274,7 @@ cli_create_monitor_getopts(int argc, char **argv)
 
 	optind = 0;
 
-	while ((c = getopt_long(argc, argv, "C:D:p:",
+	while ((c = getopt_long(argc, argv, "C:D:p:A:",
 							long_options, &option_index)) != -1)
 	{
 		switch (c)
@@ -317,6 +320,12 @@ cli_create_monitor_getopts(int argc, char **argv)
 				break;
 			}
 
+			case 'A':
+			{
+				strlcpy(options.pgSetup.authMethod, optarg, NAMEDATALEN);
+				log_trace("--auth %s", options.pgSetup.authMethod);
+				break;
+			}
 			default:
 			{
 				/* getopt_long already wrote an error message */

--- a/src/bin/pg_autoctl/cli_create_drop_node.c
+++ b/src/bin/pg_autoctl/cli_create_drop_node.c
@@ -54,7 +54,8 @@ CommandLine create_monitor_command =
 				 "  --pgctl       path to pg_ctl\n" \
 				 "  --pgdata      path to data directory\n" \
 				 "  --pgport      PostgreSQL's port number\n" \
-				 "  --nodename    hostname by which postgres is reachable\n",
+				 "  --nodename    hostname by which postgres is reachable\n" \
+				 "  --auth        authentication method for connections from data nodes\n",
 				 cli_create_monitor_getopts,
 				 cli_create_monitor);
 
@@ -72,7 +73,7 @@ CommandLine create_postgres_command =
 				 "  --nodename    pg_auto_failover node\n"
 				 "  --formation   pg_auto_failover formation\n"
 				 "  --monitor     pg_auto_failover Monitor Postgres URL\n"
-				 "  --auth        pg_auto_failover authentication method"
+				 "  --auth        authentication method for connections from monitor\n"
 				 KEEPER_CLI_ALLOW_RM_PGDATA_OPTION,
 				 cli_create_postgres_getopts,
 				 cli_create_postgres);

--- a/src/bin/pg_autoctl/cli_do_misc.c
+++ b/src/bin/pg_autoctl/cli_do_misc.c
@@ -186,7 +186,8 @@ keeper_cli_create_monitor_user(int argc, char **argv)
 
 	if (!primary_create_user_with_hba(&postgres,
 									  PG_AUTOCTL_HEALTH_USERNAME, password,
-									  monitorHostname))
+									  monitorHostname,
+									  pg_setup_get_auth_method(&(config.pgSetup))))
 	{
 		log_fatal("Failed to create the database user that the pg_auto_failover "
 				  " monitor uses for health checks, see above for details");

--- a/src/bin/pg_autoctl/cli_do_root.c
+++ b/src/bin/pg_autoctl/cli_do_root.c
@@ -238,6 +238,7 @@ keeper_cli_keeper_setup_getopts(int argc, char **argv)
 		{ "listen", required_argument, NULL, 'l' },
 		{ "proxyport", required_argument, NULL, 'y' },
 		{ "username", required_argument, NULL, 'U' },
+		{ "auth", required_argument, NULL, 'A' },
 		{ "dbname", required_argument, NULL, 'd' },
 		{ "nodename", required_argument, NULL, 'n' },
 		{ "formation", required_argument, NULL, 'f' },
@@ -250,7 +251,7 @@ keeper_cli_keeper_setup_getopts(int argc, char **argv)
 
 	int optind =
 		cli_create_node_getopts(argc, argv,
-								long_options, "C:D:h:p:l:y:U:d:n:f:g:m:R",
+								long_options, "C:D:h:p:l:y:U:A:d:n:f:g:m:R",
 								&options);
 
 	/* publish our option parsing in the global variable */

--- a/src/bin/pg_autoctl/defaults.h
+++ b/src/bin/pg_autoctl/defaults.h
@@ -28,6 +28,7 @@
 #define POSTGRES_DEFAULT_LISTEN_ADDRESSES "*"
 #define DEFAULT_DATABASE_NAME "postgres"
 #define DEFAULT_USERNAME "postgres"
+#define DEFAULT_AUTH_METHOD "trust"
 #define REPLICATION_SLOT_NAME_DEFAULT "pgautofailover_standby"
 #define REPLICATION_PASSWORD_DEFAULT NULL
 #define FORMATION_DEFAULT "default"

--- a/src/bin/pg_autoctl/fsm_transition.c
+++ b/src/bin/pg_autoctl/fsm_transition.c
@@ -58,6 +58,7 @@ fsm_init_primary(Keeper *keeper)
 	char *password = NULL;
 	char monitorHostname[_POSIX_HOST_NAME_MAX];
 	int monitorPort = 0;
+	char *authMethod = NULL;
 
 	log_info("Initialising postgres as a primary");
 
@@ -99,10 +100,11 @@ fsm_init_primary(Keeper *keeper)
 	}
 
 	password = NULL;
+	authMethod = pg_setup_get_auth_method(&(config->pgSetup));
 
 	if (!primary_create_user_with_hba(postgres,
 									  PG_AUTOCTL_HEALTH_USERNAME, password,
-									  monitorHostname))
+									  monitorHostname, authMethod))
 	{
 		log_error("Failed to initialise postgres as primary because creating the "
 				  "database user that the pg_auto_failover monitor "

--- a/src/bin/pg_autoctl/keeper_pg_init.c
+++ b/src/bin/pg_autoctl/keeper_pg_init.c
@@ -423,7 +423,8 @@ reach_initial_state(Keeper *keeper)
 					(void) pghba_enable_lan_cidr(&keeper->postgres.sqlClient,
 												 HBA_DATABASE_ALL, NULL,
 												 keeper->config.nodename,
-												 NULL, "trust", NULL);
+												 NULL, DEFAULT_AUTH_METHOD, NULL);
+
 				}
 			}
 			else

--- a/src/bin/pg_autoctl/monitor_config.c
+++ b/src/bin/pg_autoctl/monitor_config.c
@@ -60,6 +60,10 @@
 	make_strbuf_option("postgresql", "listen_addresses", "listen", \
 					   false, MAXPGPATH, config->pgSetup.listen_addresses)
 
+#define OPTION_POSTGRESQL_AUTH_METHOD(config) \
+	make_strbuf_option("postgresql", "auth_method", "auth", \
+					   false, MAXPGPATH, config->pgSetup.authMethod)
+
 
 #define SET_INI_OPTIONS_ARRAY(config) \
 	{ \
@@ -72,6 +76,7 @@
 		OPTION_POSTGRESQL_HOST(config), \
 		OPTION_POSTGRESQL_PORT(config), \
 		OPTION_POSTGRESQL_LISTEN_ADDRESSES(config), \
+		OPTION_POSTGRESQL_AUTH_METHOD(config), \
 		INI_OPTION_LAST \
 	}
 
@@ -311,6 +316,7 @@ monitor_config_log_settings(MonitorConfig config)
 	log_debug("postgresql.dbname: %s", config.pgSetup.dbname);
 	log_debug("postgresql.host: %s", config.pgSetup.pghost);
 	log_debug("postgresql.port: %d", config.pgSetup.pgport);
+	log_debug("postgresql.auth: %s", config.pgSetup.authMethod);
 }
 
 

--- a/src/bin/pg_autoctl/monitor_pg_init.c
+++ b/src/bin/pg_autoctl/monitor_pg_init.c
@@ -230,7 +230,9 @@ monitor_install(const char *nodename,
 							   HBA_DATABASE_DBNAME,
 							   PG_AUTOCTL_MONITOR_DBNAME,
 							   nodename,
-							   PG_AUTOCTL_MONITOR_USERNAME, "trust", NULL))
+							   PG_AUTOCTL_MONITOR_USERNAME,
+							   pg_setup_get_auth_method(&pgSetup),
+							   NULL))
 	{
 		log_warn("Failed to grant connection to local network.");
 		return false;

--- a/src/bin/pg_autoctl/pgsetup.c
+++ b/src/bin/pg_autoctl/pgsetup.c
@@ -316,6 +316,17 @@ pg_setup_init(PostgresSetup *pgSetup,
 				POSTGRES_DEFAULT_LISTEN_ADDRESSES, MAXPGPATH);
 	}
 
+
+	/*
+	 * If --auth is given, then set our authMethod to this value
+	 * otherwise it remains empty
+	 */
+	if (!IS_EMPTY_STRING_BUFFER(options->authMethod))
+	{
+		strlcpy(pgSetup->authMethod,
+				options->authMethod, NAMEDATALEN);
+	}
+
 	/*
 	 * And we always double-check with PGDATA/postmaster.pid if we have it, and
 	 * we should have it in the normal/expected case.
@@ -832,6 +843,24 @@ pg_setup_get_username(PostgresSetup *pgSetup)
 	log_trace("username fallback to default: %s", DEFAULT_USERNAME);
 
 	return DEFAULT_USERNAME;
+}
+
+
+/*
+ * pg_setup_get_auth_method returns pgSetup->authMethod when it exists, otherwise it
+ * returns DEFAULT_AUTH_METHOD
+ */
+char *
+pg_setup_get_auth_method(PostgresSetup *pgSetup)
+{
+	if (!IS_EMPTY_STRING_BUFFER(pgSetup->authMethod))
+	{
+		return pgSetup->authMethod;
+	}
+
+	log_trace("auth method not configured, falling back to default value : %s", DEFAULT_AUTH_METHOD);
+
+	return DEFAULT_AUTH_METHOD;
 }
 
 

--- a/src/bin/pg_autoctl/pgsetup.h
+++ b/src/bin/pg_autoctl/pgsetup.h
@@ -107,6 +107,7 @@ typedef struct pg_setup
 	int pgport;                             /* PGPORT */
 	char listen_addresses[MAXPGPATH];       /* listen_addresses */
 	int proxyport;                          /* Proxy port */
+	char authMethod[NAMEDATALEN];           /* auth method, defaults to trust */
 	PostmasterStatus pm_status;				/* Postmaster status */
 	bool is_in_recovery;                    /* select pg_is_in_recovery() */
 	PostgresControlData control;            /* pg_controldata pgdata */
@@ -131,6 +132,7 @@ bool pg_setup_is_running(PostgresSetup *pgSetup);
 bool pg_setup_is_primary(PostgresSetup *pgSetup);
 bool pg_setup_is_ready(PostgresSetup *pgSetup, bool pg_is_not_running_is_ok);
 char *pg_setup_get_username(PostgresSetup *pgSetup);
+char *pg_setup_get_auth_method(PostgresSetup *pgSetup);
 bool pg_setup_set_absolute_pgdata(PostgresSetup *pgSetup);
 
 PgInstanceKind nodeKindFromString(const char *nodeKind);

--- a/src/bin/pg_autoctl/primary_standby.c
+++ b/src/bin/pg_autoctl/primary_standby.c
@@ -411,17 +411,12 @@ primary_add_standby_to_hba(LocalPostgresServer *postgres, char *standbyHostname,
 	PGSQL *pgsql = &(postgres->sqlClient);
 	PostgresSetup *postgresSetup = &(postgres->postgresSetup);
 	char hbaFilePath[MAXPGPATH];
-	char *authMethod = NULL;
+	char *authMethod =  "trust";
 
 	if (replicationPassword)
 	{
 		authMethod = pg_setup_get_auth_method(postgresSetup);
 	}
-	else
-	{
-		authMethod = "trust";
-	}
-
 
 	log_trace("primary_add_standby_to_hba");
 

--- a/src/bin/pg_autoctl/primary_standby.c
+++ b/src/bin/pg_autoctl/primary_standby.c
@@ -333,7 +333,7 @@ postgres_add_default_settings(LocalPostgresServer *postgres)
  */
 bool
 primary_create_user_with_hba(LocalPostgresServer *postgres, char *userName,
-							 char *password, char *hostname)
+							 char *password, char *hostname, char *authMethod)
 {
 	PGSQL *pgsql = &(postgres->sqlClient);
 	bool login = true;
@@ -357,7 +357,7 @@ primary_create_user_with_hba(LocalPostgresServer *postgres, char *userName,
 	}
 
 	if (!pghba_ensure_host_rule_exists(hbaFilePath, HBA_DATABASE_ALL, NULL, userName,
-									   hostname, "trust"))
+									   hostname, authMethod))
 	{
 		log_error("Failed to set the pg_hba rule for user \"%s\"", userName);
 		return false;
@@ -411,7 +411,17 @@ primary_add_standby_to_hba(LocalPostgresServer *postgres, char *standbyHostname,
 	PGSQL *pgsql = &(postgres->sqlClient);
 	PostgresSetup *postgresSetup = &(postgres->postgresSetup);
 	char hbaFilePath[MAXPGPATH];
-	char* authMethod = replicationPassword ? "md5" : "trust";
+	char *authMethod = NULL;
+
+	if (replicationPassword)
+	{
+		authMethod = pg_setup_get_auth_method(postgresSetup);
+	}
+	else
+	{
+		authMethod = "trust";
+	}
+
 
 	log_trace("primary_add_standby_to_hba");
 

--- a/src/bin/pg_autoctl/primary_standby.h
+++ b/src/bin/pg_autoctl/primary_standby.h
@@ -57,7 +57,7 @@ bool primary_enable_synchronous_replication(LocalPostgresServer *postgres);
 bool primary_disable_synchronous_replication(LocalPostgresServer *postgres);
 bool postgres_add_default_settings(LocalPostgresServer *postgres);
 bool primary_create_user_with_hba(LocalPostgresServer *postgres, char *userName,
-								  char *password, char *hostname);
+								  char *password, char *hostname, char *authMethod);
 bool primary_create_replication_user(LocalPostgresServer *postgres,
 									 char *replicationUser,
 									 char *replicationPassword);

--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -41,28 +41,28 @@ class Cluster:
         self.monitor = None
         self.datanodes = []
 
-    def create_monitor(self, datadir, port=5432, nodename=None):
+    def create_monitor(self, datadir, port=5432, nodename=None, auth_method=None, password=None):
         """
         Initializes the monitor and returns an instance of MonitorNode.
         """
         if self.monitor is not None:
             raise Exception("Monitor has already been created.")
         vnode = self.vlan.create_node()
-        self.monitor = MonitorNode(datadir, vnode, port, nodename)
+        self.monitor = MonitorNode(datadir, vnode, port, nodename, auth_method, password)
         self.monitor.create()
         return self.monitor
 
     # TODO group should auto sense for normal operations and passed to the
     # create cli as an argument when explicitly set by the test
     def create_datanode(self, datadir, port=5432, group=0,
-                        listen_flag=False, role=Role.Postgres, formation=None):
+                        listen_flag=False, role=Role.Postgres, formation=None, auth_method=None, password=None):
         """
         Initializes a data node and returns an instance of DataNode. This will
         do the "keeper init" and "pg_autoctl run" commands.
         """
         vnode = self.vlan.create_node()
         nodeid = len(self.datanodes) + 1
-        datanode = DataNode(datadir, vnode, port, os.getenv("USER"), "postgres",
+        datanode = DataNode(datadir, vnode, port, os.getenv("USER"), auth_method, password, "postgres",
                             self.monitor, nodeid, group, listen_flag,
                             role, formation)
         self.datanodes.append(datanode)
@@ -82,11 +82,13 @@ class PGNode:
     """
     Common stuff between MonitorNode and DataNode.
     """
-    def __init__(self, datadir, vnode, port, username, database, role):
+    def __init__(self, datadir, vnode, port, username, auth_method, password, database, role):
         self.datadir = datadir
         self.vnode = vnode
         self.port = port
         self.username = username
+        self.password = password
+        self.auth_method = auth_method
         self.database = database
         self.role = role
         self.pg_autoctl_run_proc = None
@@ -96,6 +98,10 @@ class PGNode:
         Returns a connection string which can be used to connect to this postgres
         node.
         """
+        if (self.password is not None):
+            return ("postgres://%s:%s@%s:%d/%s" % (self.username, self.password, self.vnode.address,
+                    self.port, self.database))
+        
         return ("postgres://%s@%s:%d/%s" % (self.username, self.vnode.address,
                                            self.port, self.database))
 
@@ -245,9 +251,9 @@ class PGNode:
                             "pg_autoctl.state")
 
 class DataNode(PGNode):
-    def __init__(self, datadir, vnode, port, username, database, monitor,
+    def __init__(self, datadir, vnode, port, username, auth_method, password, database, monitor,
                  nodeid, group, listen_flag, role, formation):
-        super().__init__(datadir, vnode, port, username, database, role)
+        super().__init__(datadir, vnode, port, username, auth_method, password, database, role)
         self.monitor = monitor
         self.nodeid = nodeid
         self.group = group
@@ -364,9 +370,9 @@ SELECT reportedstate
 
 
 class MonitorNode(PGNode):
-    def __init__(self, datadir, vnode, port, nodename):
+    def __init__(self, datadir, vnode, port, nodename, auth_method, password):
         super().__init__(datadir, vnode, port,
-                         "autoctl_node", "pg_auto_failover", Role.Monitor)
+                         "autoctl_node", auth_method, password, "pg_auto_failover", Role.Monitor)
 
         # set the nodename, default to the ip address of the node
         if nodename:
@@ -384,9 +390,20 @@ class MonitorNode(PGNode):
                         '--pgdata', self.datadir,
                         '--pgport', str(self.port),
                         '--nodename', self.nodename]
+        
+        if self.auth_method is not None:
+            init_command.extend(['--auth', self.auth_method])    
+        
         init_proc = self.vnode.run(init_command)
         wait_or_timeout_proc(init_proc,
                              name="create monitor",
+                             timeout=COMMAND_TIMEOUT)
+        if self.password is not None:
+            alter_user_set_passwd_command = 'alter user ' + self.username + ' with password' + ' \'' + self.password + '\''
+            passwd_command = [shutil.which('psql'), '-d', self.database, '-c', alter_user_set_passwd_command]
+            passwd_proc = self.vnode.run(passwd_command)
+            wait_or_timeout_proc(passwd_proc,
+                             name="monitor passwd",
                              timeout=COMMAND_TIMEOUT)
 
     def create_formation(self, formation_name,

--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -100,7 +100,7 @@ class PGNode:
         node.
         """
       
-        if (self.authMethod is not None and self.username in self.authenticatedUsers):
+        if (self.authMethod and self.username in self.authenticatedUsers):
             return ("postgres://%s:%s@%s:%d/%s" % (self.username, self.authenticatedUsers[self.username], self.vnode.address,
                     self.port, self.database))
         
@@ -134,7 +134,7 @@ class PGNode:
             return
         for authenticatedUser in self.authenticatedUsers:
             password = self.authenticatedUsers[authenticatedUser]
-            alter_user_set_passwd_command = 'alter user ' + authenticatedUser + ' with password \'' + password + '\''
+            alter_user_set_passwd_command =  "alter user %s with password \'%s\'" % (authenticatedUser, password)
             passwd_command = [shutil.which('psql'), '-d', self.database, '-c', alter_user_set_passwd_command]
             passwd_proc = self.vnode.run(passwd_command)
             wait_or_timeout_proc(passwd_proc,
@@ -410,7 +410,7 @@ class MonitorNode(PGNode):
                         '--pgport', str(self.port),
                         '--nodename', self.nodename]
         
-        if self.authMethod is not None:
+        if self.authMethod:
             init_command.extend(['--auth', self.authMethod])    
         
         init_proc = self.vnode.run(init_command)
@@ -418,7 +418,7 @@ class MonitorNode(PGNode):
                              name="create monitor",
                              timeout=COMMAND_TIMEOUT)
         
-        if self.authMethod is not None:
+        if self.authMethod:
             super().create_authenticated_users()
         
 

--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -41,28 +41,28 @@ class Cluster:
         self.monitor = None
         self.datanodes = []
 
-    def create_monitor(self, datadir, port=5432, nodename=None, auth_method=None, password=None):
+    def create_monitor(self, datadir, port=5432, nodename=None, authMethod=None):
         """
         Initializes the monitor and returns an instance of MonitorNode.
         """
         if self.monitor is not None:
             raise Exception("Monitor has already been created.")
         vnode = self.vlan.create_node()
-        self.monitor = MonitorNode(datadir, vnode, port, nodename, auth_method, password)
+        self.monitor = MonitorNode(datadir, vnode, port, nodename, authMethod)
         self.monitor.create()
         return self.monitor
 
     # TODO group should auto sense for normal operations and passed to the
     # create cli as an argument when explicitly set by the test
     def create_datanode(self, datadir, port=5432, group=0,
-                        listen_flag=False, role=Role.Postgres, formation=None, auth_method=None, password=None):
+                        listen_flag=False, role=Role.Postgres, formation=None, authMethod=None):
         """
         Initializes a data node and returns an instance of DataNode. This will
         do the "keeper init" and "pg_autoctl run" commands.
         """
         vnode = self.vlan.create_node()
         nodeid = len(self.datanodes) + 1
-        datanode = DataNode(datadir, vnode, port, os.getenv("USER"), auth_method, password, "postgres",
+        datanode = DataNode(datadir, vnode, port, os.getenv("USER"), authMethod, "postgres",
                             self.monitor, nodeid, group, listen_flag,
                             role, formation)
         self.datanodes.append(datanode)
@@ -82,24 +82,26 @@ class PGNode:
     """
     Common stuff between MonitorNode and DataNode.
     """
-    def __init__(self, datadir, vnode, port, username, auth_method, password, database, role):
+    def __init__(self, datadir, vnode, port, username, authMethod, authenticatedUserCredentials, database, role):
         self.datadir = datadir
         self.vnode = vnode
         self.port = port
         self.username = username
-        self.password = password
-        self.auth_method = auth_method
+        self.authMethod = authMethod
         self.database = database
         self.role = role
         self.pg_autoctl_run_proc = None
+        self.authenticatedUsers = authenticatedUserCredentials
+            
 
     def connection_string(self):
         """
         Returns a connection string which can be used to connect to this postgres
         node.
         """
-        if (self.password is not None):
-            return ("postgres://%s:%s@%s:%d/%s" % (self.username, self.password, self.vnode.address,
+      
+        if (self.authMethod is not None and self.username in self.authenticatedUsers):
+            return ("postgres://%s:%s@%s:%d/%s" % (self.username, self.authenticatedUsers[self.username], self.vnode.address,
                     self.port, self.database))
         
         return ("postgres://%s@%s:%d/%s" % (self.username, self.vnode.address,
@@ -127,6 +129,18 @@ class PGNode:
             except psycopg2.ProgrammingError:
                 return None
 
+    def create_authenticated_users(self):
+        if self.authMethod is None:
+            return
+        for authenticatedUser in self.authenticatedUsers:
+            password = self.authenticatedUsers[authenticatedUser]
+            alter_user_set_passwd_command = 'alter user ' + authenticatedUser + ' with password \'' + password + '\''
+            passwd_command = [shutil.which('psql'), '-d', self.database, '-c', alter_user_set_passwd_command]
+            passwd_proc = self.vnode.run(passwd_command)
+            wait_or_timeout_proc(passwd_proc,
+                             name="monitor passwd",
+                             timeout=COMMAND_TIMEOUT)
+    
     def stop_pg_autoctl(self):
         """
         Kills the keeper by sending a SIGTERM to keeper's process group.
@@ -251,9 +265,9 @@ class PGNode:
                             "pg_autoctl.state")
 
 class DataNode(PGNode):
-    def __init__(self, datadir, vnode, port, username, auth_method, password, database, monitor,
+    def __init__(self, datadir, vnode, port, username, authMethod, database, monitor,
                  nodeid, group, listen_flag, role, formation):
-        super().__init__(datadir, vnode, port, username, auth_method, password, database, role)
+        super().__init__(datadir, vnode, port, username, authMethod, {"pgautofailover_monitor":"monitor_password"}, database, role)
         self.monitor = monitor
         self.nodeid = nodeid
         self.group = group
@@ -289,6 +303,10 @@ class DataNode(PGNode):
         wait_or_timeout_proc(init_proc,
                              name="keeper init",
                              timeout=COMMAND_TIMEOUT)
+
+        if (self.get_state() == 'primary'):
+            super().create_authenticated_users()
+
 
     def wait_until_state(self, target_state, timeout=STATE_CHANGE_TIMEOUT):
         """
@@ -370,9 +388,10 @@ SELECT reportedstate
 
 
 class MonitorNode(PGNode):
-    def __init__(self, datadir, vnode, port, nodename, auth_method, password):
+    def __init__(self, datadir, vnode, port, nodename, authMethod):
+           
         super().__init__(datadir, vnode, port,
-                         "autoctl_node", auth_method, password, "pg_auto_failover", Role.Monitor)
+                         "autoctl_node", authMethod, {'autoctl_node':'autoctl_node_password'}, "pg_auto_failover", Role.Monitor)
 
         # set the nodename, default to the ip address of the node
         if nodename:
@@ -391,20 +410,17 @@ class MonitorNode(PGNode):
                         '--pgport', str(self.port),
                         '--nodename', self.nodename]
         
-        if self.auth_method is not None:
-            init_command.extend(['--auth', self.auth_method])    
+        if self.authMethod is not None:
+            init_command.extend(['--auth', self.authMethod])    
         
         init_proc = self.vnode.run(init_command)
         wait_or_timeout_proc(init_proc,
                              name="create monitor",
                              timeout=COMMAND_TIMEOUT)
-        if self.password is not None:
-            alter_user_set_passwd_command = 'alter user ' + self.username + ' with password' + ' \'' + self.password + '\''
-            passwd_command = [shutil.which('psql'), '-d', self.database, '-c', alter_user_set_passwd_command]
-            passwd_proc = self.vnode.run(passwd_command)
-            wait_or_timeout_proc(passwd_proc,
-                             name="monitor passwd",
-                             timeout=COMMAND_TIMEOUT)
+        
+        if self.authMethod is not None:
+            super().create_authenticated_users()
+        
 
     def create_formation(self, formation_name,
                          kind="pgsql", secondary=None, dbname=None):
@@ -474,15 +490,6 @@ class MonitorNode(PGNode):
                              name="disable feature",
                              timeout=COMMAND_TIMEOUT)
 
-
-    def destroy(self):
-        """
-        Cleans up the processes and files created for the monitor.
-        """
-        # stop monitor
-        self.stop_postgres()
-        # remove monitor
-        shutil.rmtree(self.datadir, ignore_errors=True)
 
 
 def wait_or_timeout_proc(proc, name, timeout):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -16,11 +16,13 @@ def teardown_module():
 def test_000_create_monitor():
     monitor = cluster.create_monitor("/tmp/monitor", authMethod="md5")
     monitor.wait_until_pg_is_running()
+    monitor.set_user_password("autoctl_node", "autoctl_node_password")
 
 def test_001_init_primary():
     global node1
     node1 = cluster.create_datanode("/tmp/node1", authMethod="md5")
     node1.create()
+    node1.set_user_password("pgautofailover_monitor", "monitor_password")
     node1.run()
     assert node1.wait_until_state(target_state="single")
 
@@ -32,6 +34,7 @@ def test_003_init_secondary():
     global node2
     node2 = cluster.create_datanode("/tmp/auth/node2", authMethod="md5")
     node2.create()
+    # no need to set passwords here because it will be inherited prom the primary
     node2.run()
     assert node2.wait_until_state(target_state="secondary")
     assert node1.wait_until_state(target_state="primary")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,5 +1,6 @@
 import pgautofailover_utils as pgautofailover
 from nose.tools import *
+import time
 
 cluster = None
 node1 = None
@@ -14,12 +15,12 @@ def teardown_module():
     cluster.destroy()
 
 def test_000_create_monitor():
-    monitor = cluster.create_monitor("/tmp/monitor", auth_method="md5", password="EasyPassword")
+    monitor = cluster.create_monitor("/tmp/monitor", authMethod="md5")
     monitor.wait_until_pg_is_running()
 
 def test_001_init_primary():
     global node1
-    node1 = cluster.create_datanode("/tmp/node1", auth_method="md5", password="EasyPassword")
+    node1 = cluster.create_datanode("/tmp/node1", authMethod="md5")
     node1.create()
     node1.run()
     assert node1.wait_until_state(target_state="single")
@@ -34,7 +35,7 @@ def test_002_create_t1():
 
 def test_003_init_secondary():
     global node2
-    node2 = cluster.create_datanode("/tmp/node2", auth_method="md5", password="EasyPassword")
+    node2 = cluster.create_datanode("/tmp/auth/node2", authMethod="md5")
     node2.create()
     node2.run()
     assert node2.wait_until_state(target_state="secondary")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -5,7 +5,6 @@ import time
 cluster = None
 node1 = None
 node2 = None
-node3 = None
 
 def setup_module():
     global cluster
@@ -24,10 +23,6 @@ def test_001_init_primary():
     node1.create()
     node1.run()
     assert node1.wait_until_state(target_state="single")
-
-def test_001_stop_postgres():
-    node1.stop_postgres()
-    assert node1.wait_until_pg_is_running()
 
 def test_002_create_t1():
     node1.run_sql_query("CREATE TABLE t1(a int)")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,41 @@
+import pgautofailover_utils as pgautofailover
+from nose.tools import *
+
+cluster = None
+node1 = None
+node2 = None
+node3 = None
+
+def setup_module():
+    global cluster
+    cluster = pgautofailover.Cluster()
+
+def teardown_module():
+    cluster.destroy()
+
+def test_000_create_monitor():
+    monitor = cluster.create_monitor("/tmp/monitor", auth_method="md5", password="EasyPassword")
+    monitor.wait_until_pg_is_running()
+
+def test_001_init_primary():
+    global node1
+    node1 = cluster.create_datanode("/tmp/node1", auth_method="md5", password="EasyPassword")
+    node1.create()
+    node1.run()
+    assert node1.wait_until_state(target_state="single")
+
+def test_001_stop_postgres():
+    node1.stop_postgres()
+    assert node1.wait_until_pg_is_running()
+
+def test_002_create_t1():
+    node1.run_sql_query("CREATE TABLE t1(a int)")
+    node1.run_sql_query("INSERT INTO t1 VALUES (1), (2)")
+
+def test_003_init_secondary():
+    global node2
+    node2 = cluster.create_datanode("/tmp/node2", auth_method="md5", password="EasyPassword")
+    node2.create()
+    node2.run()
+    assert node2.wait_until_state(target_state="secondary")
+    assert node1.wait_until_state(target_state="primary")


### PR DESCRIPTION
we can now configure auth param in pg_hba for following users

Monitor:
autoctl_node : user to connect to monitor from pg_autoctl nodes

Nodes:
pgautofailover_monitor : user to connect to pg_autoctl nodes from the monitor

Replication user auth mode is also set to provided value if the replication user password is also set.
