### PR TITLE
Fix execv() failure handling and argv0 usage.

### DIFF
--- a/src/bin/lib/subcommands.c/runprogram.h
+++ b/src/bin/lib/subcommands.c/runprogram.h
@@ -224,6 +224,10 @@ execute_program(Program *prog)
 			{
 				prog->returnCode = -1;
 				prog->error = errno;
+
+				fprintf(stdout, "%s\n", strerror(errno));
+				fprintf(stderr, "%s\n", strerror(errno));
+				exit(EXIT_CODE_INTERNAL_ERROR);
 			}
 			return;
 		}

--- a/src/bin/pg_autoctl/cli_root.h
+++ b/src/bin/pg_autoctl/cli_root.h
@@ -14,6 +14,8 @@
 #include "commandline.h"
 
 extern char pg_autoctl_argv0[];
+extern char pg_autoctl_program[];
+extern int logLevel;
 
 extern CommandLine help;
 extern CommandLine version;

--- a/src/bin/pg_autoctl/file_utils.c
+++ b/src/bin/pg_autoctl/file_utils.c
@@ -426,7 +426,7 @@ unlink_file(const char *filename)
  * then argv[0] (here pg_autoctl_argv0) is just "pg_autoctl".
  */
 bool
-get_program_absolute_path(char *program, int size)
+set_program_absolute_path(char *program, int size)
 {
 #if defined(__APPLE__)
 	int actualSize = _NSGetExecutablePath(program, (uint32_t *) &size);
@@ -438,6 +438,9 @@ get_program_absolute_path(char *program, int size)
 				  "to %d bytes only", actualSize, size);
 		return false;
 	}
+
+	log_debug("Found absolute program: \"%s\"", program);
+
 #else
 	/*
 	 * On Linux and FreeBSD and Solaris, we can find a symbolic link to our

--- a/src/bin/pg_autoctl/file_utils.h
+++ b/src/bin/pg_autoctl/file_utils.h
@@ -28,6 +28,6 @@ void path_in_same_directory(const char *basePath,
 int search_pathlist(const char *pathlist, const char *filename, char ***result);
 void search_pathlist_destroy_result(char **result);
 bool unlink_file(const char *filename);
-bool get_program_absolute_path(char *program, int size);
+bool set_program_absolute_path(char *program, int size);
 
 #endif /* FILE_UTILS_H */

--- a/src/bin/pg_autoctl/systemd_config.c
+++ b/src/bin/pg_autoctl/systemd_config.c
@@ -77,7 +77,6 @@ void
 systemd_config_init(SystemdServiceConfig *config, const char *pgdata)
 {
 	IniOption systemdOptions[] = SET_INI_OPTIONS_ARRAY(config);
-	char program[MAXPGPATH] = { 0 };
 
 	/* time to setup config->pathnames.systemd */
 	snprintf(config->pathnames.systemd, MAXPGPATH,
@@ -91,13 +90,7 @@ systemd_config_init(SystemdServiceConfig *config, const char *pgdata)
 
 	strlcpy(config->User, config->pgSetup.username, NAMEDATALEN);
 
-	if (!get_program_absolute_path(program, MAXPGPATH))
-	{
-		/* errors have already been logged */
-		exit(EXIT_CODE_INTERNAL_ERROR);
-	}
-
-	snprintf(config->ExecStart, BUFSIZE, "%s run", program);
+	snprintf(config->ExecStart, BUFSIZE, "%s run", pg_autoctl_program);
 
 	if (!ini_validate_options(systemdOptions))
 	{


### PR DESCRIPTION
In some cases:

  - we would use argv[0] as the binary to invoke again in sub-programs
  - execv() would fail with "No such file or directory"

Then our handling of execv() failure was leaving a process and a pipe
behind, leading to a strange process tree and a bad situation.

This patch fixes the code so that we get the realpath for the currently
executed program (using proper API in macOS but a heuristic for other OSes),
and fixes the error handling at the execv() call site too.