### PR TITLE
Ensure the monitor's Postgres is running as part of `pg_autoctl run`

### DIFF
--- a/src/bin/pg_autoctl/cli_common.c
+++ b/src/bin/pg_autoctl/cli_common.c
@@ -630,7 +630,7 @@ monitor_init_from_pgsetup(Monitor *monitor, PostgresSetup *pgSetup)
 			char connInfo[MAXCONNINFO];
 			MonitorConfig mconfig = { 0 };
 
-			(void) monitor_config_init_from_pgsetup(monitor, &mconfig, pgSetup,
+			(void) monitor_config_init_from_pgsetup(&mconfig, pgSetup,
 													missingPgdataIsOk,
 													pgIsNotRunningIsOk);
 

--- a/src/bin/pg_autoctl/cli_config.c
+++ b/src/bin/pg_autoctl/cli_config.c
@@ -99,8 +99,7 @@ cli_config_check(int argc, char **argv)
 			Monitor monitor;
 			MonitorConfig mconfig = { 0 };
 
-			if (!monitor_config_init_from_pgsetup(&monitor,
-												  &mconfig,
+			if (!monitor_config_init_from_pgsetup(&mconfig,
 												  &config.pgSetup,
 												  missingPgdataIsOk,
 												  pgIsNotRunningIsOk))
@@ -307,8 +306,7 @@ cli_monitor_config_get(int argc, char **argv)
 	bool missing_pgdata_is_ok = true;
 	bool pg_is_not_running_is_ok = true;
 
-	if (!monitor_config_init_from_pgsetup(&monitor,
-										  &mconfig,
+	if (!monitor_config_init_from_pgsetup(&mconfig,
 										  &kconfig.pgSetup,
 										  missing_pgdata_is_ok,
 										  pg_is_not_running_is_ok))
@@ -470,8 +468,7 @@ cli_monitor_config_set(int argc, char **argv)
 		bool missing_pgdata_is_ok = true;
 		bool pg_is_not_running_is_ok = true;
 
-		if (!monitor_config_init_from_pgsetup(&monitor,
-											  &mconfig,
+		if (!monitor_config_init_from_pgsetup(&mconfig,
 											  &kconfig.pgSetup,
 											  missing_pgdata_is_ok,
 											  pg_is_not_running_is_ok))

--- a/src/bin/pg_autoctl/cli_create_drop_node.c
+++ b/src/bin/pg_autoctl/cli_create_drop_node.c
@@ -593,7 +593,7 @@ cli_create_monitor(int argc, char **argv)
 
 	if (createAndRun)
 	{
-		(void) monitor_listen_loop(&monitor);
+		(void) monitor_service_run(&monitor, &config);
 	}
 }
 

--- a/src/bin/pg_autoctl/cli_do_misc.c
+++ b/src/bin/pg_autoctl/cli_do_misc.c
@@ -441,7 +441,7 @@ keeper_cli_destroy_node(int argc, char **argv)
 			bool missingPgdataIsOk = true;
 			bool pgIsNotRunningIsOk = true;
 
-			if (!monitor_config_init_from_pgsetup(&monitor, &mconfig,
+			if (!monitor_config_init_from_pgsetup(&mconfig,
 												  &config.pgSetup,
 												  missingPgdataIsOk,
 												  pgIsNotRunningIsOk))

--- a/src/bin/pg_autoctl/cli_show.c
+++ b/src/bin/pg_autoctl/cli_show.c
@@ -541,8 +541,7 @@ cli_show_monitor_uri(int argc, char **argv)
 			bool pgIsNotRunningIsOk = true;
 			char connInfo[MAXCONNINFO];
 
-			if (!monitor_config_init_from_pgsetup(&monitor,
-												  &mconfig,
+			if (!monitor_config_init_from_pgsetup(&mconfig,
 												  &kconfig.pgSetup,
 												  missingPgdataIsOk,
 												  pgIsNotRunningIsOk))

--- a/src/bin/pg_autoctl/monitor.c
+++ b/src/bin/pg_autoctl/monitor.c
@@ -19,6 +19,7 @@
 #include "defaults.h"
 #include "log.h"
 #include "monitor.h"
+#include "monitor_config.h"
 #include "parsing.h"
 #include "pgsql.h"
 #include "catalog/pg_type.h"
@@ -1865,13 +1866,73 @@ prepare_connection_to_current_system_user(Monitor *source, Monitor *target)
 
 
 /*
- * monitor_listen_loop loops over a LISTEN command that is notified at every
+ * ensure_monitor_pg_running checks if monitor is running, attempts to restart if it is not.
+ * The function verifies if the extension version is the same as expected.  It returns true
+ * if the monitor is up and running.
+ */
+bool
+ensure_monitor_pg_running(Monitor *monitor, struct MonitorConfig *mconfig)
+{
+	MonitorExtensionVersion version = { 0 };
+	char postgresUri[MAXCONNINFO];
+
+	if (!pg_is_running(mconfig->pgSetup.pg_ctl, mconfig->pgSetup.pgdata))
+	{
+		log_info("Postgres is not running, starting postgres");
+		pgsql_finish(&(monitor->pgsql));
+
+		if (!pg_ctl_start(mconfig->pgSetup.pg_ctl,
+						  mconfig->pgSetup.pgdata,
+						  mconfig->pgSetup.pgport,
+						  mconfig->pgSetup.listen_addresses))
+		{
+			log_error("Failed to start PostgreSQL, see above for details");
+			return false;
+		}
+
+		/*
+		 * Check version compatibility.
+		 *
+		 * The function terminates any existing connection during clenaup
+		 * therefore it is not called when PG is found to be running to not
+		 * to intervene pgsql_listen call.
+		 */
+		if (!monitor_ensure_extension_version(monitor, &version))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+
+	}
+
+	return true;
+}
+
+
+/*
+ * monitor_service_run watches over monitor process, restarts if it is necessary,
+ * also loops over a LISTEN command that is notified at every
  * change of state on the monitor, and prints the change on stdout.
  */
 bool
-monitor_listen_loop(Monitor *monitor)
+monitor_service_run(Monitor *monitor,  struct MonitorConfig *mconfig)
 {
 	char *channels[] = { "log", "state", NULL };
+	char postgresUri[MAXCONNINFO];
+
+	/* We exit the loop if we can't get monitor to be running during the start */
+	if (!ensure_monitor_pg_running(monitor, mconfig))
+	{
+		/* errors were already logged */
+		log_warn("Failed to ensure PostgreSQL is running, exiting the service");
+		return false;
+	}
+
+	/* Now get the the Monitor URI to display it to the user, and move along */
+	if (monitor_config_get_postgres_uri(mconfig, postgresUri, MAXCONNINFO))
+	{
+		log_info("pg_auto_failover monitor is ready at %s", postgresUri);
+	}
 
 	log_info("Contacting the monitor to LISTEN to its events.");
 	pgsql_listen(&(monitor->pgsql), channels);
@@ -1881,6 +1942,13 @@ monitor_listen_loop(Monitor *monitor)
 	 */
 	for (;;)
 	{
+		if (!ensure_monitor_pg_running(monitor, mconfig))
+		{
+			log_warn("Failed to ensure PostgreSQL is running, retrying in %d seconds", PG_AUTOCTL_MONITOR_SLEEP_TIME);
+			sleep(PG_AUTOCTL_MONITOR_SLEEP_TIME);
+			continue;
+		}
+
 		if (!monitor_get_notifications(monitor))
 		{
 			log_warn("Re-establishing connection. We might miss notifications.");

--- a/src/bin/pg_autoctl/monitor.h
+++ b/src/bin/pg_autoctl/monitor.h
@@ -12,6 +12,7 @@
 
 
 #include "pgsql.h"
+#include "monitor_config.h"
 #include "state.h"
 
 
@@ -104,8 +105,8 @@ bool monitor_get_extension_version(Monitor *monitor,
 bool monitor_extension_update(Monitor *monitor, const char *targetVersion);
 bool monitor_ensure_extension_version(Monitor *monitor,
 									  MonitorExtensionVersion *version);
-
-bool monitor_listen_loop(Monitor *monitor);
+bool ensure_monitor_pg_running(Monitor *monitor, struct MonitorConfig *mconfig);
+bool monitor_service_run(Monitor *monitor, struct MonitorConfig *mconfig);
 
 
 #endif /* MONITOR_H */

--- a/src/bin/pg_autoctl/monitor_config.c
+++ b/src/bin/pg_autoctl/monitor_config.c
@@ -177,8 +177,7 @@ monitor_config_init(MonitorConfig *config,
  * `pg_autoctl do destroy`.
  */
 bool
-monitor_config_init_from_pgsetup(Monitor *monitor,
-								 MonitorConfig *mconfig,
+monitor_config_init_from_pgsetup(MonitorConfig *mconfig,
 								 PostgresSetup *pgSetup,
 								 bool missingPgdataIsOk,
 								 bool pgIsNotRunningIsOk)

--- a/src/bin/pg_autoctl/monitor_config.h
+++ b/src/bin/pg_autoctl/monitor_config.h
@@ -37,8 +37,7 @@ bool monitor_config_set_pathnames_from_pgdata(MonitorConfig *config);
 void monitor_config_init(MonitorConfig *config,
 						 bool missing_pgdata_is_ok,
 						 bool pg_is_not_running_is_ok);
-bool monitor_config_init_from_pgsetup(Monitor *monitor,
-									  MonitorConfig *mconfig,
+bool monitor_config_init_from_pgsetup(MonitorConfig *mconfig,
 									  PostgresSetup *pgSetup,
 									  bool missingPgdataIsOk,
 									  bool pgIsNotRunningIsOk);

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,6 +1,5 @@
 import pgautofailover_utils as pgautofailover
 from nose.tools import *
-import time
 
 cluster = None
 node1 = None
@@ -34,7 +33,7 @@ def test_003_init_secondary():
     global node2
     node2 = cluster.create_datanode("/tmp/auth/node2", authMethod="md5")
     node2.create()
-    # no need to set passwords here because it will be inherited prom the primary
+    # no need to set passwords here because it will be inherited from the primary
     node2.run()
     assert node2.wait_until_state(target_state="secondary")
     assert node1.wait_until_state(target_state="primary")

--- a/tests/test_basic_operation.py
+++ b/tests/test_basic_operation.py
@@ -17,6 +17,7 @@ def teardown_module():
 def test_000_create_monitor():
     global monitor
     monitor = cluster.create_monitor("/tmp/basic/monitor")
+    monitor.run()
 
 def test_001_init_primary():
     global node1
@@ -124,3 +125,9 @@ def test_016_drop_primary():
    node2.drop()
    assert not node2.pg_is_running()
    assert node3.wait_until_state(target_state="single")
+
+def test_017_stop_postgres_monitor():
+    original_state = node3.get_state()
+    monitor.stop_postgres()
+    monitor.wait_until_pg_is_running()
+    assert node3.wait_until_state(target_state=original_state)

--- a/tests/test_extension_update.py
+++ b/tests/test_extension_update.py
@@ -20,11 +20,11 @@ def test_000_create_monitor():
 def test_001_update_extension():
     os.environ["PG_AUTOCTL_DEBUG"] = '1'
     os.environ["PG_AUTOCTL_EXTENSION_VERSION"] = 'dummy'
+    cluster.monitor.stop_postgres()
+
     cluster.monitor.run()
 
-    # we need to allow some time for the pg_autctl run command to start and
-    # execute ALTER EXTENSION ... UPDATE TO ...
-    time.sleep(1)
+    cluster.monitor.wait_until_pg_is_running()
 
     results = cluster.monitor.run_sql_query(
         """SELECT installed_version
@@ -32,5 +32,3 @@ def test_001_update_extension():
             WHERE name = 'pgautofailover'
         """)
     assert results == [('dummy',)]
-
-


### PR DESCRIPTION
Keeper now checks the state of monitor and restart it if it is found to be not active.

Fixes :  #86
