### PR TITLE
Add support for producing pg_autoctl man pages.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -158,7 +158,11 @@ latex_show_urls = 'footnote'
 # (source start file, name, description, authors, manual section).
 man_pages = [
     (master_doc, 'pg_auto_failover', 'pg_auto_failover Documentation',
-     [author], 1)
+     [author], 1),
+    ('ref/reference', 'pg_autoctl', 'pg_auto_failover agent',
+     [author], 1),
+    ('ref/configuration', 'pg_autoctl', 'pg_auto_failover Configuration',
+     [author], 5)
 ]
 
 


### PR DESCRIPTION
Fixes #61.

With that setting when doing `make man` we now have the following output:

```
$ ls -l ./docs/_build/man/
total 240
-rw-r--r--  1 dim  staff  85016 Sep 19 14:05 pg_auto_failover.1
-rw-r--r--  1 dim  staff  24316 Sep 19 14:05 pg_autoctl.1
-rw-r--r--  1 dim  staff  11116 Sep 19 14:05 pg_autoctl.5
```

Those pages can be installed in the packages script and are actually covering the `pg_autoctl` tool itself.