### PR TITLE
Fix initialiazing an already existing Postgres cluster.

### DIFF
--- a/src/bin/pg_autoctl/fsm_transition.c
+++ b/src/bin/pg_autoctl/fsm_transition.c
@@ -94,6 +94,7 @@ fsm_init_primary(Keeper *keeper)
 			return false;
 		}
 
+		/* did the user try again after having stopped Postgres maybe? */
 		if (initState.pgInitState < PRE_INIT_STATE_RUNNING)
 		{
 			log_info("PostgreSQL state has changed since registration time: %s",

--- a/src/bin/pg_autoctl/keeper.c
+++ b/src/bin/pg_autoctl/keeper.c
@@ -898,35 +898,11 @@ keeper_init_state_write(Keeper *keeper)
 	int fd;
 	char buffer[PG_AUTOCTL_KEEPER_STATE_FILE_SIZE];
 	KeeperStateInit initState = { 0 };
-	PostgresSetup pgSetup = { 0 };
-	bool missingPgdataIsOk = true;
-	bool pgIsNotRunningIsOk = true;
 
-	initState.pg_autoctl_state_version = PG_AUTOCTL_STATE_VERSION;
-
-	if (!pg_setup_init(&pgSetup, &(keeper->config.pgSetup),
-					   missingPgdataIsOk, pgIsNotRunningIsOk))
+	if (!keeper_init_state_discover(keeper, &initState))
 	{
-		log_fatal("Failed to initialise the keeper init state, "
-				  "see above for details");
+		/* errors have already been logged */
 		return false;
-	}
-
-	if (pg_setup_is_running(&pgSetup) && pg_setup_is_primary(&pgSetup))
-	{
-		initState.pgInitState = PRE_INIT_STATE_PRIMARY;
-	}
-	else if (pg_setup_is_running(&pgSetup))
-	{
-		initState.pgInitState = PRE_INIT_STATE_RUNNING;
-	}
-	else if (pg_setup_pgdata_exists(&pgSetup))
-	{
-		initState.pgInitState = PRE_INIT_STATE_EXISTS;
-	}
-	else
-	{
-		initState.pgInitState = PRE_INIT_STATE_EMPTY;
 	}
 
 	log_info("Writing keeper init state file at \"%s\"",
@@ -973,6 +949,48 @@ keeper_init_state_write(Keeper *keeper)
 	return true;
 }
 
+
+/*
+ * keeper_init_state_discover discovers the current KeeperStateInit from the
+ * command line options, by checking everything we can about the possibly
+ * existing Postgres instance.
+ */
+bool
+keeper_init_state_discover(Keeper *keeper, KeeperStateInit *initState)
+{
+	PostgresSetup pgSetup = { 0 };
+	bool missingPgdataIsOk = true;
+	bool pgIsNotRunningIsOk = true;
+
+	initState->pg_autoctl_state_version = PG_AUTOCTL_STATE_VERSION;
+
+	if (!pg_setup_init(&pgSetup, &(keeper->config.pgSetup),
+					   missingPgdataIsOk, pgIsNotRunningIsOk))
+	{
+		log_fatal("Failed to initialise the keeper init state, "
+				  "see above for details");
+		return false;
+	}
+
+	if (pg_setup_is_running(&pgSetup) && pg_setup_is_primary(&pgSetup))
+	{
+		initState->pgInitState = PRE_INIT_STATE_PRIMARY;
+	}
+	else if (pg_setup_is_running(&pgSetup))
+	{
+		initState->pgInitState = PRE_INIT_STATE_RUNNING;
+	}
+	else if (pg_setup_pgdata_exists(&pgSetup))
+	{
+		initState->pgInitState = PRE_INIT_STATE_EXISTS;
+	}
+	else
+	{
+		initState->pgInitState = PRE_INIT_STATE_EMPTY;
+	}
+
+	return true;
+}
 
 /*
  * keeper_init_state_read reads the information kept in the keeper init file.

--- a/src/bin/pg_autoctl/keeper.c
+++ b/src/bin/pg_autoctl/keeper.c
@@ -992,6 +992,7 @@ keeper_init_state_discover(Keeper *keeper, KeeperStateInit *initState)
 	return true;
 }
 
+
 /*
  * keeper_init_state_read reads the information kept in the keeper init file.
  */

--- a/src/bin/pg_autoctl/keeper.h
+++ b/src/bin/pg_autoctl/keeper.h
@@ -53,7 +53,7 @@ bool keeper_check_monitor_extension_version(Keeper *keeper);
 bool keeper_init_state_write(Keeper *keeper);
 bool keeper_init_state_read(Keeper *keeper, KeeperStateInit *initState);
 bool keeper_state_as_json(Keeper *keeper, char *json, int size);
-
+bool keeper_init_state_discover(Keeper *keeper, KeeperStateInit *initState);
 
 /* loop.c */
 bool keeper_service_init(Keeper *keeper, pid_t *pid);


### PR DESCRIPTION
We refuse to own an already running Postgres cluster. Then it's fair for us
to also accept that the user might just stop the Postgres instance and give
it to us again. This patch makes us recognize the situation and proceed with
our initialisation steps in that case.

Fixes #111.