### PR TITLE
Fix missing include header.

### DIFF
--- a/src/bin/pg_autoctl/Makefile
+++ b/src/bin/pg_autoctl/Makefile
@@ -33,7 +33,8 @@ CFLAGS += $(COMMON_LIBS)
 
 LIBS  = -L $(shell $(PG_CONFIG) --libdir)
 LIBS += -L $(shell $(PG_CONFIG) --pkglibdir)
-LIBS += -lpq -lpgport -lpgcommon
+LIBS += $(shell $(PG_CONFIG) --libs)
+LIBS += -lpq
 
 all: $(PG_AUTOCTL) ;
 

--- a/src/bin/pg_autoctl/cli_create_drop_node.c
+++ b/src/bin/pg_autoctl/cli_create_drop_node.c
@@ -8,6 +8,7 @@
  *
  */
 
+#include <arpa/inet.h>
 #include <errno.h>
 #include <inttypes.h>
 #include <getopt.h>

--- a/src/bin/pg_autoctl/keeper.c
+++ b/src/bin/pg_autoctl/keeper.c
@@ -8,8 +8,9 @@
  */
 #include <fcntl.h>
 #include <inttypes.h>
-#include <time.h>
 #include <stdlib.h>
+#include <sys/stat.h>
+#include <time.h>
 #include <unistd.h>
 
 

--- a/src/bin/pg_autoctl/state.c
+++ b/src/bin/pg_autoctl/state.c
@@ -11,6 +11,7 @@
 #include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 #include <time.h>
 #include <unistd.h>
 


### PR DESCRIPTION
Some of our C files are missing headers and compile then fails on FreeBSD.
I'm not sure how compile passes in other systems / compilers, and the fix
seems relevant and general enough for all platforms.

Fixes #32.