### PR TITLE
Drop replication slot after failover being demoted to secondary

### DIFF
--- a/src/bin/pg_autoctl/fsm_transition.c
+++ b/src/bin/pg_autoctl/fsm_transition.c
@@ -473,8 +473,9 @@ fsm_rewind_or_init(Keeper *keeper)
 
 	if (!primary_drop_replication_slot(postgres, config->replication_slot_name))
 	{
-		log_warn("Failed to drop replication slot \"%s\" used by the standby failed",
+		log_error("Failed to drop replication slot \"%s\" used by the standby failed",
 				  config->replication_slot_name);
+		return false;
 	}
 
 	return true;

--- a/src/bin/pg_autoctl/fsm_transition.c
+++ b/src/bin/pg_autoctl/fsm_transition.c
@@ -471,6 +471,12 @@ fsm_rewind_or_init(Keeper *keeper)
 		}
 	}
 
+	if (!primary_drop_replication_slot(postgres, config->replication_slot_name))
+	{
+		log_warn("Failed to drop replication slot \"%s\" used by the standby failed",
+				  config->replication_slot_name);
+	}
+
 	return true;
 }
 

--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -483,6 +483,17 @@ class MonitorNode(PGNode):
                              name="disable feature",
                              timeout=COMMAND_TIMEOUT)
 
+    def failover(self, formation='default', group=0):
+        """
+        performs manual failover for given formation and group id
+        """
+        failover_commmand_text = "select * from pgautofailover.perform_failover('%s', %s)" %(formation, group)
+        failover_command = [shutil.which('psql'), '-d', self.database, '-c', failover_commmand_text]
+        failover_proc = self.vnode.run(failover_command)
+        wait_or_timeout_proc(failover_proc,
+                         name="manual failover",
+                         timeout=COMMAND_TIMEOUT)
+
 
 
 def wait_or_timeout_proc(proc, name, timeout):


### PR DESCRIPTION
Replication slot record remains in pg_replication_slots after
primary gets demoted to be secondary. This commit explicitly
removes the record.

Fixes #42 