### PR TITLE
WIP: fix pg_setup_standby_mode.

### DIFF
--- a/src/bin/pg_autoctl/fsm_transition.c
+++ b/src/bin/pg_autoctl/fsm_transition.c
@@ -533,6 +533,14 @@ fsm_enable_sync_rep(Keeper *keeper)
 {
 	LocalPostgresServer *postgres = &(keeper->postgres);
 
+	if (!ensure_local_postgres_is_running(postgres))
+	{
+		log_error("Failed to enable sync rep because the server "
+				  "was not running and could not be restarted, "
+				  "see above for details");
+		return false;
+	}
+
 	return primary_enable_synchronous_replication(postgres);
 }
 

--- a/src/bin/pg_autoctl/fsm_transition.c
+++ b/src/bin/pg_autoctl/fsm_transition.c
@@ -257,10 +257,13 @@ fsm_init_primary(Keeper *keeper)
 			 * In test environements allow nodes from the same network to
 			 * connect. The network is discovered automatically.
 			 */
-			(void) pghba_enable_lan_cidr(&keeper->postgres.sqlClient,
+			char *hbaFilePath = keeper->postgres.postgresSetup.pgConfigPath.hba;
+
+			(void) pghba_enable_lan_cidr(hbaFilePath,
 										 HBA_DATABASE_ALL, NULL,
 										 keeper->config.nodename,
-										 NULL, DEFAULT_AUTH_METHOD, NULL);
+										 NULL, DEFAULT_AUTH_METHOD,
+										 &keeper->postgres.sqlClient);
 		}
 	}
 	else

--- a/src/bin/pg_autoctl/fsm_transition.c
+++ b/src/bin/pg_autoctl/fsm_transition.c
@@ -245,28 +245,10 @@ fsm_init_primary(Keeper *keeper)
 	}
 
 	/*
-	 * What remains to be done is either opening the HBA for a test setup, or
-	 * when we are initializing pg_auto_failover on an existing PostgreSQL
-	 * primary server instance, making sure that the parameters are all set.
+	 * When we are initializing pg_auto_failover on an existing PostgreSQL
+	 * primary server instance, make sure that the parameters are all set.
 	 */
-	if (pgInstanceIsOurs)
-	{
-		if (getenv("PG_REGRESS_SOCK_DIR") != NULL)
-		{
-			/*
-			 * In test environements allow nodes from the same network to
-			 * connect. The network is discovered automatically.
-			 */
-			char *hbaFilePath = keeper->postgres.postgresSetup.pgConfigPath.hba;
-
-			(void) pghba_enable_lan_cidr(hbaFilePath,
-										 HBA_DATABASE_ALL, NULL,
-										 keeper->config.nodename,
-										 NULL, DEFAULT_AUTH_METHOD,
-										 &keeper->postgres.sqlClient);
-		}
-	}
-	else
+	if (!pgInstanceIsOurs)
 	{
 		/*
 		 * As we are registering a previsouly existing PostgreSQL

--- a/src/bin/pg_autoctl/keeper.c
+++ b/src/bin/pg_autoctl/keeper.c
@@ -541,7 +541,9 @@ keeper_update_pg_state(Keeper *keeper)
 
 	/*
 	 * In some states, PostgreSQL isn't expected to be running, or not expected
-	 * to have a streaming replication to monitor at all.
+	 * to have a streaming replication to monitor at all. When the streaming
+	 * replication is running as expected then postgres->pgsrSyncState is
+	 * filled in, otherwise it's an empty string.
 	 */
 	switch (keeperState->current_role)
 	{
@@ -570,6 +572,7 @@ keeper_update_pg_state(Keeper *keeper)
 
 		case SECONDARY_STATE:
 		case CATCHINGUP_STATE:
+		case WAIT_PRIMARY_STATE:
 		{
 			/* pg_stat_replication.sync_state is only available upstream */
 			return postgres->pgIsRunning

--- a/src/bin/pg_autoctl/keeper.c
+++ b/src/bin/pg_autoctl/keeper.c
@@ -517,7 +517,7 @@ keeper_update_pg_state(Keeper *keeper)
 		{
 			log_error("Failed to obtain the HBA file path from the local "
 					  "PostgreSQL server.");
-			return false;;
+			return false;
 		}
 	}
 	else

--- a/src/bin/pg_autoctl/keeper.c
+++ b/src/bin/pg_autoctl/keeper.c
@@ -572,9 +572,7 @@ keeper_update_pg_state(Keeper *keeper)
 
 		case SECONDARY_STATE:
 		case CATCHINGUP_STATE:
-		case WAIT_PRIMARY_STATE:
 		{
-			/* pg_stat_replication.sync_state is only available upstream */
 			return postgres->pgIsRunning
 				&& !IS_EMPTY_STRING_BUFFER(postgres->currentLSN);
 		}

--- a/src/bin/pg_autoctl/keeper.c
+++ b/src/bin/pg_autoctl/keeper.c
@@ -125,7 +125,7 @@ keeper_ensure_current_state(Keeper *keeper)
 	PostgresSetup *pgSetup = &(keeper->postgres.postgresSetup);
 	LocalPostgresServer *postgres = &(keeper->postgres);
 
-	log_trace("keeper_ensure_current_state: %s",
+	log_debug("keeper_ensure_current_state: %s",
 			  NodeStateToString(keeperState->current_role));
 
 	switch (keeperState->current_role)

--- a/src/bin/pg_autoctl/keeper.c
+++ b/src/bin/pg_autoctl/keeper.c
@@ -644,12 +644,15 @@ keeper_restart_postgres(Keeper *keeper)
 {
 	PostgresSetup *pgSetup = &(keeper->postgres.postgresSetup);
 
+	log_trace("keeper_restart_postgres");
+
 	if (!pg_ctl_restart(pgSetup->pg_ctl, pgSetup->pgdata))
 	{
 		log_error("Failed to restart PostgreSQL instance at \"%s\", "
 				  "see above for details.", pgSetup->pgdata);
 		return false;
 	}
+
 	if (!keeper_update_pg_state(keeper))
 	{
 		log_error("Failed to update the keeper's state from the local "

--- a/src/bin/pg_autoctl/keeper.c
+++ b/src/bin/pg_autoctl/keeper.c
@@ -125,7 +125,7 @@ keeper_ensure_current_state(Keeper *keeper)
 	PostgresSetup *pgSetup = &(keeper->postgres.postgresSetup);
 	LocalPostgresServer *postgres = &(keeper->postgres);
 
-	log_debug("keeper_ensure_current_state: %s",
+	log_debug("Ensuring current state: %s",
 			  NodeStateToString(keeperState->current_role));
 
 	switch (keeperState->current_role)
@@ -573,6 +573,7 @@ keeper_update_pg_state(Keeper *keeper)
 		case SECONDARY_STATE:
 		case CATCHINGUP_STATE:
 		{
+			/* pg_stat_replication.sync_state is only available upstream */
 			return postgres->pgIsRunning
 				&& !IS_EMPTY_STRING_BUFFER(postgres->currentLSN);
 		}

--- a/src/bin/pg_autoctl/keeper.c
+++ b/src/bin/pg_autoctl/keeper.c
@@ -496,6 +496,29 @@ keeper_update_pg_state(Keeper *keeper)
 			log_error("Failed to update the local Postgres metadata");
 			return false;
 		}
+
+		/*
+		 * Update our cache of file path locations for Postgres configuration
+		 * files (including HBA), in case it's been moved to somewhere else.
+		 * This could happen when using the debian/ubuntu pg_createcluster
+		 * command on an already existing cluster, for instance.
+		 *
+		 */
+		if (!pgsql_get_config_file_path(pgsql,
+										pgSetup->pgConfigPath.conf, MAXPGPATH))
+		{
+			log_error("Failed to get the postgresql.conf path from the "
+					  "local Postgres server, see above for details");
+			return false;
+		}
+
+		if (!pgsql_get_hba_file_path(pgsql,
+									 pgSetup->pgConfigPath.hba, MAXPGPATH))
+		{
+			log_error("Failed to obtain the HBA file path from the local "
+					  "PostgreSQL server.");
+			return false;;
+		}
 	}
 	else
 	{

--- a/src/bin/pg_autoctl/keeper_config.c
+++ b/src/bin/pg_autoctl/keeper_config.c
@@ -78,6 +78,14 @@
 	make_strbuf_option("postgresql", "listen_addresses", "listen", \
 					   false, MAXPGPATH, config->pgSetup.listen_addresses)
 
+#define OPTION_POSTGRESQL_CONFIG_FILE(config) \
+	make_strbuf_option("postgresql", "config_file", NULL, \
+					   false, MAXPGPATH, config->pgSetup.pgConfigPath.conf)
+
+#define OPTION_POSTGRESQL_HBA_FILE(config) \
+	make_strbuf_option("postgresql", "hba_file", NULL, \
+					   false, MAXPGPATH, config->pgSetup.pgConfigPath.hba)
+
 #define OPTION_REPLICATION_SLOT_NAME(config) \
 	make_string_option_default("replication", "slot", NULL, false, \
 							   &config->replication_slot_name, \
@@ -147,7 +155,9 @@
 		OPTION_POSTGRESQL_PORT(config), \
 		OPTION_POSTGRESQL_PROXY_PORT(config), \
 		OPTION_POSTGRESQL_LISTEN_ADDRESSES(config), \
-		OPTION_REPLICATION_PASSWORD(config), \
+		OPTION_POSTGRESQL_CONFIG_FILE(config), \
+		OPTION_POSTGRESQL_HBA_FILE(config), \
+		OPTION_REPLICATION_PASSWORD(config),		\
 		OPTION_REPLICATION_SLOT_NAME(config), \
 		OPTION_REPLICATION_MAXIMUM_BACKUP_RATE(config), \
 		OPTION_REPLICATION_BACKUP_DIR(config), \
@@ -426,6 +436,8 @@ keeper_config_log_settings(KeeperConfig config)
 	log_debug("postgresql.dbname: %s", config.pgSetup.dbname);
 	log_debug("postgresql.host: %s", config.pgSetup.pghost);
 	log_debug("postgresql.port: %d", config.pgSetup.pgport);
+	log_debug("postgresql.conf_file: %s", config.pgSetup.pgConfigPath.conf);
+	log_debug("postgresql.hba_file: %s", config.pgSetup.pgConfigPath.hba);
 
 	log_debug("replication.replication_slot_name: %s",
 			  config.replication_slot_name);

--- a/src/bin/pg_autoctl/keeper_pg_init.c
+++ b/src/bin/pg_autoctl/keeper_pg_init.c
@@ -679,13 +679,20 @@ create_database_and_extension(Keeper *keeper)
 	 */
 	if (IS_CITUS_INSTANCE_KIND(postgres->pgKind))
 	{
-		(void) pghba_enable_lan_cidr(pgSetup->pgConfigPath.hba,
-									 HBA_DATABASE_DBNAME,
-									 pgSetup->dbname,
-									 config->nodename,
-									 pg_setup_get_username(pgSetup),
-									 "trust",
-									 &initPostgres.sqlClient);
+		char *hbaFilePath = initPostgres.postgresSetup.pgConfigPath.hba;
+
+		if (!pghba_enable_lan_cidr(hbaFilePath,
+								   HBA_DATABASE_DBNAME,
+								   pgSetup->dbname,
+								   config->nodename,
+								   pg_setup_get_username(pgSetup),
+								   "trust",
+								   &initPostgres.sqlClient))
+		{
+			log_fatal("Failed to grant connection privileges to "
+					  "local area network, see above for details");
+			return false;
+		}
 	}
 
 	/*

--- a/src/bin/pg_autoctl/keeper_pg_init.c
+++ b/src/bin/pg_autoctl/keeper_pg_init.c
@@ -645,6 +645,23 @@ create_database_and_extension(Keeper *keeper)
 	}
 
 	/*
+	 * Now that Postgres is running, the initPostgres.postgresSetup structure
+	 * has been updated with the config and hba file properties. Let's update
+	 * our configuration file with those entries.
+	 */
+	strlcpy(config->pgSetup.pgConfigPath.conf,
+			initPostgres.postgresSetup.pgConfigPath.conf, MAXPGPATH);
+
+	strlcpy(config->pgSetup.pgConfigPath.hba,
+			initPostgres.postgresSetup.pgConfigPath.hba, MAXPGPATH);
+
+	if (!keeper_config_write_file(config))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/*
 	 * If username was set in the setup and doesn't exist we need to create it.
 	 */
 	if (!IS_EMPTY_STRING_BUFFER(pgSetup->username))

--- a/src/bin/pg_autoctl/keeper_pg_init.c
+++ b/src/bin/pg_autoctl/keeper_pg_init.c
@@ -679,13 +679,13 @@ create_database_and_extension(Keeper *keeper)
 	 */
 	if (IS_CITUS_INSTANCE_KIND(postgres->pgKind))
 	{
-		(void) pghba_enable_lan_cidr(&initPostgres.sqlClient,
+		(void) pghba_enable_lan_cidr(pgSetup->pgConfigPath.hba,
 									 HBA_DATABASE_DBNAME,
 									 pgSetup->dbname,
 									 config->nodename,
 									 pg_setup_get_username(pgSetup),
 									 "trust",
-									 NULL);
+									 &initPostgres.sqlClient);
 	}
 
 	/*

--- a/src/bin/pg_autoctl/monitor_pg_init.c
+++ b/src/bin/pg_autoctl/monitor_pg_init.c
@@ -232,13 +232,13 @@ monitor_install(const char *nodename,
 	 * Now allow nodes on the same network to connect to pg_auto_failover
 	 * database.
 	 */
-	if (!pghba_enable_lan_cidr(&postgres.sqlClient,
+	if (!pghba_enable_lan_cidr(pgSetup.pgConfigPath.hba,
 							   HBA_DATABASE_DBNAME,
 							   PG_AUTOCTL_MONITOR_DBNAME,
 							   nodename,
 							   PG_AUTOCTL_MONITOR_USERNAME,
 							   pg_setup_get_auth_method(&pgSetup),
-							   NULL))
+							   &postgres.sqlClient))
 	{
 		log_warn("Failed to grant connection to local network.");
 		return false;

--- a/src/bin/pg_autoctl/pgctl.c
+++ b/src/bin/pg_autoctl/pgctl.c
@@ -107,7 +107,7 @@ pg_controldata(PostgresSetup *pgSetup, bool missing_ok)
 	}
 
 	path_in_same_directory(pgSetup->pg_ctl, "pg_controldata", pg_controldata_path);
-	log_debug("%s %s", pg_controldata_path, pgSetup->pgdata);
+	log_trace("%s %s", pg_controldata_path, pgSetup->pgdata);
 
 	/* We parse the output of pg_controldata, make sure it's as expected */
 	setenv("LANG", "C", 1);

--- a/src/bin/pg_autoctl/pgctl.c
+++ b/src/bin/pg_autoctl/pgctl.c
@@ -1163,7 +1163,7 @@ pg_write_standby_signal(const char *configFilePath,
 	 */
 	join_path_components(signalFilePath, pgdata, "standby.signal");
 
-	log_info("Writing recovery configuration to \"%s\"", signalFilePath);
+	log_info("Creating standby signal file \"%s\"", signalFilePath);
 
 	if (!write_file("", 0, signalFilePath))
 	{

--- a/src/bin/pg_autoctl/pgctl.c
+++ b/src/bin/pg_autoctl/pgctl.c
@@ -1192,7 +1192,7 @@ pg_write_standby_signal(const char *configFilePath,
 	 * false here and let the main loop try again. At least Postgres won't
 	 * start as a cloned single accepting writes.
 	 */
-	if (!pg_include_config(standbyConfigFilePath,
+	if (!pg_include_config(configFilePath,
 						   AUTOCTL_SB_CONF_INCLUDE_LINE,
 						   AUTOCTL_SB_CONF_INCLUDE_REGEX,
 						   AUTOCTL_CONF_INCLUDE_COMMENT))

--- a/src/bin/pg_autoctl/pghba.c
+++ b/src/bin/pg_autoctl/pghba.c
@@ -297,6 +297,12 @@ pghba_enable_lan_cidr(const char *hbaFilePath,
 		return false;
 	}
 
+	if (pgsql == NULL)
+	{
+		log_error("BUG: pghba_enable_lan_cidr pgsql connection is NULL.");
+		return false;
+	}
+
 	if (!pgsql_reload_conf(pgsql))
 	{
 		log_error("Failed to reload PostgreSQL configuration for new HBA rule");

--- a/src/bin/pg_autoctl/pghba.h
+++ b/src/bin/pg_autoctl/pghba.h
@@ -28,11 +28,12 @@ bool pghba_ensure_host_rule_exists(const char *hbaFilePath,
 								   const char *hostname,
 								   const char *authenticationScheme);
 
-bool pghba_enable_lan_cidr(PGSQL *pgsql, HBADatabaseType databaseType,
+bool pghba_enable_lan_cidr(const char *hbaFilePath,
+						   HBADatabaseType databaseType,
 						   const char *database,
 						   const char *hostname,
 						   const char *username,
 						   const char *authenticationScheme,
-						   const char *pgdata);
+						   PGSQL *pgsql);
 
 #endif /* PGHBA_H */

--- a/src/bin/pg_autoctl/pgsetup.c
+++ b/src/bin/pg_autoctl/pgsetup.c
@@ -353,6 +353,7 @@ pg_setup_init(PostgresSetup *pgSetup,
 		PGSQL pgsql = { 0 };
 		char connInfo[MAXCONNINFO];
 		char dbname[NAMEDATALEN];
+		char username[NAMEDATALEN];
 
 		/*
 		 * Sometimes `pg_ctl start` returns with success and Postgres is still
@@ -383,6 +384,9 @@ pg_setup_init(PostgresSetup *pgSetup,
 		strlcpy(dbname, pgSetup->dbname, NAMEDATALEN);
 		strlcpy(pgSetup->dbname, "template1", NAMEDATALEN);
 
+		strlcpy(username, pgSetup->username, NAMEDATALEN);
+		strlcpy(pgSetup->username, "", NAMEDATALEN);
+
 		/* initialise a SQL connection to the local postgres server */
 		pg_setup_get_local_connection_string(pgSetup, connInfo);
 		pgsql_init(&pgsql, connInfo, PGSQL_CONN_LOCAL);
@@ -412,6 +416,7 @@ pg_setup_init(PostgresSetup *pgSetup,
 		pgsql_finish(&pgsql);
 
 		strlcpy(pgSetup->dbname, dbname, NAMEDATALEN);
+		strlcpy(pgSetup->username, username, NAMEDATALEN);
 	}
 
 	if (errors > 0)

--- a/src/bin/pg_autoctl/pgsetup.c
+++ b/src/bin/pg_autoctl/pgsetup.c
@@ -742,8 +742,6 @@ pg_setup_is_running(PostgresSetup *pgSetup)
 bool
 pg_setup_is_ready(PostgresSetup *pgSetup, bool pg_is_not_running_is_ok)
 {
-	log_trace("pg_setup_is_ready");
-
 	if (pgSetup->control.pg_control_version > 0)
 	{
 		bool firstTime = true;
@@ -773,8 +771,11 @@ pg_setup_is_ready(PostgresSetup *pgSetup, bool pg_is_not_running_is_ok)
 		 */
 		while (pgSetup->pm_status != POSTMASTER_STATUS_READY)
 		{
-			log_trace("pg_setup_is_ready: %s",
-					  pmStatusToString(pgSetup->pm_status));
+			if (!firstTime)
+			{
+				log_trace("pg_setup_is_ready: %s",
+						  pmStatusToString(pgSetup->pm_status));
+			}
 
  			if (!get_pgpid(pgSetup, pg_is_not_running_is_ok))
 			{
@@ -1039,9 +1040,6 @@ nodeKindToString(PgInstanceKind kind)
 static PostmasterStatus
 pmStatusFromString(const char *postmasterStatus)
 {
-	log_trace("pmStatusFromString: postmaster status is \"%s\"",
-			  postmasterStatus);
-
 	if (strcmp(postmasterStatus, PM_STATUS_STARTING) == 0)
 	{
 		return POSTMASTER_STATUS_STARTING;

--- a/src/bin/pg_autoctl/pgsetup.c
+++ b/src/bin/pg_autoctl/pgsetup.c
@@ -418,6 +418,16 @@ pg_setup_init(PostgresSetup *pgSetup,
 		strlcpy(pgSetup->dbname, dbname, NAMEDATALEN);
 		strlcpy(pgSetup->username, username, NAMEDATALEN);
 	}
+	else
+	{
+		/*
+		 * When Postgres is not running, keep the configuration entries for the
+		 * config and hba files in the new structure: we have a cache for the
+		 * values.
+		 */
+		strlcpy(pgSetup->pgConfigPath.conf, options->pgConfigPath.conf, MAXPGPATH);
+		strlcpy(pgSetup->pgConfigPath.hba, options->pgConfigPath.hba, MAXPGPATH);
+	}
 
 	if (errors > 0)
 	{
@@ -594,8 +604,8 @@ void
 fprintf_pg_setup(FILE *stream, PostgresSetup *pgSetup)
 {
 	fprintf(stream, "pgdata:             %s\n", pgSetup->pgdata);
-	fprintf(stream, "postgresql.conf:    %s\n", pgSetup->pgConfigPath.conf);
-	fprintf(stream, "pg_hba.conf:        %s\n", pgSetup->pgConfigPath.hba);
+	fprintf(stream, "config_file:        %s\n", pgSetup->pgConfigPath.conf);
+	fprintf(stream, "hba_file:           %s\n", pgSetup->pgConfigPath.hba);
 	fprintf(stream, "pg_ctl:             %s\n", pgSetup->pg_ctl);
 	fprintf(stream, "pg_version:         %s\n", pgSetup->pg_version);
 	fprintf(stream, "pghost:             %s\n", pgSetup->pghost);

--- a/src/bin/pg_autoctl/pgsetup.c
+++ b/src/bin/pg_autoctl/pgsetup.c
@@ -387,6 +387,22 @@ pg_setup_init(PostgresSetup *pgSetup,
 		pg_setup_get_local_connection_string(pgSetup, connInfo);
 		pgsql_init(&pgsql, connInfo, PGSQL_CONN_LOCAL);
 
+		if (!pgsql_get_config_file_path(&pgsql,
+										pgSetup->pgConfigPath.conf, MAXPGPATH))
+		{
+			log_error("Failed to get the postgresql.conf path from the "
+					  "local Postgres server, see above for details");
+			errors++;
+		}
+
+		if (!pgsql_get_hba_file_path(&pgsql,
+									 pgSetup->pgConfigPath.hba, MAXPGPATH))
+		{
+			log_error("Failed to obtain the HBA file path from the local "
+					  "PostgreSQL server.");
+			errors++;
+		}
+
 		if (!pgsql_is_in_recovery(&pgsql, &pgSetup->is_in_recovery))
 		{
 			/* we logged about it already */
@@ -573,6 +589,8 @@ void
 fprintf_pg_setup(FILE *stream, PostgresSetup *pgSetup)
 {
 	fprintf(stream, "pgdata:             %s\n", pgSetup->pgdata);
+	fprintf(stream, "postgresql.conf:    %s\n", pgSetup->pgConfigPath.conf);
+	fprintf(stream, "pg_hba.conf:        %s\n", pgSetup->pgConfigPath.hba);
 	fprintf(stream, "pg_ctl:             %s\n", pgSetup->pg_ctl);
 	fprintf(stream, "pg_version:         %s\n", pgSetup->pg_version);
 	fprintf(stream, "pghost:             %s\n", pgSetup->pghost);

--- a/src/bin/pg_autoctl/pgsetup.h
+++ b/src/bin/pg_autoctl/pgsetup.h
@@ -44,6 +44,17 @@ typedef struct pg_pidfile
 } PostgresPIDFile;
 
 /*
+ * PgConfigPath is a cache of the location of configuration and HBA files so
+ * that we can construct new files at the proper places and then edit those
+ * files to add include lines or new setup.
+ */
+typedef struct pg_config_path
+{
+	char conf[MAXPGPATH];
+	char hba[MAXPGPATH];
+} PgConfigPath;
+
+/*
  * From pidfile.h we also extract the Postmaster status, one of the following
  * values:
  */
@@ -124,6 +135,7 @@ typedef struct pg_setup
 	PostgresPIDFile pidFile;                /* postmaster.pid information */
 	PgInstanceKind pgKind;					/* standalone/coordinator/worker */
 	NodeReplicationSettings settings; 		/* monitor side node replication settings */
+	PgConfigPath pgConfigPath;				/* path to postgresql.conf etc */
 } PostgresSetup;
 
 #define IS_EMPTY_STRING_BUFFER(strbuf) (strbuf[0] == '\0')

--- a/src/bin/pg_autoctl/pgsql.c
+++ b/src/bin/pg_autoctl/pgsql.c
@@ -127,7 +127,8 @@ pgsql_finish(PGSQL *pgsql)
 {
 	if (pgsql->connection != NULL)
 	{
-		log_trace("Disconnecting from \"%s\"", pgsql->connectionString);
+		log_trace("Disconnecting from \"%s\" [%p]",
+				  pgsql->connectionString, pgsql->connection);
 		PQfinish(pgsql->connection);
 		pgsql->connection = NULL;
 	}
@@ -198,6 +199,8 @@ pgsql_open_connection(PGSQL *pgsql)
 	}
 
 	pgsql->connection = connection;
+
+	log_trace("Connected to \"%s\" [%p]", pgsql->connectionString, connection);
 
 	/* set the libpq notice receiver to integrate notifications as warnings. */
 	PQsetNoticeProcessor(connection, &pgAutoCtlDefaultNoticeProcessor, NULL);

--- a/src/bin/pg_autoctl/pgsql.c
+++ b/src/bin/pg_autoctl/pgsql.c
@@ -1308,7 +1308,6 @@ validate_connection_string(const char *connectionString)
  *  - sync_state from pg_stat_replication when a primary
  *  - current_lsn from the server
  *
->>>>>>> 46577ea... Simplify the Postgres metadata fetching logic.
  * With those metadata we can then check our expectations and take decisions in
  * some cases. We can obtain all the metadata that we need easily enough in a
  * single SQL query, so that's what we do.

--- a/src/bin/pg_autoctl/pgsql.c
+++ b/src/bin/pg_autoctl/pgsql.c
@@ -127,7 +127,7 @@ pgsql_finish(PGSQL *pgsql)
 {
 	if (pgsql->connection != NULL)
 	{
-		log_debug("Disconnecting from \"%s\"", pgsql->connectionString);
+		log_trace("Disconnecting from \"%s\"", pgsql->connectionString);
 		PQfinish(pgsql->connection);
 		pgsql->connection = NULL;
 	}
@@ -149,7 +149,7 @@ pgsql_open_connection(PGSQL *pgsql)
 		return pgsql->connection;
 	}
 
-	log_debug("Connecting to \"%s\"", pgsql->connectionString);
+	log_trace("Connecting to \"%s\"", pgsql->connectionString);
 
 	/* Make a connection to the database */
 	connection = PQconnectdb(pgsql->connectionString);
@@ -376,7 +376,7 @@ pgsql_execute_with_params(PGSQL *pgsql, const char *sql, int paramCount,
 		return false;
 	}
 
-	log_debug("%s;", sql);
+	log_trace("%s;", sql);
 
 	if (paramCount > 0)
 	{
@@ -400,7 +400,7 @@ pgsql_execute_with_params(PGSQL *pgsql, const char *sql, int paramCount,
 			remainingBytes -= bytesWritten;
 			writePointer += bytesWritten;
 		}
-		log_debug("%s", debugParameters);
+		log_trace("%s", debugParameters);
 	}
 
 	result = PQexecParams(connection, sql,

--- a/src/bin/pg_autoctl/pgsql.h
+++ b/src/bin/pg_autoctl/pgsql.h
@@ -174,6 +174,7 @@ int make_conninfo_field_int(char *destination, const char *key, int value);
 bool validate_connection_string(const char *connectionString);
 
 bool pgsql_get_postgres_metadata(PGSQL *pgsql, const char *slotName,
+								 char *config_file, char *hba_file,
 								 bool *pg_is_in_recovery,
 								 char *pgsrSyncState, char *currentLSN);
 

--- a/src/bin/pg_autoctl/primary_standby.c
+++ b/src/bin/pg_autoctl/primary_standby.c
@@ -296,7 +296,6 @@ primary_disable_synchronous_replication(LocalPostgresServer *postgres)
 bool
 postgres_add_default_settings(LocalPostgresServer *postgres)
 {
-	PGSQL *pgsql = &(postgres->sqlClient);
 	PostgresSetup *pgSetup = &(postgres->postgresSetup);
 	GUC *default_settings = postgres_default_settings;
 
@@ -369,7 +368,8 @@ primary_create_user_with_hba(LocalPostgresServer *postgres, char *userName,
  * to connect for replication.
  */
 bool
-primary_create_replication_user(LocalPostgresServer *postgres, char *replicationUsername,
+primary_create_replication_user(LocalPostgresServer *postgres,
+								char *replicationUsername,
 								char *replicationPassword)
 {
 	bool result = false;
@@ -522,7 +522,6 @@ bool
 primary_rewind_to_standby(LocalPostgresServer *postgres,
 						  ReplicationSource *replicationSource)
 {
-	PGSQL *pgsql = &(postgres->sqlClient);
 	PostgresSetup *pgSetup = &(postgres->postgresSetup);
 	NodeAddress *primaryNode = &(replicationSource->primaryNode);
 

--- a/src/bin/pg_autoctl/state.c
+++ b/src/bin/pg_autoctl/state.c
@@ -110,7 +110,7 @@ keeper_state_write(KeeperStateData *keeperState, const char *filename)
 		return false;
 	}
 
-	log_debug("Writing current state to \"%s\"", tempFileName);
+	log_trace("Writing current state to \"%s\"", tempFileName);
 
 	/*
 	 * Comment kept as is from PostgreSQL source code, function
@@ -155,7 +155,7 @@ keeper_state_write(KeeperStateData *keeperState, const char *filename)
 
 	close(fd);
 
-	log_debug("rename \"%s\" to \"%s\"", tempFileName, filename);
+	log_trace("rename \"%s\" to \"%s\"", tempFileName, filename);
 
 	/* now remove the old state file, and replace it with the new one */
 	if (rename(tempFileName, filename) != 0)

--- a/tests/test_basic_operation.py
+++ b/tests/test_basic_operation.py
@@ -115,8 +115,8 @@ def test_015_multiple_manual_failover_verify_replication_slot_removed():
     print()
     print("Calling pgautofailover.failover() on the monitor")
     monitor.failover()
-    assert node3.wait_until_state(target_state="primary")
     assert node2.wait_until_state(target_state="secondary")
+    assert node3.wait_until_state(target_state="primary")
     node2_replication_slots = node2.run_sql_query(count_repl_slots)
     assert node2_replication_slots == [(0,)]
     node3_replication_slots = node3.run_sql_query(count_repl_slots)


### PR DESCRIPTION
When introducting support for Postgres 12 we also introduced a bug when
installing the standby.signal file expects a running Postgres to get the
file path for the HBA setup... at a time where it's required that Postgres
is not running.

The fix consists of caching the file path locations of postgresql.conf and
pg_hba.conf. Those are not expected to ever change, and we still invalidate
the cache at each keeper loop, to be sure (see pg_createcluster in debian
packaging tools: it could still happen).