### PR TITLE
Fix creating a secondary server in an already existing directory.

### DIFF
--- a/docs/ref/configuration.rst
+++ b/docs/ref/configuration.rst
@@ -116,7 +116,7 @@ An example configuration file looks like the following::
   monitor = postgres://autoctl_node@192.168.1.34:6000/pg_auto_failover
   formation = default
   group = 0
-  nodename = node1.db.local.tld
+  nodename = node1.db
   nodekind = standalone
   
   [postgresql]
@@ -129,7 +129,7 @@ An example configuration file looks like the following::
   [replication]
   slot = pgautofailover_standby
   maximum_backup_rate = 100M
-  backup_directory = /data/backup/node1.db.local.tld
+  backup_directory = /data/backup/node1.db
   
   [timeout]
   network_partition_timeout = 20

--- a/docs/ref/configuration.rst
+++ b/docs/ref/configuration.rst
@@ -129,6 +129,7 @@ An example configuration file looks like the following::
   [replication]
   slot = pgautofailover_standby
   maximum_backup_rate = 100M
+  backup_directory = /data/backup/node1.db.local.tld
   
   [timeout]
   network_partition_timeout = 20
@@ -177,6 +178,18 @@ in PostgreSQL.
 When pg_auto_failover (re-)builds a standby node using the ``pg_basebackup``
 command, this parameter is given to ``pg_basebackup`` to throttle the
 network bandwidth used. Defaults to 100Mbps.
+
+**replication.backup_directory**
+
+When pg_auto_failover (re-)builds a standby node using the ``pg_basebackup``
+command, this parameter is the target directory where to copy the bits from
+the primary server. When the copy has been successful, then the directory is
+renamed to **postgresql.pgdata**.
+
+The default value is computed from ``${PGDATA}/../backup/${nodename}`` and
+can be set to any value of your preference. Remember that the directory
+renaming is an atomic operation only when both the source and the target of
+the copy are in the same filesystem, at least in Unix systems.
 
 **timeout**
 

--- a/docs/ref/reference.rst
+++ b/docs/ref/reference.rst
@@ -360,7 +360,7 @@ When initializing a pg_auto_failover keeper with ``--pgdata /data/pgsql``, then:
       monitor = postgres://autoctl_node@192.168.1.34:6000/pg_auto_failover
       formation = default
       group = 1
-      nodename = node1.db.local.tld
+      nodename = node1.db
 
       [postgresql]
       pgdata = /data/pgsql/

--- a/src/bin/pg_autoctl/cli_do_misc.c
+++ b/src/bin/pg_autoctl/cli_do_misc.c
@@ -329,6 +329,7 @@ keeper_cli_init_standby(int argc, char **argv)
 	replicationSource.password = config.replication_password;
 	replicationSource.slotName = config.replication_slot_name;
 	replicationSource.maximumBackupRate = MAXIMUM_BACKUP_RATE;
+	replicationSource.backupDir = config.backupDirectory;
 
 	if (!standby_init_database(&postgres, &replicationSource))
 	{

--- a/src/bin/pg_autoctl/fsm_transition.c
+++ b/src/bin/pg_autoctl/fsm_transition.c
@@ -421,6 +421,7 @@ fsm_init_standby(Keeper *keeper)
 	replicationSource.password = config->replication_password;
 	replicationSource.slotName = config->replication_slot_name;
 	replicationSource.maximumBackupRate = config->maximum_backup_rate;
+	replicationSource.backupDir = config->backupDirectory;
 
 	if (!standby_init_database(postgres, &replicationSource))
 	{
@@ -458,6 +459,7 @@ fsm_rewind_or_init(Keeper *keeper)
 	replicationSource.password = config->replication_password;
 	replicationSource.slotName = config->replication_slot_name;
 	replicationSource.maximumBackupRate = config->maximum_backup_rate;
+	replicationSource.backupDir = config->backupDirectory;
 
 	if (!primary_rewind_to_standby(postgres, &replicationSource))
 	{

--- a/src/bin/pg_autoctl/keeper_config.h
+++ b/src/bin/pg_autoctl/keeper_config.h
@@ -37,6 +37,7 @@ typedef struct KeeperConfig
 	char *replication_slot_name;
 	char *replication_password;
 	char *maximum_backup_rate;
+	char backupDirectory[MAXPGPATH];
 
 	/* pg_autoctl timeouts */
 	int network_partition_timeout;

--- a/src/bin/pg_autoctl/pgctl.c
+++ b/src/bin/pg_autoctl/pgctl.c
@@ -414,6 +414,7 @@ ensure_default_settings_file_exists(const char *configFilePath,
 bool
 pg_basebackup(const char *pgdata,
 			  const char *pg_ctl,
+			  const char *backupdir,
 			  const char *maximum_backup_rate,
 			  const char *replication_username,
 			  const char *replication_password,
@@ -423,11 +424,7 @@ pg_basebackup(const char *pgdata,
 	int returnCode;
 	Program program;
 	char primary_port_str[10];
-	char backupdir[MAXPGPATH];
 	char pg_basebackup[MAXPGPATH];
-
-	/* create the temporary backup directory at $pgdata/../backup */
-	path_in_same_directory(pgdata, "backup", backupdir);
 
 	log_debug("mkdir -p \"%s\"", backupdir);
 	if (!ensure_empty_dir(backupdir, 0700))

--- a/src/bin/pg_autoctl/pgctl.h
+++ b/src/bin/pg_autoctl/pgctl.h
@@ -30,14 +30,17 @@ char * pg_ctl_version(const char *pg_ctl_path);
 bool pg_add_auto_failover_default_settings(PostgresSetup *pgSetup,
 										   char *configFilePath,
 										   GUC *settings);
-bool pg_basebackup(const char *pgdata, const char *pg_ctl,
+bool pg_basebackup(const char *pgdata,
+				   const char *pg_ctl,
+				   const char *backupdir,
 				   const char *maximum_backup_rate,
 				   const char *replication_username,
 				   const char *replication_password,
 				   const char *replication_slot_name,
 				   const char *primary_hostname, int primary_port);
 bool pg_rewind(const char *pgdata, const char *pg_ctl, const char *primaryHost,
-			   int primaryPort, const char *databaseName, const char *replicationUsername,
+			   int primaryPort, const char *databaseName,
+			   const char *replicationUsername,
 			   const char *replicationPassword);
 
 bool pg_ctl_initdb(const char *pg_ctl, const char *pgdata);

--- a/src/bin/pg_autoctl/pgsql.h
+++ b/src/bin/pg_autoctl/pgsql.h
@@ -74,6 +74,7 @@ typedef struct ReplicationSource
 	char *slotName;
 	char *password;
 	char *maximumBackupRate;
+	char *backupDir;
 } ReplicationSource;
 
 

--- a/src/bin/pg_autoctl/primary_standby.c
+++ b/src/bin/pg_autoctl/primary_standby.c
@@ -474,7 +474,7 @@ standby_init_database(LocalPostgresServer *postgres,
 	log_trace("standby_init_database");
 	log_info("Initialising PostgreSQL as a hot standby");
 
-	if (directory_exists(pgSetup->pgdata))
+	if (pg_setup_pgdata_exists(pgSetup))
 	{
 		log_info("Target directory exists: \"%s\", stopping PostgreSQL",
 				 pgSetup->pgdata);
@@ -494,6 +494,7 @@ standby_init_database(LocalPostgresServer *postgres,
 	 */
 	if (!pg_basebackup(pgSetup->pgdata,
 					   pgSetup->pg_ctl,
+					   replicationSource->backupDir,
 					   replicationSource->maximumBackupRate,
 					   replicationSource->userName,
 					   replicationSource->password,


### PR DESCRIPTION
This could have been a one-liner, but raises the question of the hard-coded
choice for the backup directory. The major reason of the target PGDATA
already existing is that it's targeting a mount-point. Then our default
choice of ${PGDATA}/../backup for the pg_basebackup target is not a good
one, because the renaming of the directory will cross file system boundaries
and not be atomic anymore.

This patch then allows to configure the backup directory. In passing, the
default value now includes the nodename, so that it's easier to run tests
environments with multiple instances on the same machine.

See #64 and #74.