### PR TITLE
Refrain from using PGDATA as the systemd service WorkingDirectory.

### DIFF
--- a/src/bin/pg_autoctl/cli_systemd.c
+++ b/src/bin/pg_autoctl/cli_systemd.c
@@ -29,7 +29,6 @@ static SystemdServiceConfig systemdOptions;
 
 
 static int cli_systemd_getopt(int argc, char **argv);
-static void cli_systemd_enable_service(int argc, char **argv);
 static void cli_systemd_cat_service_file(int argc, char **argv);
 
 /* pg_autoctl show systemd, see cli_show.c */


### PR DESCRIPTION
In normal operations we might remove or replace PGDATA, when doing a full pg_basebackup for instance, during a failover. It turns out that systemd doesn't like that.

Instead of using PGDATA as the WorkingDirectory we can use the User home directory instead. That should be safe.