### PR TITLE
Remove unnecessary warning message from the log

### DIFF
--- a/src/bin/pg_autoctl/keeper.c
+++ b/src/bin/pg_autoctl/keeper.c
@@ -590,7 +590,6 @@ keeper_get_replication_state(Keeper *keeper)
 				postgres->currentLSN,
 				PG_LSN_MAXLENGTH,
 				missingStateOk);
-		log_warn("latest received lsn = %s", postgres->currentLSN);
 	}
 	else
 	{


### PR DESCRIPTION
This message was causing too much noise in the log without
providing any benefit