### PR TITLE
Allow for conditional writing of pg_hba.conf (#62)

### DIFF
--- a/docs/ref/reference.rst
+++ b/docs/ref/reference.rst
@@ -92,6 +92,7 @@ commands are dealing with the monitor:
         --pgport      PostgreSQL's port number
         --nodename    hostname by which postgres is reachable
         --auth        authentication method for connections from data nodes
+        --no-pg-hba   Do not allow pg_autoctl to manage pg_hba.conf
 
      The ``--pgdata`` option is mandatory and default to the environment
      variable ``PGDATA``. The ``--pgport`` default value is 5432, and the
@@ -120,12 +121,12 @@ commands are dealing with the monitor:
      You may use the `--nodename` command line option to bypass the whole
      DNS lookup based process and force the local node name to a fixed
      value.
-     
+
      The ``--auth`` option allows setting up authentication method to be used
      for connections from data nodes with ``autoctl_node`` user.
      If this option is used, please make sure password is manually set on
      the monitor, and appropriate setting is added to `.pgpass` file on data node.
-     
+
      See :ref:`pg_auto_failover_security` for notes on `.pgpass`
 
   - ``pg_autoctl run``
@@ -279,6 +280,7 @@ The other commands accept the same set of options.
     --monitor     pg_auto_failover Monitor Postgres URL
     --auth        authentication method for connections from monitor
     --allow-removing-pgdata   Allow pg_autoctl to remove the database directory
+    --no-pg-hba   Do not allow pg_autoctl to manage pg_hba.conf
 
 Three different modes of initialization are supported by this command,
 corresponding to as many implementation strategies.

--- a/src/bin/pg_autoctl/cli_common.c
+++ b/src/bin/pg_autoctl/cli_common.c
@@ -47,7 +47,7 @@ bool noPgHba = false;
  *		{ "formation", required_argument, NULL, 'f' },
  *		{ "group", required_argument, NULL, 'g' },
  *		{ "monitor", required_argument, NULL, 'm' },
- *		{ "no-pga-hba", no_argument, NULL, 'N' },
+ *		{ "no-pg-hba", no_argument, NULL, 'N' },
  *		{ "allow-removing-pgdata", no_argument, NULL, 'R' },
  *		{ "help", no_argument, NULL, 0 },
  *		{ NULL, 0, NULL, 0 }
@@ -213,7 +213,7 @@ cli_create_node_getopts(int argc, char **argv,
 
 			case 'N':
 			{
-				/* { "no-pga-hba", no_argument, NULL, 'N' } */
+				/* { "no-pg-hba", no_argument, NULL, 'N' } */
 				noPgHba = true;
 				log_trace("--no-pg-hba");
 				break;

--- a/src/bin/pg_autoctl/cli_common.c
+++ b/src/bin/pg_autoctl/cli_common.c
@@ -26,7 +26,7 @@
 /* handle command line options for our setup. */
 KeeperConfig keeperOptions;
 bool allowRemovingPgdata = false;
-bool noPgHba = false;
+bool skipPgHba = false;
 
 
 /*
@@ -47,7 +47,7 @@ bool noPgHba = false;
  *		{ "formation", required_argument, NULL, 'f' },
  *		{ "group", required_argument, NULL, 'g' },
  *		{ "monitor", required_argument, NULL, 'm' },
- *		{ "no-pg-hba", no_argument, NULL, 'N' },
+ *		{ "skip-pg-hba", no_argument, NULL, 's' },
  *		{ "allow-removing-pgdata", no_argument, NULL, 'R' },
  *		{ "help", no_argument, NULL, 0 },
  *		{ NULL, 0, NULL, 0 }
@@ -211,14 +211,6 @@ cli_create_node_getopts(int argc, char **argv,
 				break;
 			}
 
-			case 'N':
-			{
-				/* { "no-pg-hba", no_argument, NULL, 'N' } */
-				noPgHba = true;
-				log_trace("--no-pg-hba");
-				break;
-			}
-
 			case 'R':
 			{
 				/* { "allow-removing-pgdata", no_argument, NULL, 'R' } */
@@ -226,6 +218,15 @@ cli_create_node_getopts(int argc, char **argv,
 				log_trace("--allow-removing-pgdata");
 				break;
 			}
+
+			case 's':
+			{
+				/* { "skip-pg-hba", no_argument, NULL, 'N' } */
+				skipPgHba = true;
+				log_trace("--skip-pg-hba");
+				break;
+			}
+
 
 			default:
 			{

--- a/src/bin/pg_autoctl/cli_common.c
+++ b/src/bin/pg_autoctl/cli_common.c
@@ -26,6 +26,7 @@
 /* handle command line options for our setup. */
 KeeperConfig keeperOptions;
 bool allowRemovingPgdata = false;
+bool noPgHba = false;
 
 
 /*
@@ -46,6 +47,7 @@ bool allowRemovingPgdata = false;
  *		{ "formation", required_argument, NULL, 'f' },
  *		{ "group", required_argument, NULL, 'g' },
  *		{ "monitor", required_argument, NULL, 'm' },
+ *		{ "no-pga-hba", no_argument, NULL, 'N' },
  *		{ "allow-removing-pgdata", no_argument, NULL, 'R' },
  *		{ "help", no_argument, NULL, 0 },
  *		{ NULL, 0, NULL, 0 }
@@ -206,6 +208,14 @@ cli_create_node_getopts(int argc, char **argv,
 				}
 				strlcpy(LocalOptionConfig.monitor_pguri, optarg, MAXCONNINFO);
 				log_trace("--monitor %s", LocalOptionConfig.monitor_pguri);
+				break;
+			}
+
+			case 'N':
+			{
+				/* { "no-pga-hba", no_argument, NULL, 'N' } */
+				noPgHba = true;
+				log_trace("--no-pg-hba");
 				break;
 			}
 

--- a/src/bin/pg_autoctl/cli_common.h
+++ b/src/bin/pg_autoctl/cli_common.h
@@ -21,7 +21,7 @@
 extern MonitorConfig monitorOptions;
 extern KeeperConfig keeperOptions;
 extern bool allowRemovingPgdata;
-extern bool noPgHba;
+extern bool skipPgHba;
 
 #define KEEPER_CLI_WORKER_SETUP_OPTIONS \
 	"  --pgctl       path to pg_ctl\n" \
@@ -57,7 +57,7 @@ extern bool noPgHba;
 	"  --pgdata      path to data directory\n" \
 
 #define KEEPER_NO_PG_HBA \
-	"  --no-pg-hba   Do not allow pg_autoctl to manage pg_hba.conf\n"
+	"  --skip-pg-hba   Do not allow pg_autoctl to manage pg_hba.conf\n"
 
 /* cli_do.c */
 extern CommandLine do_commands;

--- a/src/bin/pg_autoctl/cli_common.h
+++ b/src/bin/pg_autoctl/cli_common.h
@@ -21,6 +21,7 @@
 extern MonitorConfig monitorOptions;
 extern KeeperConfig keeperOptions;
 extern bool allowRemovingPgdata;
+extern bool noPgHba;
 
 #define KEEPER_CLI_WORKER_SETUP_OPTIONS \
 	"  --pgctl       path to pg_ctl\n" \
@@ -55,6 +56,8 @@ extern bool allowRemovingPgdata;
 #define KEEPER_CLI_PGDATA_OPTION \
 	"  --pgdata      path to data directory\n" \
 
+#define KEEPER_NO_PG_HBA \
+	"  --no-pg-hba   Do not allow pg_autoctl to manage pg_hba.conf\n"
 
 /* cli_do.c */
 extern CommandLine do_commands;

--- a/src/bin/pg_autoctl/cli_create_drop_node.c
+++ b/src/bin/pg_autoctl/cli_create_drop_node.c
@@ -55,7 +55,8 @@ CommandLine create_monitor_command =
 				 "  --pgdata      path to data directory\n" \
 				 "  --pgport      PostgreSQL's port number\n" \
 				 "  --nodename    hostname by which postgres is reachable\n" \
-				 "  --auth        authentication method for connections from data nodes\n",
+				 "  --auth        authentication method for connections from data nodes\n"
+				 KEEPER_NO_PG_HBA,
 				 cli_create_monitor_getopts,
 				 cli_create_monitor);
 
@@ -74,7 +75,8 @@ CommandLine create_postgres_command =
 				 "  --formation   pg_auto_failover formation\n"
 				 "  --monitor     pg_auto_failover Monitor Postgres URL\n"
 				 "  --auth        authentication method for connections from monitor\n"
-				 KEEPER_CLI_ALLOW_RM_PGDATA_OPTION,
+				 KEEPER_CLI_ALLOW_RM_PGDATA_OPTION
+				 KEEPER_NO_PG_HBA,
 				 cli_create_postgres_getopts,
 				 cli_create_postgres);
 
@@ -203,13 +205,14 @@ cli_create_postgres_getopts(int argc, char **argv)
 		{ "formation", required_argument, NULL, 'f' },
 		{ "monitor", required_argument, NULL, 'm' },
 		{ "allow-removing-pgdata", no_argument, NULL, 'R' },
+		{ "no-pg-hba", no_argument, NULL, 'N' },
 		{ "help", no_argument, NULL, 0 },
 		{ NULL, 0, NULL, 0 }
 	};
 
 	int optind =
 		cli_create_node_getopts(argc, argv,
-								long_options, "C:D:h:p:l:U:A:d:n:f:m:R",
+								long_options, "C:D:h:p:l:U:A:d:n:f:m:R:N",
 								&options);
 
 	/* publish our option parsing in the global variable */
@@ -266,6 +269,7 @@ cli_create_monitor_getopts(int argc, char **argv)
 		{ "nodename", required_argument, NULL, 'n' },
 		{ "listen", required_argument, NULL, 'l' },
 		{ "auth", required_argument, NULL, 'A' },
+		{ "no-pg-hba", no_argument, NULL, 'N' },
 		{ "help", no_argument, NULL, 0 },
 		{ NULL, 0, NULL, 0 }
 	};
@@ -275,7 +279,7 @@ cli_create_monitor_getopts(int argc, char **argv)
 
 	optind = 0;
 
-	while ((c = getopt_long(argc, argv, "C:D:p:A:",
+	while ((c = getopt_long(argc, argv, "C:D:p:A:l:N:",
 							long_options, &option_index)) != -1)
 	{
 		switch (c)
@@ -327,6 +331,14 @@ cli_create_monitor_getopts(int argc, char **argv)
 				log_trace("--auth %s", options.pgSetup.authMethod);
 				break;
 			}
+
+			case 'N':
+			{
+				noPgHba = true;
+				log_trace("--no-pg-hba");
+				break;
+			}
+
 			default:
 			{
 				/* getopt_long already wrote an error message */

--- a/src/bin/pg_autoctl/cli_create_drop_node.c
+++ b/src/bin/pg_autoctl/cli_create_drop_node.c
@@ -332,10 +332,10 @@ cli_create_monitor_getopts(int argc, char **argv)
 				break;
 			}
 
-			case 'N':
+			case 's':
 			{
-				noPgHba = true;
-				log_trace("--no-pg-hba");
+				skipPgHba = true;
+				log_trace("--skip-pg-hba");
 				break;
 			}
 

--- a/src/bin/pg_autoctl/cli_do_misc.c
+++ b/src/bin/pg_autoctl/cli_do_misc.c
@@ -255,7 +255,7 @@ keeper_cli_add_standby_to_hba(int argc, char **argv)
 		exit(EXIT_CODE_BAD_ARGS);
 	}
 
-	if (!noPgHba)
+	if (!skipPgHba)
 	{
 		if (!primary_add_standby_to_hba(&postgres, standbyHostname, config.replication_password))
 		{

--- a/src/bin/pg_autoctl/cli_do_misc.c
+++ b/src/bin/pg_autoctl/cli_do_misc.c
@@ -255,12 +255,15 @@ keeper_cli_add_standby_to_hba(int argc, char **argv)
 		exit(EXIT_CODE_BAD_ARGS);
 	}
 
-	if (!primary_add_standby_to_hba(&postgres, standbyHostname, config.replication_password))
+	if (!noPgHba)
 	{
-		log_fatal("Failed to grant access to the standby by adding relevant lines to "
-				  "pg_hba.conf for the standby hostname and user, see above for "
-				  "details");
-		exit(EXIT_CODE_PGSQL);
+		if (!primary_add_standby_to_hba(&postgres, standbyHostname, config.replication_password))
+		{
+			log_fatal("Failed to grant access to the standby by adding relevant lines to "
+					"pg_hba.conf for the standby hostname and user, see above for "
+					"details");
+			exit(EXIT_CODE_PGSQL);
+		}
 	}
 }
 

--- a/src/bin/pg_autoctl/fsm_transition.c
+++ b/src/bin/pg_autoctl/fsm_transition.c
@@ -103,7 +103,7 @@ fsm_init_primary(Keeper *keeper)
 	password = NULL;
 	authMethod = pg_setup_get_auth_method(&(config->pgSetup));
 
-	if (!noPgHba) {
+	if (!skipPgHba) {
 		if (!primary_create_user(postgres,
 								 PG_AUTOCTL_HEALTH_USERNAME, password,
 								 monitorHostname, authMethod))
@@ -261,7 +261,7 @@ prepare_replication(Keeper *keeper, bool other_node_missing_is_ok)
 		return other_node_missing_is_ok;
 	}
 
-	if (!noPgHba)
+	if (!skipPgHba)
 	{
 		if (!primary_add_standby_to_hba(postgres,
 										otherNode.host,

--- a/src/bin/pg_autoctl/keeper_pg_init.c
+++ b/src/bin/pg_autoctl/keeper_pg_init.c
@@ -414,7 +414,7 @@ reach_initial_state(Keeper *keeper)
 			 * existing PostgreSQL primary server instance, making sure that
 			 * the parameters are all set.
 			 */
-			if (!noPgHba
+			if (!skipPgHba
 				&& pgInstanceIsOurs)
 			{
 				if (getenv("PG_REGRESS_SOCK_DIR") != NULL)
@@ -712,7 +712,7 @@ create_database_and_extension(Keeper *keeper)
 	/* we didn't start PostgreSQL yet, also we just ran initdb */
 	snprintf(hbaFilePath, MAXPGPATH, "%s/pg_hba.conf", pgSetup->pgdata);
 
-	if (!noPgHba)
+	if (!skipPgHba)
 	{
 		/*
 		* The Postgres URI given to the user by our facility is going to use
@@ -815,7 +815,7 @@ create_database_and_extension(Keeper *keeper)
 	 * Now allow nodes on the same network to connect to the coordinator, and
 	 * the coordinator to connect to its workers.
 	 */
-	if (!noPgHba
+	if (!skipPgHba
 		&& IS_CITUS_INSTANCE_KIND(postgres->pgKind))
 	{
 		(void) pghba_enable_lan_cidr(&initPostgres.sqlClient,

--- a/src/bin/pg_autoctl/primary_standby.c
+++ b/src/bin/pg_autoctl/primary_standby.c
@@ -328,6 +328,33 @@ postgres_add_default_settings(LocalPostgresServer *postgres)
 
 
 /*
+ * primary_create_user creates a user.
+ */
+bool
+primary_create_user(LocalPostgresServer *postgres, char *userName,
+					char *password, char *hostname, char *authMethod)
+{
+	PGSQL *pgsql = &(postgres->sqlClient);
+	bool login = true;
+	bool superuser = false;
+	bool replication = false;
+	char hbaFilePath[MAXPGPATH];
+
+	log_trace("primary_create_user");
+
+	if (!pgsql_create_user(pgsql, userName, password, login, superuser, replication))
+	{
+		log_error("Failed to create user \"%s\" on local postgres server", userName);
+		return false;
+	}
+
+	pgsql_finish(pgsql);
+
+	return true;
+}
+
+
+/*
  * primary_create_user_with_hba creates a user and updates pg_hba.conf
  * to allow the user to connect from the given hostname.
  */

--- a/src/bin/pg_autoctl/primary_standby.h
+++ b/src/bin/pg_autoctl/primary_standby.h
@@ -50,6 +50,8 @@ bool primary_drop_replication_slot(LocalPostgresServer *postgres,
 bool primary_enable_synchronous_replication(LocalPostgresServer *postgres);
 bool primary_disable_synchronous_replication(LocalPostgresServer *postgres);
 bool postgres_add_default_settings(LocalPostgresServer *postgres);
+bool primary_create_user(LocalPostgresServer *postgres, char *userName,
+						 char *password, char *hostname, char *authMethod);
 bool primary_create_user_with_hba(LocalPostgresServer *postgres, char *userName,
 								  char *password, char *hostname, char *authMethod);
 bool primary_create_replication_user(LocalPostgresServer *postgres,


### PR DESCRIPTION
What?
Add a cli option (`--no-pg-hba`) for create monitor and create postgres

Why?
In some environments it is preferable for configuration management create
the `pg_hba.conf` file and having `pg_auto_failover` create it will cause
configuration management and `pg_auto_failover` to overwrite each other.

In addition, the current implementation is too opinionated about the
CIDR block used. In my environment, I need something much more restrictive.