### PR TITLE
Implement pg_autoctl create postgres|monitor --run.

### DIFF
--- a/src/bin/pg_autoctl/cli_common.c
+++ b/src/bin/pg_autoctl/cli_common.c
@@ -30,6 +30,7 @@
 /* handle command line options for our setup. */
 KeeperConfig keeperOptions;
 bool allowRemovingPgdata = false;
+bool createAndRun = false;
 
 
 /*
@@ -58,6 +59,8 @@ bool allowRemovingPgdata = false;
  *		{ "help", no_argument, NULL, 'h' },
  *		{ "candidate-priority", required_argument, NULL, 'P'},
  *		{ "replication-quorum", required_argument, NULL, 'r'},
+ *		{ "help", no_argument, NULL, 0 },
+ *		{ "run", no_argument, NULL, 'x' },
  *		{ NULL, 0, NULL, 0 }
  *	};
  *
@@ -239,6 +242,7 @@ cli_create_node_getopts(int argc, char **argv,
 				log_trace("--allow-removing-pgdata");
 				break;
 			}
+
 			case 'P':
 			{
 				/* { "candidate-priority", required_argument, NULL, 'P'} */
@@ -254,6 +258,7 @@ cli_create_node_getopts(int argc, char **argv,
 				log_trace("--candidate-priority %d", candidatePriority);
 				break;
 			}
+
 			case 'r':
 			{
 				/* { "replication-quorum", required_argument, NULL, 'r'} */
@@ -311,6 +316,14 @@ cli_create_node_getopts(int argc, char **argv,
 				break;
 			}
 
+			case 'x':
+			{
+				/* { "run", no_argument, NULL, 'x' }, */
+				createAndRun = true;
+				log_trace("--run");
+				break;
+			}
+
 			default:
 			{
 				/* getopt_long already wrote an error message */
@@ -363,6 +376,16 @@ cli_create_node_getopts(int argc, char **argv,
 		strlcpy(LocalOptionConfig.monitor_pguri,
 				PG_AUTOCTL_MONITOR_DISABLED,
 				MAXCONNINFO);
+	}
+
+	/*
+	 * We have a PGDATA setting, prepare our configuration pathnames from it.
+	 */
+	if (!keeper_config_set_pathnames_from_pgdata(
+			&(LocalOptionConfig.pathnames), LocalOptionConfig.pgSetup.pgdata))
+	{
+		/* errors have already been logged */
+		exit(EXIT_CODE_BAD_ARGS);
 	}
 
 	if (errors > 0)

--- a/src/bin/pg_autoctl/cli_common.h
+++ b/src/bin/pg_autoctl/cli_common.h
@@ -21,6 +21,7 @@
 extern MonitorConfig monitorOptions;
 extern KeeperConfig keeperOptions;
 extern bool allowRemovingPgdata;
+extern bool createAndRun;
 
 #define KEEPER_CLI_WORKER_SETUP_OPTIONS \
 	"  --pgctl       path to pg_ctl\n" \

--- a/src/bin/pg_autoctl/cli_create_drop_node.c
+++ b/src/bin/pg_autoctl/cli_create_drop_node.c
@@ -55,7 +55,8 @@ CommandLine create_monitor_command =
 				 "  --pgdata      path to data directory\n" \
 				 "  --pgport      PostgreSQL's port number\n" \
 				 "  --nodename    hostname by which postgres is reachable\n" \
-				 "  --auth        authentication method for connections from data nodes\n",
+				 "  --auth        authentication method for connections from data nodes\n"
+				 "  --run         create node then run pg_autoctl service\n",
 				 cli_create_monitor_getopts,
 				 cli_create_monitor);
 
@@ -107,13 +108,6 @@ cli_create_config(Keeper *keeper, KeeperConfig *config)
 	 *   - configuration exists already, we need PGDATA
 	 *   - configuration doesn't exist already, we need PGDATA, and more
 	 */
-	if (!keeper_config_set_pathnames_from_pgdata(&config->pathnames,
-												 config->pgSetup.pgdata))
-	{
-		/* errors have already been logged */
-		exit(EXIT_CODE_BAD_ARGS);
-	}
-
 	if (file_exists(config->pathnames.config))
 	{
 		KeeperConfig options = *config;
@@ -180,6 +174,33 @@ cli_create_pg(Keeper *keeper, KeeperConfig *config)
 	else
 	{
 		log_info("Keeper has been succesfully initialized.");
+
+		if (createAndRun)
+		{
+			pid_t pid = 0;
+
+			/* now that keeper_pg_init is done, finish the keeper init */
+			if (!keeper_init(keeper, config))
+			{
+				/* errors have already been logged */
+				exit(EXIT_CODE_KEEPER);
+			}
+
+			if (!keeper_service_init(keeper, &pid))
+			{
+				log_fatal("Failed to initialize pg_auto_failover service, "
+						  "see above for details");
+				exit(EXIT_CODE_KEEPER);
+			}
+
+			if (!keeper_check_monitor_extension_version(keeper))
+			{
+				/* errors have already been logged */
+				exit(EXIT_CODE_MONITOR);
+			}
+
+			keeper_service_run(keeper, &pid);
+		}
 	}
 
 	keeper_config_destroy(config);
@@ -215,12 +236,14 @@ cli_create_postgres_getopts(int argc, char **argv)
  		{ "help", no_argument, NULL, 'h' },
 		{ "candidate-priority", required_argument, NULL, 'P'},
 		{ "replication-quorum", required_argument, NULL, 'r'},
+		{ "run", no_argument, NULL, 'x' },
+		{ "help", no_argument, NULL, 0 },
 		{ NULL, 0, NULL, 0 }
 	};
 
 	int optind =
-		cli_create_node_getopts(argc, argv,
-								long_options, "C:D:H:p:l:U:A:d:n:f:m:MRVvqhP:r:",
+		cli_create_node_getopts(argc, argv, long_options,
+								"C:D:H:p:l:U:A:d:n:f:m:MRVvqhP:r:x",
 								&options);
 
 	/* publish our option parsing in the global variable */
@@ -240,14 +263,17 @@ cli_create_postgres(int argc, char **argv)
 	Keeper keeper = { 0 };
 	KeeperConfig config = keeperOptions;
 
-	/* pg_autoctl create postgres: mark ourselves as a standalone node */
-	config.pgSetup.pgKind = NODE_KIND_STANDALONE;
-	strlcpy(config.nodeKind, "standalone", NAMEDATALEN);
-
-	if (!check_or_discover_nodename(&config))
+	if (!file_exists(config.pathnames.config))
 	{
-		/* errors have already been logged */
-		exit(EXIT_CODE_BAD_ARGS);
+		/* pg_autoctl create postgres: mark ourselves as a standalone node */
+		config.pgSetup.pgKind = NODE_KIND_STANDALONE;
+		strlcpy(config.nodeKind, "standalone", NAMEDATALEN);
+
+		if (!check_or_discover_nodename(&config))
+		{
+			/* errors have already been logged */
+			exit(EXIT_CODE_BAD_ARGS);
+		}
 	}
 
 	if (!cli_create_config(&keeper, &config))
@@ -282,6 +308,8 @@ cli_create_monitor_getopts(int argc, char **argv)
 		{ "verbose", no_argument, NULL, 'v' },
 		{ "quiet", no_argument, NULL, 'q' },
  		{ "help", no_argument, NULL, 'h' },
+		{ "run", no_argument, NULL, 'x' },
+		{ "help", no_argument, NULL, 0 },
 		{ NULL, 0, NULL, 0 }
 	};
 
@@ -290,7 +318,7 @@ cli_create_monitor_getopts(int argc, char **argv)
 
 	optind = 0;
 
-	while ((c = getopt_long(argc, argv, "C:D:p:A:Vvqh",
+	while ((c = getopt_long(argc, argv, "C:D:p:n:l:A:Vvqhx",
 							long_options, &option_index)) != -1)
 	{
 		switch (c)
@@ -383,10 +411,19 @@ cli_create_monitor_getopts(int argc, char **argv)
 				break;
 			}
 
+			case 'x':
+			{
+				/* { "run", no_argument, NULL, 'x' }, */
+				createAndRun = true;
+				log_trace("--run");
+				break;
+			}
+
 			default:
 			{
 				/* getopt_long already wrote an error message */
-				errors++;
+				commandline_help(stderr);
+				exit(EXIT_CODE_BAD_ARGS);
 				break;
 			}
 		}
@@ -553,6 +590,35 @@ cli_create_monitor(int argc, char **argv)
 	}
 
 	log_info("Monitor has been succesfully initialized.");
+
+	if (createAndRun)
+	{
+		char *channels[] = { "log", "state", NULL };
+
+		log_info("Contacting the monitor to LISTEN to its events.");
+		pgsql_listen(&(monitor.pgsql), channels);
+
+		/*
+		 * Main loop for notifications.
+		 */
+		for (;;)
+		{
+			if (!monitor_get_notifications(&monitor))
+			{
+				log_warn("Re-establishing connection. "
+						 "We might miss notifications.");
+				pgsql_finish(&(monitor.pgsql));
+
+				pgsql_listen(&(monitor.pgsql), channels);
+
+				/* skip sleeping */
+				continue;
+			}
+
+			sleep(PG_AUTOCTL_MONITOR_SLEEP_TIME);
+		}
+		pgsql_finish(&(monitor.pgsql));
+	}
 }
 
 

--- a/src/bin/pg_autoctl/cli_create_drop_node.c
+++ b/src/bin/pg_autoctl/cli_create_drop_node.c
@@ -593,31 +593,7 @@ cli_create_monitor(int argc, char **argv)
 
 	if (createAndRun)
 	{
-		char *channels[] = { "log", "state", NULL };
-
-		log_info("Contacting the monitor to LISTEN to its events.");
-		pgsql_listen(&(monitor.pgsql), channels);
-
-		/*
-		 * Main loop for notifications.
-		 */
-		for (;;)
-		{
-			if (!monitor_get_notifications(&monitor))
-			{
-				log_warn("Re-establishing connection. "
-						 "We might miss notifications.");
-				pgsql_finish(&(monitor.pgsql));
-
-				pgsql_listen(&(monitor.pgsql), channels);
-
-				/* skip sleeping */
-				continue;
-			}
-
-			sleep(PG_AUTOCTL_MONITOR_SLEEP_TIME);
-		}
-		pgsql_finish(&(monitor.pgsql));
+		(void) monitor_listen_loop(&monitor);
 	}
 }
 

--- a/src/bin/pg_autoctl/cli_service.c
+++ b/src/bin/pg_autoctl/cli_service.c
@@ -240,30 +240,7 @@ cli_monitor_run(int argc, char **argv)
 		log_info("pg_auto_failover monitor is ready at %s", postgresUri);
 	}
 
-	log_info("Contacting the monitor to LISTEN to its events.");
- 	pgsql_listen(&(monitor.pgsql), channels);
-
-	/*
-	 * Main loop for notifications.
-	 */
-	for (;;)
-	{
-		if (!monitor_get_notifications(&monitor))
-		{
-			log_warn("Re-establishing connection. We might miss notifications.");
-			pgsql_finish(&(monitor.pgsql));
-
-			pgsql_listen(&(monitor.pgsql), channels);
-
-			/* skip sleeping */
-			continue;
-		}
-
-		sleep(PG_AUTOCTL_MONITOR_SLEEP_TIME);
-	}
-	pgsql_finish(&(monitor.pgsql));
-
-	return;
+	(void) monitor_listen_loop(&monitor);
 }
 
 

--- a/src/bin/pg_autoctl/keeper_pg_init.c
+++ b/src/bin/pg_autoctl/keeper_pg_init.c
@@ -129,10 +129,20 @@ keeper_pg_init_and_register(Keeper *keeper, KeeperConfig *config)
 
 	if (file_exists(config->pathnames.state))
 	{
-		log_fatal("The state file \"%s\" exists and there's no init in progress",
-				  config->pathnames.state);
-		log_info("HINT: use `pg_autoctl run` to start the service.");
-		return false;
+		if (createAndRun)
+		{
+			if (!keeper_init(keeper, config))
+			{
+				return false;
+			}
+		}
+		else
+		{
+			log_fatal("The state file \"%s\" exists and "
+					  "there's no init in progress", config->pathnames.state);
+			log_info("HINT: use `pg_autoctl run` to start the service.");
+		}
+		return createAndRun;
 	}
 
 	if (postgresInstanceExists

--- a/src/bin/pg_autoctl/monitor.h
+++ b/src/bin/pg_autoctl/monitor.h
@@ -105,6 +105,7 @@ bool monitor_extension_update(Monitor *monitor, const char *targetVersion);
 bool monitor_ensure_extension_version(Monitor *monitor,
 									  MonitorExtensionVersion *version);
 
+bool monitor_listen_loop(Monitor *monitor);
 
 
 #endif /* MONITOR_H */

--- a/tests/test_basic_operation.py
+++ b/tests/test_basic_operation.py
@@ -21,9 +21,10 @@ def test_000_create_monitor():
 def test_001_init_primary():
     global node1
     node1 = cluster.create_datanode("/tmp/basic/node1")
-    node1.create()
-    node1.run()
+    node1.create(run = True)
+    #node1.run()
     assert node1.wait_until_state(target_state="single")
+
 
 def test_001_stop_postgres():
     node1.stop_postgres()
@@ -36,8 +37,8 @@ def test_002_create_t1():
 def test_003_init_secondary():
     global node2
     node2 = cluster.create_datanode("/tmp/basic/node2")
-    node2.create()
-    node2.run()
+    node2.create(run = True)
+    #node2.run()
     assert node2.wait_until_state(target_state="secondary")
     assert node1.wait_until_state(target_state="primary")
 
@@ -82,7 +83,11 @@ def test_011_writes_to_node1_fail():
     node1.run_sql_query("INSERT INTO t1 VALUES (3)")
 
 def test_012_fail_secondary():
+    print ("Node 1 state " , node1.get_state())
+    print ("Node 2 state " , node2.get_state())
     node1.fail()
+    print ("Node 1 state " , node1.get_state())
+    print ("Node 2 state " , node2.get_state())
     assert node2.wait_until_state(target_state="wait_primary")
 
 def test_013_drop_secondary():

--- a/tests/test_basic_operation.py
+++ b/tests/test_basic_operation.py
@@ -21,8 +21,8 @@ def test_000_create_monitor():
 def test_001_init_primary():
     global node1
     node1 = cluster.create_datanode("/tmp/basic/node1")
-    node1.create(run = True)
-    #node1.run()
+    node1.create()
+    node1.run()
     assert node1.wait_until_state(target_state="single")
 
 
@@ -37,8 +37,8 @@ def test_002_create_t1():
 def test_003_init_secondary():
     global node2
     node2 = cluster.create_datanode("/tmp/basic/node2")
-    node2.create(run = True)
-    #node2.run()
+    node2.create()
+    node2.run()
     assert node2.wait_until_state(target_state="secondary")
     assert node1.wait_until_state(target_state="primary")
 
@@ -83,11 +83,7 @@ def test_011_writes_to_node1_fail():
     node1.run_sql_query("INSERT INTO t1 VALUES (3)")
 
 def test_012_fail_secondary():
-    print ("Node 1 state " , node1.get_state())
-    print ("Node 2 state " , node2.get_state())
     node1.fail()
-    print ("Node 1 state " , node1.get_state())
-    print ("Node 2 state " , node2.get_state())
     assert node2.wait_until_state(target_state="wait_primary")
 
 def test_013_drop_secondary():

--- a/tests/test_create_run.py
+++ b/tests/test_create_run.py
@@ -1,0 +1,93 @@
+import pgautofailover_utils as pgautofailover
+from nose.tools import *
+
+cluster = None
+monitor = None
+node1 = None
+node2 = None
+node3 = None
+
+def setup_module():
+    global cluster
+    cluster = pgautofailover.Cluster()
+
+def teardown_module():
+    cluster.destroy()
+
+def test_000_create_monitor():
+    global monitor
+    monitor = cluster.create_monitor("/tmp/basic/monitor")
+
+def test_001_init_primary():
+    global node1
+    node1 = cluster.create_datanode("/tmp/basic/node1")
+    node1.create(run = True)
+    assert node1.wait_until_state(target_state="single")
+
+def test_002_create_t1():
+    node1.run_sql_query("CREATE TABLE t1(a int)")
+    node1.run_sql_query("INSERT INTO t1 VALUES (1), (2)")
+
+def test_003_init_secondary():
+    global node2
+    node2 = cluster.create_datanode("/tmp/basic/node2")
+    node2.create(run = True)
+    assert node2.wait_until_state(target_state="secondary")
+    assert node1.wait_until_state(target_state="primary")
+
+def test_004_read_from_secondary():
+    results = node2.run_sql_query("SELECT * FROM t1")
+    assert results == [(1,), (2,)]
+
+def test_005_maintenance():
+    node2.enable_maintenance()
+    assert node2.wait_until_state(target_state="maintenance")
+    node2.fail()
+    node1.run_sql_query("INSERT INTO t1 VALUES (3)")
+    node2.run()
+    node2.disable_maintenance()
+    assert node2.wait_until_pg_is_running()
+    assert node2.wait_until_pg_is_running()        
+    assert node2.wait_until_state(target_state="secondary")
+    assert node1.wait_until_state(target_state="primary")
+
+def test_006_fail_primary():
+    node1.fail()
+    assert node2.wait_until_state(target_state="wait_primary", timeout=180)
+
+def test_007_start_node1_again():
+    print(node1.get_events_str())
+    node1.run()
+    assert node2.wait_until_state(target_state="primary")
+    assert node1.wait_until_state(target_state="secondary")
+
+def test_008_read_from_new_secondary():
+    results = node1.run_sql_query("SELECT * FROM t1 ORDER BY a")
+    assert results == [(1,), (2,), (3,)]
+
+def test_009_fail_secondary():
+    node1.fail()
+    assert node2.wait_until_state(target_state="wait_primary")
+
+def test_010_drop_secondary():
+    node1.run()
+    assert node1.wait_until_state(target_state="secondary")
+    node1.drop()
+    assert not node1.pg_is_running()
+    assert node2.wait_until_state(target_state="single")
+    
+def test_011_add_new_secondary():
+    global node3
+    node3 = cluster.create_datanode("/tmp/basic/node3")
+    node3.create(run = True)
+    assert node3.wait_until_state(target_state="secondary")
+    assert node2.wait_until_state(target_state="primary")
+
+def test_012_multiple_manual_failover():
+   monitor.failover()
+   assert node3.wait_until_state(target_state="primary")
+   assert node2.wait_until_state(target_state="secondary")
+   
+   monitor.failover()
+   assert node2.wait_until_state(target_state="primary")
+   assert node3.wait_until_state(target_state="secondary")


### PR DESCRIPTION
This allows for using the same command the first time and at following
boots, making it even easier than before to integrate in docker or k8s
environments. Provisioning and startup can now be the same if needed.