### PR TITLE
Fix dockerfile build-dependencies.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,12 @@ RUN apt-get update \
     libicu-dev \
     libkrb5-dev \
     libssl-dev \
+    libedit-dev \
+    libpam-dev \
+    zlib1g-dev \
+    libxml2-dev \
+    libxslt1-dev \
+    libselinux1-dev \
     make \
     openssl \
     pipenv \

--- a/src/bin/pg_autoctl/Makefile
+++ b/src/bin/pg_autoctl/Makefile
@@ -31,8 +31,8 @@ CFLAGS += -I $(shell $(PG_CONFIG) --cflags)
 CFLAGS += -Wformat
 CFLAGS += $(COMMON_LIBS)
 
-LIBS  = -L $(shell $(PG_CONFIG) --libdir)
-LIBS += -L $(shell $(PG_CONFIG) --pkglibdir)
+LIBS  = -L $(shell $(PG_CONFIG) --pkglibdir)
+LIBS += $(shell $(PG_CONFIG) --ldflags)
 LIBS += $(shell $(PG_CONFIG) --libs)
 LIBS += -lpq
 


### PR DESCRIPTION
Now that we're using $(shell $(PG_CONFIG) --libs) to have the list of
librairies we depend on, we must align the build dependencies of
pg_auto_failover with the Postgres build dependencies on the platform where
we build.

In debian, that means having build dependencies towards readline
support (that's libedit), pam, zlib, xml, xstl, and selinux.

See #34.