### PR TITLE
Avoid using stdin/stdout/stderr as variable names

### DIFF
--- a/src/bin/lib/subcommands.c/runprogram.h
+++ b/src/bin/lib/subcommands.c/runprogram.h
@@ -41,8 +41,8 @@ typedef struct
 	int error;					/* save errno when something's gone wrong */
 	int returnCode;
 
-	char *stdout;
-	char *stderr;
+	char *stdOut;
+	char *stdErr;
 } Program;
 
 Program run_program(const char *program, ...);
@@ -56,7 +56,7 @@ static size_t read_into_buf(int filedes, PQExpBuffer buffer);
 
 
 /*
- * Run a program using fork() and exec(), get the stdout and stderr output from
+ * Run a program using fork() and exec(), get the stdOut and stdErr output from
  * the run and then return a Program struct instance with the result of running
  * the program.
  */
@@ -72,8 +72,8 @@ run_program(const char *program, ...)
 	prog.returnCode = -1;
 	prog.error = 0;
 	prog.setsid = false;
-	prog.stdout = NULL;
-	prog.stderr = NULL;
+	prog.stdOut = NULL;
+	prog.stdErr = NULL;
 
 	prog.args = (char **) malloc(ARGS_INCREMENT * sizeof(char *));
 	prog.args[nb_args++] = prog.program;
@@ -119,8 +119,8 @@ initialize_program(char **args, bool setsid)
 	prog.returnCode = -1;
 	prog.error = 0;
 	prog.setsid = setsid;
-	prog.stdout = NULL;
-	prog.stderr = NULL;
+	prog.stdOut = NULL;
+	prog.stdErr = NULL;
 
 	for(argsIndex = 0; args[argsIndex] != NULL; argsIndex++)
 	{
@@ -188,17 +188,17 @@ execute_program(Program *prog)
 			/* fork succeeded, in child */
 
 			/*
-			 * We redirect /dev/null into stdin rather than closing stdin,
+			 * We redirect /dev/null into _stdin rather than closing stdin,
 			 * because apparently closing it may cause undefined behavior if
 			 * any read was to happen.
 			 */
-			int stdin = open(DEV_NULL, O_RDONLY);
+			int _stdin = open(DEV_NULL, O_RDONLY);
 
-			dup2(stdin, STDIN_FILENO);
+			dup2(_stdin, STDIN_FILENO);
 			dup2(outpipe[1], STDOUT_FILENO);
 			dup2(errpipe[1], STDERR_FILENO);
 
-			close(stdin);
+			close(_stdin);
 			close(outpipe[0]);
 			close(outpipe[1]);
 			close(errpipe[0]);
@@ -256,14 +256,14 @@ free_program(Program *prog)
 	}
 	free(prog->args);
 
-	if (prog->stdout != NULL)
+	if (prog->stdOut != NULL)
 	{
-		free(prog->stdout);
+		free(prog->stdOut);
 	}
 
-	if (prog->stderr != NULL)
+	if (prog->stdErr != NULL)
 	{
-		free(prog->stderr);
+		free(prog->stdErr);
 	}
 
 	return;
@@ -272,7 +272,7 @@ free_program(Program *prog)
 
 /*
  * read_from_pipes reads the output from the child process and sets the Program
- * slots stdout and stderr with the accumulated output we read.
+ * slots stdOut and stdErr with the accumulated output we read.
  */
 static void
 read_from_pipes(Program *prog, pid_t childPid, int *outpipe, int *errpipe)
@@ -366,7 +366,7 @@ read_from_pipes(Program *prog, pid_t childPid, int *outpipe, int *errpipe)
 	}
 
 	/*
-	 * Now we're done reading from both STDOUT and STDERR of the child
+	 * Now we're done reading from both stdOut and stdErr of the child
 	 * process, so close the file descriptors and prepare the char *
 	 * strings output in our Program structure.
 	 */
@@ -375,12 +375,12 @@ read_from_pipes(Program *prog, pid_t childPid, int *outpipe, int *errpipe)
 
 	if (outbuf->len > 0)
 	{
-		prog->stdout = strndup(outbuf->data, outbuf->len);
+		prog->stdOut = strndup(outbuf->data, outbuf->len);
 	}
 
 	if (errbuf->len > 0)
 	{
-		prog->stderr = strndup(errbuf->data, errbuf->len);
+		prog->stdErr = strndup(errbuf->data, errbuf->len);
 	}
 
 	destroyPQExpBuffer(outbuf);

--- a/src/bin/pg_autoctl/pgctl.c
+++ b/src/bin/pg_autoctl/pgctl.c
@@ -84,7 +84,7 @@ pg_ctl_version(const char *pg_ctl_path)
 		return NULL;
 	}
 
-	version = parse_version_number(prog.stdout);
+	version = parse_version_number(prog.stdOut);
 	free_program(&prog);
 
 	return version;
@@ -116,7 +116,7 @@ pg_controldata(PostgresSetup *pgSetup, bool missing_ok)
 
 	if (prog.returnCode == 0)
 	{
-		success = parse_controldata(&pgSetup->control, prog.stdout);
+		success = parse_controldata(&pgSetup->control, prog.stdOut);
 	}
 	else
 	{
@@ -128,7 +128,7 @@ pg_controldata(PostgresSetup *pgSetup, bool missing_ok)
 		{
 			success = false;
 			log_error("Failed to run \"%s\" on \"%s\": %s",
-					  pg_controldata, pgSetup->pgdata, prog.stderr);
+					  pg_controldata, pgSetup->pgdata, prog.stdErr);
 		}
 	}
 	free_program(&prog);
@@ -553,20 +553,20 @@ pg_rewind(const char *pgdata, const char *pg_ctl, const char *primaryHost,
 static void
 log_program_output(Program prog)
 {
-	if (prog.stdout != NULL)
+	if (prog.stdOut != NULL)
 	{
-		log_info("%s", prog.stdout);
+		log_info("%s", prog.stdOut);
 	}
 
-	if (prog.stderr != NULL)
+	if (prog.stdErr != NULL)
 	{
 		if (prog.returnCode == 0)
 		{
-			log_info("%s", prog.stderr);
+			log_info("%s", prog.stdErr);
 		}
 		else
 		{
-			log_error("%s", prog.stderr);
+			log_error("%s", prog.stdErr);
 		}
 	}
 }
@@ -697,9 +697,9 @@ pg_ctl_start(const char *pg_ctl,
 			log_warn("Failed to start PostgreSQL. pg_ctl start returned: %d",
 					 program.returnCode);
 
-			if (program.stdout != NULL)
+			if (program.stdOut != NULL)
 			{
-				log_warn("%s", program.stdout);
+				log_warn("%s", program.stdOut);
 			}
 
 			log_info("PostgreSQL is running. pg_ctl status returned %d",
@@ -713,9 +713,9 @@ pg_ctl_start(const char *pg_ctl,
 			log_error("Failed to start PostgreSQL. pg_ctl start returned: %d",
 					  program.returnCode);
 
-			if (program.stdout)
+			if (program.stdOut)
 			{
-				log_error("%s", program.stdout);
+				log_error("%s", program.stdOut);
 			}
 		}
 
@@ -730,9 +730,9 @@ pg_ctl_start(const char *pg_ctl,
 	 * Now append the output from pg_ctl start (known to be all in stdout) to
 	 * the startup log file, as if by using pg_ctl --log option.
 	 */
-	if (program.stdout)
+	if (program.stdOut)
 	{
-		append_to_file(program.stdout, strlen(program.stdout), logfile);
+		append_to_file(program.stdOut, strlen(program.stdOut), logfile);
 	}
 
 	free_program(&program);
@@ -877,9 +877,9 @@ pg_ctl_promote(const char *pg_ctl, const char *pgdata)
 
 	log_debug("%s promote -D %s", pg_ctl, pgdata);
 
-	if (program.stderr != NULL)
+	if (program.stdErr != NULL)
 	{
-		log_error("%s", program.stderr);
+		log_error("%s", program.stdErr);
 	}
 
 	if (returnCode != 0)


### PR DESCRIPTION
These are macros in C89/C99

On OpenBSD 6.6 this causes the following build error

```
In file included from pgctl.c:28:
/home/eradman/git/pg_auto_failover/src/bin/pg_autoctl/../lib/subcommands.c/runprogram.h:44:8: error: expected member name or
      ';' after declaration specifiers
        char *stdout;
        ~~~~  ^
```

```
$ cc --version
OpenBSD clang version 8.0.1 (tags/RELEASE_801/final) (based on LLVM 8.0.1)
Target: amd64-unknown-openbsd6.6
Thread model: posix
InstalledDir: /usr/bin
```