### PR TITLE
Improve options and arguments parsing.

### DIFF
--- a/src/bin/lib/subcommands.c/commandline.c
+++ b/src/bin/lib/subcommands.c/commandline.c
@@ -44,6 +44,8 @@ commandline_run(CommandLine *command, int argc, char **argv)
 		return;
 	}
 
+	current_command = command;
+
 	/* Otherwise let the command parse any options that occur here. */
 	if (command->getopt != NULL)
 	{
@@ -59,7 +61,6 @@ commandline_run(CommandLine *command, int argc, char **argv)
 
 	if (command->run != NULL)
 	{
-		current_command = command;
 		return command->run(argc, argv);
 	}
 	else if (argc == 0)

--- a/src/bin/pg_autoctl/cli_common.c
+++ b/src/bin/pg_autoctl/cli_common.c
@@ -275,6 +275,16 @@ keeper_cli_getopt_pgdata(int argc, char **argv)
 	};
 	optind = 0;
 
+	/*
+	 * The only command lines that are using keeper_cli_getopt_pgdata are
+	 * terminal ones: they don't accept subcommands. In that case our option
+	 * parsing can happen in any order and we don't need getopt_long to behave
+	 * in a POSIXLY_CORRECT way.
+	 *
+	 * The unsetenv() call allows getopt_long() to reorder arguments for us.
+	 */
+	unsetenv("POSIXLY_CORRECT");
+
 	while ((c = getopt_long(argc, argv, "D:",
 							long_options, &option_index)) != -1)
 	{

--- a/src/bin/pg_autoctl/cli_common.c
+++ b/src/bin/pg_autoctl/cli_common.c
@@ -11,6 +11,8 @@
 #include <inttypes.h>
 #include <getopt.h>
 
+#include "commandline.h"
+
 #include "cli_common.h"
 #include "cli_root.h"
 #include "commandline.h"
@@ -36,19 +38,22 @@ bool allowRemovingPgdata = false;
  *	static struct option long_options[] = {
  *		{ "pgctl", required_argument, NULL, 'C' },
  *		{ "pgdata", required_argument, NULL, 'D' },
- *		{ "pghost", required_argument, NULL, 'h' },
+ *		{ "pghost", required_argument, NULL, 'H' },
  *		{ "pgport", required_argument, NULL, 'p' },
  *		{ "listen", required_argument, NULL, 'l' },
  *		{ "proxyport", required_argument, NULL, 'y' },
  *		{ "username", required_argument, NULL, 'U' },
-		{ "auth", required_argument, NULL, 'A' },
+ *		{ "auth", required_argument, NULL, 'A' },
  *		{ "dbname", required_argument, NULL, 'd' },
  *		{ "nodename", required_argument, NULL, 'n' },
  *		{ "formation", required_argument, NULL, 'f' },
  *		{ "group", required_argument, NULL, 'g' },
  *		{ "monitor", required_argument, NULL, 'm' },
  *		{ "allow-removing-pgdata", no_argument, NULL, 'R' },
- *		{ "help", no_argument, NULL, 0 },
+ *		{ "version", no_argument, NULL, 'V' },
+ *		{ "verbose", no_argument, NULL, 'v' },
+ *		{ "quiet", no_argument, NULL, 'q' },
+ *		{ "help", no_argument, NULL, 'h' },
  *		{ NULL, 0, NULL, 0 }
  *	};
  *
@@ -100,7 +105,7 @@ cli_create_node_getopts(int argc, char **argv,
 				break;
 			}
 
-			case 'h':
+			case 'H':
 			{
 				/* { "pghost", required_argument, NULL, 'h' } */
 				strlcpy(LocalOptionConfig.pgSetup.pghost, optarg, _POSIX_HOST_NAME_MAX);
@@ -252,6 +257,13 @@ cli_create_node_getopts(int argc, char **argv,
 				break;
 			}
 
+			case 'h':
+			{
+				commandline_help(stderr);
+				exit(EXIT_CODE_QUIT);
+				break;
+			}
+
 			default:
 			{
 				/* getopt_long already wrote an error message */
@@ -309,6 +321,7 @@ keeper_cli_getopt_pgdata(int argc, char **argv)
 		{ "version", no_argument, NULL, 'V' },
 		{ "verbose", no_argument, NULL, 'v' },
 		{ "quiet", no_argument, NULL, 'q' },
+		{ "help", no_argument, NULL, 'h' },
 		{ NULL, 0, NULL, 0 }
 	};
 	optind = 0;
@@ -323,7 +336,7 @@ keeper_cli_getopt_pgdata(int argc, char **argv)
 	 */
 	unsetenv("POSIXLY_CORRECT");
 
-	while ((c = getopt_long(argc, argv, "D:Vvq",
+	while ((c = getopt_long(argc, argv, "D:Vvqh",
 							long_options, &option_index)) != -1)
 	{
 		switch (c)
@@ -365,6 +378,13 @@ keeper_cli_getopt_pgdata(int argc, char **argv)
 			case 'q':
 			{
 				log_set_level(LOG_ERROR);
+				break;
+			}
+
+			case 'h':
+			{
+				commandline_help(stderr);
+				exit(EXIT_CODE_QUIT);
 				break;
 			}
 

--- a/src/bin/pg_autoctl/cli_common.h
+++ b/src/bin/pg_autoctl/cli_common.h
@@ -89,6 +89,9 @@ extern CommandLine show_state_command;
 extern CommandLine systemd_cat_service_file_command;
 
 
+void keeper_cli_help(int argc, char **argv);
+void keeper_cli_print_version(int argc, char **argv);
+
 int cli_create_node_getopts(int argc, char **argv,
 							struct option *long_options,
 							const char *optstring,
@@ -104,7 +107,5 @@ void exit_unless_role_is_keeper(KeeperConfig *kconfig);
 bool cli_create_config(Keeper *keeper, KeeperConfig *config);
 void cli_create_pg(Keeper *keeper, KeeperConfig *config);
 bool check_or_discover_nodename(KeeperConfig *config);
-
-
 
 #endif  /* CLI_COMMON_H */

--- a/src/bin/pg_autoctl/cli_create_drop_node.c
+++ b/src/bin/pg_autoctl/cli_create_drop_node.c
@@ -212,7 +212,7 @@ cli_create_postgres_getopts(int argc, char **argv)
 
 	int optind =
 		cli_create_node_getopts(argc, argv,
-								long_options, "C:D:h:p:l:U:A:d:n:f:m:RVvqh",
+								long_options, "C:D:H:p:l:U:A:d:n:f:m:RVvqh",
 								&options);
 
 	/* publish our option parsing in the global variable */

--- a/src/bin/pg_autoctl/cli_create_drop_node.c
+++ b/src/bin/pg_autoctl/cli_create_drop_node.c
@@ -193,7 +193,7 @@ cli_create_postgres_getopts(int argc, char **argv)
 	static struct option long_options[] = {
 		{ "pgctl", required_argument, NULL, 'C' },
 		{ "pgdata", required_argument, NULL, 'D' },
-		{ "pghost", required_argument, NULL, 'h' },
+		{ "pghost", required_argument, NULL, 'H' },
 		{ "pgport", required_argument, NULL, 'p' },
 		{ "listen", required_argument, NULL, 'l' },
 		{ "username", required_argument, NULL, 'U' },
@@ -206,12 +206,13 @@ cli_create_postgres_getopts(int argc, char **argv)
 		{ "version", no_argument, NULL, 'V' },
 		{ "verbose", no_argument, NULL, 'v' },
 		{ "quiet", no_argument, NULL, 'q' },
+ 		{ "help", no_argument, NULL, 'h' },
 		{ NULL, 0, NULL, 0 }
 	};
 
 	int optind =
 		cli_create_node_getopts(argc, argv,
-								long_options, "C:D:h:p:l:U:A:d:n:f:m:RVvq",
+								long_options, "C:D:h:p:l:U:A:d:n:f:m:RVvqh",
 								&options);
 
 	/* publish our option parsing in the global variable */
@@ -272,6 +273,7 @@ cli_create_monitor_getopts(int argc, char **argv)
 		{ "version", no_argument, NULL, 'V' },
 		{ "verbose", no_argument, NULL, 'v' },
 		{ "quiet", no_argument, NULL, 'q' },
+ 		{ "help", no_argument, NULL, 'h' },
 		{ NULL, 0, NULL, 0 }
 	};
 
@@ -280,7 +282,7 @@ cli_create_monitor_getopts(int argc, char **argv)
 
 	optind = 0;
 
-	while ((c = getopt_long(argc, argv, "C:D:p:A:Vvq",
+	while ((c = getopt_long(argc, argv, "C:D:p:A:Vvqh",
 							long_options, &option_index)) != -1)
 	{
 		switch (c)
@@ -363,6 +365,13 @@ cli_create_monitor_getopts(int argc, char **argv)
 			case 'q':
 			{
 				log_set_level(LOG_ERROR);
+				break;
+			}
+
+			case 'h':
+			{
+				commandline_help(stderr);
+				exit(EXIT_CODE_QUIT);
 				break;
 			}
 

--- a/src/bin/pg_autoctl/cli_create_drop_node.c
+++ b/src/bin/pg_autoctl/cli_create_drop_node.c
@@ -203,13 +203,15 @@ cli_create_postgres_getopts(int argc, char **argv)
 		{ "formation", required_argument, NULL, 'f' },
 		{ "monitor", required_argument, NULL, 'm' },
 		{ "allow-removing-pgdata", no_argument, NULL, 'R' },
-		{ "help", no_argument, NULL, 0 },
+		{ "version", no_argument, NULL, 'V' },
+		{ "verbose", no_argument, NULL, 'v' },
+		{ "quiet", no_argument, NULL, 'q' },
 		{ NULL, 0, NULL, 0 }
 	};
 
 	int optind =
 		cli_create_node_getopts(argc, argv,
-								long_options, "C:D:h:p:l:U:A:d:n:f:m:R",
+								long_options, "C:D:h:p:l:U:A:d:n:f:m:RVvq",
 								&options);
 
 	/* publish our option parsing in the global variable */
@@ -258,6 +260,7 @@ cli_create_monitor_getopts(int argc, char **argv)
 {
 	MonitorConfig options = { 0 };
 	int c, option_index, errors = 0;
+	int verboseCount = 0;
 
 	static struct option long_options[] = {
 		{ "pgctl", required_argument, NULL, 'C' },
@@ -266,7 +269,9 @@ cli_create_monitor_getopts(int argc, char **argv)
 		{ "nodename", required_argument, NULL, 'n' },
 		{ "listen", required_argument, NULL, 'l' },
 		{ "auth", required_argument, NULL, 'A' },
-		{ "help", no_argument, NULL, 0 },
+		{ "version", no_argument, NULL, 'V' },
+		{ "verbose", no_argument, NULL, 'v' },
+		{ "quiet", no_argument, NULL, 'q' },
 		{ NULL, 0, NULL, 0 }
 	};
 
@@ -275,7 +280,7 @@ cli_create_monitor_getopts(int argc, char **argv)
 
 	optind = 0;
 
-	while ((c = getopt_long(argc, argv, "C:D:p:A:",
+	while ((c = getopt_long(argc, argv, "C:D:p:A:Vvq",
 							long_options, &option_index)) != -1)
 	{
 		switch (c)
@@ -327,6 +332,40 @@ cli_create_monitor_getopts(int argc, char **argv)
 				log_trace("--auth %s", options.pgSetup.authMethod);
 				break;
 			}
+
+			case 'V':
+			{
+				/* keeper_cli_print_version prints version and exits. */
+				keeper_cli_print_version(argc, argv);
+				break;
+			}
+
+			case 'v':
+			{
+				++verboseCount;
+				switch (verboseCount)
+				{
+					case 1:
+						log_set_level(LOG_INFO);
+						break;
+
+					case 2:
+						log_set_level(LOG_DEBUG);
+						break;
+
+					default:
+						log_set_level(LOG_TRACE);
+						break;
+				}
+				break;
+			}
+
+			case 'q':
+			{
+				log_set_level(LOG_ERROR);
+				break;
+			}
+
 			default:
 			{
 				/* getopt_long already wrote an error message */
@@ -334,6 +373,12 @@ cli_create_monitor_getopts(int argc, char **argv)
 				break;
 			}
 		}
+	}
+
+	if (errors > 0)
+	{
+		commandline_help(stderr);
+		exit(EXIT_CODE_BAD_ARGS);
 	}
 
 	/*

--- a/src/bin/pg_autoctl/cli_do_root.c
+++ b/src/bin/pg_autoctl/cli_do_root.c
@@ -244,7 +244,9 @@ keeper_cli_keeper_setup_getopts(int argc, char **argv)
 		{ "group", required_argument, NULL, 'g' },
 		{ "monitor", required_argument, NULL, 'm' },
 		{ "allow-removing-pgdata", no_argument, NULL, 'R' },
-		{ "help", no_argument, NULL, 0 },
+		{ "version", no_argument, NULL, 'V' },
+		{ "verbose", no_argument, NULL, 'v' },
+		{ "quiet", no_argument, NULL, 'q' },
 		{ NULL, 0, NULL, 0 }
 	};
 
@@ -260,7 +262,7 @@ keeper_cli_keeper_setup_getopts(int argc, char **argv)
 
 	int optind =
 		cli_create_node_getopts(argc, argv,
-								long_options, "C:D:h:p:l:y:U:A:d:n:f:g:m:R",
+								long_options, "C:D:h:p:l:y:U:A:d:n:f:g:m:RVvq",
 								&options);
 
 	/* publish our option parsing in the global variable */

--- a/src/bin/pg_autoctl/cli_do_root.c
+++ b/src/bin/pg_autoctl/cli_do_root.c
@@ -248,6 +248,16 @@ keeper_cli_keeper_setup_getopts(int argc, char **argv)
 		{ NULL, 0, NULL, 0 }
 	};
 
+	/*
+	 * The only command lines that are using keeper_cli_getopt_pgdata are
+	 * terminal ones: they don't accept subcommands. In that case our option
+	 * parsing can happen in any order and we don't need getopt_long to behave
+	 * in a POSIXLY_CORRECT way.
+	 *
+	 * The unsetenv() call allows getopt_long() to reorder arguments for us.
+	 */
+	unsetenv("POSIXLY_CORRECT");
+
 	int optind =
 		cli_create_node_getopts(argc, argv,
 								long_options, "C:D:h:p:l:y:U:A:d:n:f:g:m:R",

--- a/src/bin/pg_autoctl/cli_do_root.c
+++ b/src/bin/pg_autoctl/cli_do_root.c
@@ -232,7 +232,7 @@ keeper_cli_keeper_setup_getopts(int argc, char **argv)
 	static struct option long_options[] = {
 		{ "pgctl", required_argument, NULL, 'C' },
 		{ "pgdata", required_argument, NULL, 'D' },
-		{ "pghost", required_argument, NULL, 'h' },
+		{ "pghost", required_argument, NULL, 'H' },
 		{ "pgport", required_argument, NULL, 'p' },
 		{ "listen", required_argument, NULL, 'l' },
 		{ "proxyport", required_argument, NULL, 'y' },
@@ -247,6 +247,7 @@ keeper_cli_keeper_setup_getopts(int argc, char **argv)
 		{ "version", no_argument, NULL, 'V' },
 		{ "verbose", no_argument, NULL, 'v' },
 		{ "quiet", no_argument, NULL, 'q' },
+		{ "help", no_argument, NULL, 'h' },
 		{ NULL, 0, NULL, 0 }
 	};
 
@@ -262,7 +263,7 @@ keeper_cli_keeper_setup_getopts(int argc, char **argv)
 
 	int optind =
 		cli_create_node_getopts(argc, argv,
-								long_options, "C:D:h:p:l:y:U:A:d:n:f:g:m:RVvq",
+								long_options, "C:D:h:p:l:y:U:A:d:n:f:g:m:RVvqh",
 								&options);
 
 	/* publish our option parsing in the global variable */

--- a/src/bin/pg_autoctl/cli_do_root.c
+++ b/src/bin/pg_autoctl/cli_do_root.c
@@ -263,7 +263,7 @@ keeper_cli_keeper_setup_getopts(int argc, char **argv)
 
 	int optind =
 		cli_create_node_getopts(argc, argv,
-								long_options, "C:D:h:p:l:y:U:A:d:n:f:g:m:RVvqh",
+								long_options, "C:D:H:p:l:y:U:A:d:n:f:g:m:RVvqh",
 								&options);
 
 	/* publish our option parsing in the global variable */

--- a/src/bin/pg_autoctl/cli_enable_disable.c
+++ b/src/bin/pg_autoctl/cli_enable_disable.c
@@ -105,12 +105,13 @@ cli_secondary_getopts(int argc, char **argv)
 		{ "version", no_argument, NULL, 'V' },
 		{ "verbose", no_argument, NULL, 'v' },
 		{ "quiet", no_argument, NULL, 'q' },
+		{ "help", no_argument, NULL, 'h' },
 		{ NULL, 0, NULL, 0 }
 	};
 
 	optind = 0;
 
-	while ((c = getopt_long(argc, argv, "D:f:Vvq",
+	while ((c = getopt_long(argc, argv, "D:f:Vvqh",
 							long_options, &option_index)) != -1)
 	{
 		switch (c)
@@ -159,6 +160,13 @@ cli_secondary_getopts(int argc, char **argv)
 			case 'q':
 			{
 				log_set_level(LOG_ERROR);
+				break;
+			}
+
+			case 'h':
+			{
+				commandline_help(stderr);
+				exit(EXIT_CODE_QUIT);
 				break;
 			}
 

--- a/src/bin/pg_autoctl/cli_enable_disable.c
+++ b/src/bin/pg_autoctl/cli_enable_disable.c
@@ -87,27 +87,30 @@ CommandLine disable_commands =
 
 
 /*
- * cli_secondary_getopts parses command line options for the secondary feature, both
- * during enable and disable. Little verification is performed however the function will
- * error when no --pgdata or --formation are provided, existance of either are not
- * verified.
+ * cli_secondary_getopts parses command line options for the secondary feature,
+ * both during enable and disable. Little verification is performed however the
+ * function will error when no --pgdata or --formation are provided, existance
+ * of either are not verified.
  */
 static int
 cli_secondary_getopts(int argc, char **argv)
 {
 	KeeperConfig options = { 0 };
 	int c, option_index, errors = 0;
+	int verboseCount = 0;
 
 	static struct option long_options[] = {
-			{ "pgdata", required_argument, NULL, 'D' },
-			{ "formation", required_argument, NULL, 'f' },
-			{ "help", no_argument, NULL, 0 },
-			{ NULL, 0, NULL, 0 }
+		{ "pgdata", required_argument, NULL, 'D' },
+		{ "formation", required_argument, NULL, 'f' },
+		{ "version", no_argument, NULL, 'V' },
+		{ "verbose", no_argument, NULL, 'v' },
+		{ "quiet", no_argument, NULL, 'q' },
+		{ NULL, 0, NULL, 0 }
 	};
 
 	optind = 0;
 
-	while ((c = getopt_long(argc, argv, "D:f:",
+	while ((c = getopt_long(argc, argv, "D:f:Vvq",
 							long_options, &option_index)) != -1)
 	{
 		switch (c)
@@ -126,6 +129,39 @@ cli_secondary_getopts(int argc, char **argv)
 				break;
 			}
 
+			case 'V':
+			{
+				/* keeper_cli_print_version prints version and exits. */
+				keeper_cli_print_version(argc, argv);
+				break;
+			}
+
+			case 'v':
+			{
+				++verboseCount;
+				switch (verboseCount)
+				{
+					case 1:
+						log_set_level(LOG_INFO);
+						break;
+
+					case 2:
+						log_set_level(LOG_DEBUG);
+						break;
+
+					default:
+						log_set_level(LOG_TRACE);
+						break;
+				}
+				break;
+			}
+
+			case 'q':
+			{
+				log_set_level(LOG_ERROR);
+				break;
+			}
+
 			default:
 			{
 				/* getopt_long already wrote an error message */
@@ -133,6 +169,12 @@ cli_secondary_getopts(int argc, char **argv)
 				break;
 			}
 		}
+	}
+
+	if (errors > 0)
+	{
+		commandline_help(stderr);
+		exit(EXIT_CODE_BAD_ARGS);
 	}
 
 	if (IS_EMPTY_STRING_BUFFER(options.pgSetup.pgdata))

--- a/src/bin/pg_autoctl/cli_formation.c
+++ b/src/bin/pg_autoctl/cli_formation.c
@@ -61,11 +61,14 @@ keeper_cli_formation_getopts(int argc, char **argv)
 {
 	FormationConfig options = { 0 };
 	int c = 0, option_index = 0, errors = 0;
+	int verboseCount = 0;
 
 	static struct option long_options[] = {
 		{ "pgdata", required_argument, NULL, 'D' },
 		{ "formation", required_argument, NULL, 'f' },
-		{ "help", no_argument, NULL, 'h' },
+		{ "version", no_argument, NULL, 'V' },
+		{ "verbose", no_argument, NULL, 'v' },
+		{ "quiet", no_argument, NULL, 'q' },
 		{ NULL, 0, NULL, 0 }
 	};
 
@@ -90,6 +93,39 @@ keeper_cli_formation_getopts(int argc, char **argv)
 				break;
 			}
 
+			case 'V':
+			{
+				/* keeper_cli_print_version prints version and exits. */
+				keeper_cli_print_version(argc, argv);
+				break;
+			}
+
+			case 'v':
+			{
+				++verboseCount;
+				switch (verboseCount)
+				{
+					case 1:
+						log_set_level(LOG_INFO);
+						break;
+
+					case 2:
+						log_set_level(LOG_DEBUG);
+						break;
+
+					default:
+						log_set_level(LOG_TRACE);
+						break;
+				}
+				break;
+			}
+
+			case 'q':
+			{
+				log_set_level(LOG_ERROR);
+				break;
+			}
+
 			default:
 			{
 				/* getopt_long already wrote an error message */
@@ -97,6 +133,12 @@ keeper_cli_formation_getopts(int argc, char **argv)
 				break;
 			}
 		}
+	}
+
+	if (errors > 0)
+	{
+		commandline_help(stderr);
+		exit(EXIT_CODE_BAD_ARGS);
 	}
 
 	if (IS_EMPTY_STRING_BUFFER(options.pgSetup.pgdata))

--- a/src/bin/pg_autoctl/cli_formation.c
+++ b/src/bin/pg_autoctl/cli_formation.c
@@ -69,12 +69,13 @@ keeper_cli_formation_getopts(int argc, char **argv)
 		{ "version", no_argument, NULL, 'V' },
 		{ "verbose", no_argument, NULL, 'v' },
 		{ "quiet", no_argument, NULL, 'q' },
+		{ "help", no_argument, NULL, 'h' },
 		{ NULL, 0, NULL, 0 }
 	};
 
 	optind = 0;
 
-	while ((c = getopt_long(argc, argv, "D:f:h",
+	while ((c = getopt_long(argc, argv, "D:f:Vvqh",
 							long_options, &option_index)) != -1)
 	{
 		switch (c)
@@ -123,6 +124,13 @@ keeper_cli_formation_getopts(int argc, char **argv)
 			case 'q':
 			{
 				log_set_level(LOG_ERROR);
+				break;
+			}
+
+			case 'h':
+			{
+				commandline_help(stderr);
+				exit(EXIT_CODE_QUIT);
 				break;
 			}
 
@@ -178,6 +186,7 @@ keeper_cli_formation_create_getopts(int argc, char **argv)
 	FormationConfig options = { 0 };
 
 	int c = 0, option_index = 0, errors = 0;
+	int verboseCount = 0;
 
 	static struct option long_options[] = {
 		{ "pgdata", required_argument, NULL, 'D' },
@@ -186,6 +195,9 @@ keeper_cli_formation_create_getopts(int argc, char **argv)
 		{ "dbname", required_argument, NULL, 'd' },
 		{ "enable-secondary", no_argument, NULL, 's' },
 		{ "disable-secondary", no_argument, NULL, 'S' },
+		{ "version", no_argument, NULL, 'V' },
+		{ "verbose", no_argument, NULL, 'v' },
+		{ "quiet", no_argument, NULL, 'q' },
 		{ "help", no_argument, NULL, 'h' },
 		{ NULL, 0, NULL, 0 }
 	};
@@ -195,7 +207,7 @@ keeper_cli_formation_create_getopts(int argc, char **argv)
 	/* set defaults for formations */
 	options.formationHasSecondary = true;
 
-	while ((c = getopt_long(argc, argv, "D:f:k:sSh",
+	while ((c = getopt_long(argc, argv, "D:f:k:sSVvqh",
 							long_options, &option_index)) != -1)
 	{
 		switch (c)
@@ -239,6 +251,46 @@ keeper_cli_formation_create_getopts(int argc, char **argv)
 			{
 				options.formationHasSecondary = false;
 				log_trace("--disable-secondary");
+				break;
+			}
+
+			case 'V':
+			{
+				/* keeper_cli_print_version prints version and exits. */
+				keeper_cli_print_version(argc, argv);
+				break;
+			}
+
+			case 'v':
+			{
+				++verboseCount;
+				switch (verboseCount)
+				{
+					case 1:
+						log_set_level(LOG_INFO);
+						break;
+
+					case 2:
+						log_set_level(LOG_DEBUG);
+						break;
+
+					default:
+						log_set_level(LOG_TRACE);
+						break;
+				}
+				break;
+			}
+
+			case 'q':
+			{
+				log_set_level(LOG_ERROR);
+				break;
+			}
+
+			case 'h':
+			{
+				commandline_help(stderr);
+				exit(EXIT_CODE_QUIT);
 				break;
 			}
 

--- a/src/bin/pg_autoctl/cli_root.c
+++ b/src/bin/pg_autoctl/cli_root.c
@@ -179,32 +179,3 @@ root_options(int argc, char **argv)
 	}
 	return optind;
 }
-
-
-/*
- * Provide help.
- */
-void
-keeper_cli_help(int argc, char **argv)
-{
-	CommandLine command = root;
-
-	if (getenv(PG_AUTOCTL_DEBUG) != NULL)
-	{
-		command = root_with_debug;
-	}
-
-	(void) commandline_print_command_tree(&command, stdout);
-}
-
-
-/*
- * keeper_cli_print_version prints the pg_autoctl version and exits with
- * successful exit code of zero.
- */
-void
-keeper_cli_print_version(int argc, char **argv)
-{
-	fprintf(stdout, "pg_autoctl version %s\n", PG_AUTOCTL_VERSION);
-	exit(0);
-}

--- a/src/bin/pg_autoctl/cli_root.c
+++ b/src/bin/pg_autoctl/cli_root.c
@@ -118,14 +118,15 @@ root_options(int argc, char **argv)
 		{ "version", no_argument, NULL, 'V' },
 		{ "verbose", no_argument, NULL, 'v' },
 		{ "quiet", no_argument, NULL, 'q' },
-		{ NULL, 0, NULL, 0 }
+		{ "help", no_argument, NULL, 'h' },
+	{ NULL, 0, NULL, 0 }
 	};
 
 	int c, option_index, errors = 0;
 
 	optind = 0;
 
-	while ((c = getopt_long(argc, argv, "Vvq",
+	while ((c = getopt_long(argc, argv, "Vvqh",
 							long_options, &option_index)) != -1)
 	{
 		switch (c)
@@ -160,6 +161,13 @@ root_options(int argc, char **argv)
 			case 'q':
 			{
 				log_set_level(LOG_ERROR);
+				break;
+			}
+
+			case 'h':
+			{
+				commandline_help(stderr);
+				exit(EXIT_CODE_QUIT);
 				break;
 			}
 

--- a/src/bin/pg_autoctl/cli_root.h
+++ b/src/bin/pg_autoctl/cli_root.h
@@ -33,8 +33,6 @@ extern CommandLine *root_subcommands_with_debug[];
 extern CommandLine root;
 extern CommandLine *root_subcommands[];
 
-void keeper_cli_help(int argc, char **argv);
-void keeper_cli_print_version(int argc, char **argv);
 int root_options(int argc, char **argv);
 
 

--- a/src/bin/pg_autoctl/cli_service.c
+++ b/src/bin/pg_autoctl/cli_service.c
@@ -272,11 +272,15 @@ cli_getopt_pgdata_and_mode(int argc, char **argv)
 {
 	KeeperConfig options = { 0 };
 	int c, option_index = 0;
+	int verboseCount = 0;
 
 	static struct option long_options[] = {
 		{ "pgdata", required_argument, NULL, 'D' },
 		{ "fast", no_argument, NULL, 'f' },
 		{ "immediate", no_argument, NULL, 'i' },
+		{ "version", no_argument, NULL, 'V' },
+		{ "verbose", no_argument, NULL, 'v' },
+		{ "quiet", no_argument, NULL, 'q' },
 		{ NULL, 0, NULL, 0 }
 	};
 
@@ -315,6 +319,39 @@ cli_getopt_pgdata_and_mode(int argc, char **argv)
 					exit(EXIT_CODE_BAD_ARGS);
 				}
 				stop_signal = SIGQUIT;
+				break;
+			}
+
+			case 'V':
+			{
+				/* keeper_cli_print_version prints version and exits. */
+				keeper_cli_print_version(argc, argv);
+				break;
+			}
+
+			case 'v':
+			{
+				++verboseCount;
+				switch (verboseCount)
+				{
+					case 1:
+						log_set_level(LOG_INFO);
+						break;
+
+					case 2:
+						log_set_level(LOG_DEBUG);
+						break;
+
+					default:
+						log_set_level(LOG_TRACE);
+						break;
+				}
+				break;
+			}
+
+			case 'q':
+			{
+				log_set_level(LOG_ERROR);
 				break;
 			}
 

--- a/src/bin/pg_autoctl/cli_service.c
+++ b/src/bin/pg_autoctl/cli_service.c
@@ -281,12 +281,13 @@ cli_getopt_pgdata_and_mode(int argc, char **argv)
 		{ "version", no_argument, NULL, 'V' },
 		{ "verbose", no_argument, NULL, 'v' },
 		{ "quiet", no_argument, NULL, 'q' },
+		{ "help", no_argument, NULL, 'h' },
 		{ NULL, 0, NULL, 0 }
 	};
 
 	optind = 0;
 
-	while ((c = getopt_long(argc, argv, "D:fi",
+	while ((c = getopt_long(argc, argv, "D:fiVvqh",
 							long_options, &option_index)) != -1)
 	{
 		switch (c)
@@ -352,6 +353,13 @@ cli_getopt_pgdata_and_mode(int argc, char **argv)
 			case 'q':
 			{
 				log_set_level(LOG_ERROR);
+				break;
+			}
+
+			case 'h':
+			{
+				commandline_help(stderr);
+				exit(EXIT_CODE_QUIT);
 				break;
 			}
 

--- a/src/bin/pg_autoctl/cli_show.c
+++ b/src/bin/pg_autoctl/cli_show.c
@@ -90,6 +90,7 @@ cli_show_state_getopts(int argc, char **argv)
 		{ "version", no_argument, NULL, 'V' },
 		{ "verbose", no_argument, NULL, 'v' },
 		{ "quiet", no_argument, NULL, 'q' },
+		{ "help", no_argument, NULL, 'h' },
 		{ NULL, 0, NULL, 0 }
 	};
 
@@ -105,7 +106,7 @@ cli_show_state_getopts(int argc, char **argv)
 
 	optind = 0;
 
-	while ((c = getopt_long(argc, argv, "D:f:g:n:Vvq",
+	while ((c = getopt_long(argc, argv, "D:f:g:n:Vvqh",
 							long_options, &option_index)) != -1)
 	{
 		switch (c)
@@ -183,6 +184,12 @@ cli_show_state_getopts(int argc, char **argv)
 				break;
 			}
 
+			case 'h':
+			{
+				commandline_help(stderr);
+				exit(EXIT_CODE_QUIT);
+				break;
+			}
 
 			default:
 			{
@@ -293,6 +300,7 @@ cli_show_uri_getopts(int argc, char **argv)
 		{ "version", no_argument, NULL, 'V' },
 		{ "verbose", no_argument, NULL, 'v' },
 		{ "quiet", no_argument, NULL, 'q' },
+		{ "help", no_argument, NULL, 'h' },
 		{ NULL, 0, NULL, 0 }
 	};
 
@@ -306,7 +314,7 @@ cli_show_uri_getopts(int argc, char **argv)
 
 	optind = 0;
 
-	while ((c = getopt_long(argc, argv, "D:f:Vvq",
+	while ((c = getopt_long(argc, argv, "D:f:Vvqh",
 							long_options, &option_index)) != -1)
 	{
 		switch (c)
@@ -355,6 +363,13 @@ cli_show_uri_getopts(int argc, char **argv)
 			case 'q':
 			{
 				log_set_level(LOG_ERROR);
+				break;
+			}
+
+			case 'h':
+			{
+				commandline_help(stderr);
+				exit(EXIT_CODE_QUIT);
 				break;
 			}
 

--- a/src/bin/pg_autoctl/cli_show.c
+++ b/src/bin/pg_autoctl/cli_show.c
@@ -79,13 +79,17 @@ static int
 cli_show_state_getopts(int argc, char **argv)
 {
 	KeeperConfig options = { 0 };
-	int c, option_index = 0;
+	int c, option_index = 0, errors = 0;
+	int verboseCount = 0;
 
 	static struct option long_options[] = {
 		{ "pgdata", required_argument, NULL, 'D' },
 		{ "formation", required_argument, NULL, 'f' },
 		{ "group", required_argument, NULL, 'g' },
 		{ "count", required_argument, NULL, 'n' },
+		{ "version", no_argument, NULL, 'V' },
+		{ "verbose", no_argument, NULL, 'v' },
+		{ "quiet", no_argument, NULL, 'q' },
 		{ NULL, 0, NULL, 0 }
 	};
 
@@ -101,7 +105,7 @@ cli_show_state_getopts(int argc, char **argv)
 
 	optind = 0;
 
-	while ((c = getopt_long(argc, argv, "D:f:g:n:",
+	while ((c = getopt_long(argc, argv, "D:f:g:n:Vvq",
 							long_options, &option_index)) != -1)
 	{
 		switch (c)
@@ -145,7 +149,54 @@ cli_show_state_getopts(int argc, char **argv)
 				log_trace("--count %d", eventCount);
 				break;
 			}
+
+			case 'V':
+			{
+				/* keeper_cli_print_version prints version and exits. */
+				keeper_cli_print_version(argc, argv);
+				break;
+			}
+
+			case 'v':
+			{
+				++verboseCount;
+				switch (verboseCount)
+				{
+					case 1:
+						log_set_level(LOG_INFO);
+						break;
+
+					case 2:
+						log_set_level(LOG_DEBUG);
+						break;
+
+					default:
+						log_set_level(LOG_TRACE);
+						break;
+				}
+				break;
+			}
+
+			case 'q':
+			{
+				log_set_level(LOG_ERROR);
+				break;
+			}
+
+
+			default:
+			{
+				/* getopt_long already wrote an error message */
+				errors++;
+				break;
+			}
 		}
+	}
+
+	if (errors > 0)
+	{
+		commandline_help(stderr);
+		exit(EXIT_CODE_BAD_ARGS);
 	}
 
 	if (IS_EMPTY_STRING_BUFFER(options.pgSetup.pgdata))
@@ -234,10 +285,14 @@ cli_show_uri_getopts(int argc, char **argv)
 {
 	KeeperConfig options = { 0 };
 	int c, option_index = 0;
+	int verboseCount = 0;
 
 	static struct option long_options[] = {
 		{ "pgdata", required_argument, NULL, 'D' },
 		{ "formation", required_argument, NULL, 'f' },
+		{ "version", no_argument, NULL, 'V' },
+		{ "verbose", no_argument, NULL, 'v' },
+		{ "quiet", no_argument, NULL, 'q' },
 		{ NULL, 0, NULL, 0 }
 	};
 
@@ -251,7 +306,7 @@ cli_show_uri_getopts(int argc, char **argv)
 
 	optind = 0;
 
-	while ((c = getopt_long(argc, argv, "D:f:m",
+	while ((c = getopt_long(argc, argv, "D:f:Vvq",
 							long_options, &option_index)) != -1)
 	{
 		switch (c)
@@ -270,9 +325,43 @@ cli_show_uri_getopts(int argc, char **argv)
 				break;
 			}
 
+			case 'V':
+			{
+				/* keeper_cli_print_version prints version and exits. */
+				keeper_cli_print_version(argc, argv);
+				break;
+			}
+
+			case 'v':
+			{
+				++verboseCount;
+				switch (verboseCount)
+				{
+					case 1:
+						log_set_level(LOG_INFO);
+						break;
+
+					case 2:
+						log_set_level(LOG_DEBUG);
+						break;
+
+					default:
+						log_set_level(LOG_TRACE);
+						break;
+				}
+				break;
+			}
+
+			case 'q':
+			{
+				log_set_level(LOG_ERROR);
+				break;
+			}
+
 			default:
 			{
 				log_error("Failed to parse command line, see above for details.");
+				commandline_help(stderr);
 				exit(EXIT_CODE_BAD_ARGS);
 				break;
 			}

--- a/src/bin/pg_autoctl/cli_systemd.c
+++ b/src/bin/pg_autoctl/cli_systemd.c
@@ -56,12 +56,13 @@ cli_systemd_getopt(int argc, char **argv)
 		{ "version", no_argument, NULL, 'V' },
 		{ "verbose", no_argument, NULL, 'v' },
 		{ "quiet", no_argument, NULL, 'q' },
+		{ "help", no_argument, NULL, 'h' },
 		{ NULL, 0, NULL, 0 }
 	};
 
 	optind = 0;
 
-	while ((c = getopt_long(argc, argv, "D:Vvq",
+	while ((c = getopt_long(argc, argv, "D:Vvqh",
 							long_options, &option_index)) != -1)
 	{
 		switch (c)
@@ -103,6 +104,13 @@ cli_systemd_getopt(int argc, char **argv)
 			case 'q':
 			{
 				log_set_level(LOG_ERROR);
+				break;
+			}
+
+			case 'h':
+			{
+				commandline_help(stderr);
+				exit(EXIT_CODE_QUIT);
 				break;
 			}
 

--- a/src/bin/pg_autoctl/cli_systemd.c
+++ b/src/bin/pg_autoctl/cli_systemd.c
@@ -48,17 +48,20 @@ cli_systemd_getopt(int argc, char **argv)
 {
 	SystemdServiceConfig options = { 0 };
 
-	int c = 0, option_index = 0;
+	int c = 0, option_index = 0, errors = 0;
+	int verboseCount = 0;
 
 	static struct option long_options[] = {
 		{ "pgdata", required_argument, NULL, 'D' },
-		{ "help", no_argument, NULL, 'h' },
+		{ "version", no_argument, NULL, 'V' },
+		{ "verbose", no_argument, NULL, 'v' },
+		{ "quiet", no_argument, NULL, 'q' },
 		{ NULL, 0, NULL, 0 }
 	};
 
 	optind = 0;
 
-	while ((c = getopt_long(argc, argv, "D:h",
+	while ((c = getopt_long(argc, argv, "D:Vvq",
 							long_options, &option_index)) != -1)
 	{
 		switch (c)
@@ -70,7 +73,52 @@ cli_systemd_getopt(int argc, char **argv)
 				break;
 			}
 
+			case 'V':
+			{
+				/* keeper_cli_print_version prints version and exits. */
+				keeper_cli_print_version(argc, argv);
+				break;
+			}
+
+			case 'v':
+			{
+				++verboseCount;
+				switch (verboseCount)
+				{
+					case 1:
+						log_set_level(LOG_INFO);
+						break;
+
+					case 2:
+						log_set_level(LOG_DEBUG);
+						break;
+
+					default:
+						log_set_level(LOG_TRACE);
+						break;
+				}
+				break;
+			}
+
+			case 'q':
+			{
+				log_set_level(LOG_ERROR);
+				break;
+			}
+
+			default:
+			{
+				/* getopt_long already wrote an error message */
+				errors++;
+				break;
+			}
 		}
+	}
+
+	if (errors > 0)
+	{
+		commandline_help(stderr);
+		exit(EXIT_CODE_BAD_ARGS);
 	}
 
 	if (IS_EMPTY_STRING_BUFFER(options.pgSetup.pgdata))

--- a/src/bin/pg_autoctl/main.c
+++ b/src/bin/pg_autoctl/main.c
@@ -48,6 +48,10 @@ main(int argc, char **argv)
 	 *
 	 * GNU and modern getopt() implementation will reorder the command
 	 * arguments, making a mess of our nice subcommands facility.
+	 *
+	 * Note that we call unsetenv("POSIXLY_CORRECT"); before parsing options
+	 * for commands that are the final sub-command of their chain and when we
+	 * might mix options and arguments.
 	 */
 	setenv("POSIXLY_CORRECT", "1", 1);
 


### PR DESCRIPTION
Our nested command and sub-commands parsing is not compatible with the
default GNU getopt behavior where they will re-order the command line so
that users are free to mix options and arguments as they want.

When we are on the final sub-command though, we could re-enable the default
behavior of GNU getopt_long for more flexibility to the user. That's what we
do with this patch, making it possible to use either form for the same
command as in the following example:

    $ pg_autoctl -q config get --pgdata /tmp/sm/a postgresql.port
    3001
    
    $ pg_autoctl config get postgresql.port --pgdata /tmp/sm/a -q
    3001

Without this patch, only the first case works.

As most of our commands only process options, only two places need to be
adjusted to make that behavior available. The other commands don't need this
at the moment.

Fixed #99.