### PR TITLE
Tolerate missing optional INI options in missing sections.

### DIFF
--- a/src/bin/pg_autoctl/ini_file.c
+++ b/src/bin/pg_autoctl/ini_file.c
@@ -53,13 +53,19 @@ read_ini_file(const char *filename, IniOption *optionList)
 
 		if (sectionIndex == INI_NOT_FOUND)
 		{
-			log_error("Failed to find section %s in \"%s\"",
-					  option->section, filename);
-			ini_destroy(ini);
-			return false;
+			if (option->required)
+			{
+				log_error("Failed to find section %s in \"%s\"",
+						  option->section, filename);
+				ini_destroy(ini);
+				return false;
+			}
+			optionIndex = INI_NOT_FOUND;
 		}
-
-		optionIndex = ini_find_property(ini, sectionIndex, option->name, 0);
+		else
+		{
+			optionIndex = ini_find_property(ini, sectionIndex, option->name, 0);
+		}
 
 		if (optionIndex == INI_NOT_FOUND)
 		{


### PR DESCRIPTION
Without this patch when reading the configuration file and it's missing a
section entirely, it would be an error even for optional parameters. This
situation mostly happens when upgrading pg_autoctl and the new version has
implemented a new configuration section, which didn't exist previously, and
has default parameters that you can run with.