### PR TITLE
Fix sprintf errors for size_t type on Windows platform

### DIFF
--- a/src/monitor/notifications.c
+++ b/src/monitor/notifications.c
@@ -84,7 +84,7 @@ NotifyStateChange(ReplicationState reportedState,
 	 * string in the message. Parsing is then easier on the receiving side too.
 	 */
 	sprintf(payload,
-			"S:%s:%s:%lu.%s:%d:%ld:%lu.%s:%d",
+			"S:%s:%s:%zu.%s:%d:%lld:%zu.%s:%d",
 			ReplicationStateGetName(reportedState),
 			ReplicationStateGetName(goalState),
 			strlen(formationId),


### PR DESCRIPTION
Use `%zu` format placeholder for `size_t`, and use `%lld` format placeholer for int64.

Error:
```
notifications.c:87:4: error: format '%lu' expects argument of type 'long unsigned int', but argument 5 has type 'size_t' {aka 'long long unsigned int'} [-Werror=format=]
   87 |    "S:%s:%s:%lu.%s:%d:%zd:%zu.%s:%d",
      |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```