### PR TITLE
Implement pg_autoctl enable|disable maintenance CLI.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN PIPENV_PIPFILE=tests/Pipfile pipenv install --system --deploy
 
 COPY Makefile ./
 COPY ./src/ ./src
-RUN make clean && make install -j8
+RUN make -s clean && make -s install -j8
 
 COPY ./tests/ ./tests
 

--- a/docs/operations.rst
+++ b/docs/operations.rst
@@ -51,6 +51,14 @@ a secondary node::
   > select pgautofailover.start_maintenance('nodename', 5432);
   > select pgautofailover.stop_maintenance('nodename', 5432);
 
+The command line tool ``pg_autoctl`` also exposes an API to schedule
+maintenance operations on the current node, which must be a secondary node
+at the moment when maintenance is requested::
+
+  $ pg_autoctl enable maintenance
+  ...
+  $ pg_autoctl disable maintenance
+
 When a standby node is in maintenance, the monitor sets the primary node
 replication to WAIT_PRIMARY: in this role, the PostgreSQL streaming
 replication is now asynchronous and the standby PostgreSQL server may be

--- a/docs/ref/reference.rst
+++ b/docs/ref/reference.rst
@@ -461,10 +461,12 @@ commands, only available in debug environments::
       state   Prints monitor's state of nodes in a given formation and group
 
     pg_autoctl enable
-      secondary  Enable secondary nodes on a formation
+      secondary    Enable secondary nodes on a formation
+      maintenance  Enable Postgres maintenance mode on this node
 
     pg_autoctl disable
-      secondary  Disable secondary nodes on a formation
+      secondary    Disable secondary nodes on a formation
+      maintenance  Disable Postgres maintenance mode on this node
 
     pg_autoctl do
     + monitor      Query a pg_auto_failover monitor
@@ -478,8 +480,6 @@ commands, only available in debug environments::
     + get       Get information from the monitor
       register  Register the current node with the monitor
       active    Call in the pg_auto_failover Node Active protocol
-      pause     Pause pg_auto_failover on this node
-      resume    Resume pg_auto_failover on this node
       version   Check that monitor version is 1.0; alter extension update if not
 
     pg_autoctl do monitor get

--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -325,6 +325,32 @@ SELECT reportedstate
             return results[0][0]
         return results
 
+    def enable_maintenance(self):
+        """
+        Enables maintenance on a pg_autoctl standby node
+
+        :return:
+        """
+        command = [shutil.which('pg_autoctl'), 'enable', 'maintenance',
+                   '--pgdata', self.datadir]
+        proc = self.vnode.run(command)
+        wait_or_timeout_proc(proc,
+                             name="enable maintenance",
+                             timeout=COMMAND_TIMEOUT)
+
+    def disable_maintenance(self):
+        """
+        Disables maintenance on a pg_autoctl standby node
+
+        :return:
+        """
+        command = [shutil.which('pg_autoctl'), 'disable', 'maintenance',
+                   '--pgdata', self.datadir]
+        proc = self.vnode.run(command)
+        wait_or_timeout_proc(proc,
+                             name="disable maintenance",
+                             timeout=COMMAND_TIMEOUT)
+
     def drop(self):
         """
         Drops a pg_autoctl node from its formation


### PR DESCRIPTION
The feature was already there and the CLI hidden in our DEBUG tooling,
because we were not sure at the time of the initial implementation how to
expose the feature to our users.

Now that we have the enable|disable subcommands already, it looks like it is
a good fit for the maintenance feature.

Fixes #33.