### PR TITLE
Implement --json for (almost) all commands.

### DIFF
--- a/src/bin/pg_autoctl/Makefile
+++ b/src/bin/pg_autoctl/Makefile
@@ -25,7 +25,7 @@ COMMON_LIBS += -I${SRC_DIR}../lib/parson/
 
 CC = $(shell $(PG_CONFIG) --cc)
 
-CFLAGS = -std=c99 -D_GNU_SOURCE
+CFLAGS = -std=c99 -D_GNU_SOURCE -g
 CFLAGS += -I $(shell $(PG_CONFIG) --includedir)
 CFLAGS += -I $(shell $(PG_CONFIG) --includedir-server)
 CFLAGS += -I $(shell $(PG_CONFIG) --pkgincludedir)/internal

--- a/src/bin/pg_autoctl/cli_common.c
+++ b/src/bin/pg_autoctl/cli_common.c
@@ -31,6 +31,7 @@
 KeeperConfig keeperOptions;
 bool allowRemovingPgdata = false;
 bool createAndRun = false;
+bool outputJSON = false;
 
 
 /*
@@ -408,7 +409,7 @@ cli_create_node_getopts(int argc, char **argv,
  * allows to determine where is our configuration file.
  */
 int
-keeper_cli_getopt_pgdata(int argc, char **argv)
+cli_getopt_pgdata(int argc, char **argv)
 {
 	KeeperConfig options = { 0 };
 	int c, option_index = 0, errors = 0;
@@ -416,6 +417,7 @@ keeper_cli_getopt_pgdata(int argc, char **argv)
 
 	static struct option long_options[] = {
 		{ "pgdata", required_argument, NULL, 'D' },
+		{ "json", no_argument, NULL, 'J' },
 		{ "version", no_argument, NULL, 'V' },
 		{ "verbose", no_argument, NULL, 'v' },
 		{ "quiet", no_argument, NULL, 'q' },
@@ -434,7 +436,7 @@ keeper_cli_getopt_pgdata(int argc, char **argv)
 	 */
 	unsetenv("POSIXLY_CORRECT");
 
-	while ((c = getopt_long(argc, argv, "D:Vvqh",
+	while ((c = getopt_long(argc, argv, "D:JVvqh",
 							long_options, &option_index)) != -1)
 	{
 		switch (c)
@@ -443,6 +445,13 @@ keeper_cli_getopt_pgdata(int argc, char **argv)
 			{
 				strlcpy(options.pgSetup.pgdata, optarg, MAXPGPATH);
 				log_trace("--pgdata %s", options.pgSetup.pgdata);
+				break;
+			}
+
+			case 'J':
+			{
+				outputJSON = true;
+				log_trace("--json");
 				break;
 			}
 

--- a/src/bin/pg_autoctl/cli_common.c
+++ b/src/bin/pg_autoctl/cli_common.c
@@ -784,3 +784,22 @@ keeper_cli_print_version(int argc, char **argv)
 	fprintf(stdout, "pg_autoctl version %s\n", PG_AUTOCTL_VERSION);
 	exit(0);
 }
+
+
+/*
+ * cli_pprint_json pretty prints the given JSON value to stdout and frees the
+ * JSON related memory.
+ */
+void
+cli_pprint_json(JSON_Value *js)
+{
+	char *serialized_string;
+
+	/* output our nice JSON object, pretty printed please */
+	serialized_string = json_serialize_to_string_pretty(js);
+	fprintf(stdout, "%s\n", serialized_string);
+
+	/* free intermediate memory */
+	json_free_serialized_string(serialized_string);
+	json_value_free(js);
+}

--- a/src/bin/pg_autoctl/cli_common.h
+++ b/src/bin/pg_autoctl/cli_common.h
@@ -22,6 +22,8 @@ extern MonitorConfig monitorOptions;
 extern KeeperConfig keeperOptions;
 extern bool allowRemovingPgdata;
 extern bool createAndRun;
+extern bool outputJSON;
+
 
 #define KEEPER_CLI_WORKER_SETUP_OPTIONS \
 	"  --pgctl       path to pg_ctl\n" \
@@ -53,8 +55,10 @@ extern bool createAndRun;
 #define KEEPER_CLI_ALLOW_RM_PGDATA_OPTION \
 	"  --allow-removing-pgdata Allow pg_autoctl to remove the database directory\n"
 
-#define KEEPER_CLI_PGDATA_OPTION \
+#define CLI_PGDATA_OPTION \
 	"  --pgdata      path to data directory\n" \
+
+#define CLI_PGDATA_USAGE " [ --pgdata ] [ --json ] "
 
 
 /* cli_do.c */
@@ -108,7 +112,7 @@ int cli_create_node_getopts(int argc, char **argv,
 							struct option *long_options,
 							const char *optstring,
 							KeeperConfig *options);
-int keeper_cli_getopt_pgdata(int argc, char **argv);
+int cli_getopt_pgdata(int argc, char **argv);
 void prepare_keeper_options(KeeperConfig *options);
 
 void set_first_pgctl(PostgresSetup *pgSetup);

--- a/src/bin/pg_autoctl/cli_common.h
+++ b/src/bin/pg_autoctl/cli_common.h
@@ -107,6 +107,7 @@ extern CommandLine systemd_cat_service_file_command;
 
 void keeper_cli_help(int argc, char **argv);
 void keeper_cli_print_version(int argc, char **argv);
+void cli_pprint_json(JSON_Value *js);
 
 int cli_create_node_getopts(int argc, char **argv,
 							struct option *long_options,

--- a/src/bin/pg_autoctl/cli_do_monitor.c
+++ b/src/bin/pg_autoctl/cli_do_monitor.c
@@ -163,7 +163,6 @@ cli_do_monitor_get_primary_node(int argc, char **argv)
 	/* output something easy to parse by another program */
 	if (outputJSON)
 	{
-		char *serialized_string = NULL;
 		JSON_Value *js = json_value_init_object();
 		JSON_Object *root = json_value_get_object(js);
 
@@ -172,12 +171,7 @@ cli_do_monitor_get_primary_node(int argc, char **argv)
 		json_object_set_string(root, "host", primaryNode.host);
 		json_object_set_number(root, "port", (double) primaryNode.port);
 
-		serialized_string = json_serialize_to_string_pretty(js);
-
-		fprintf(stdout, "%s\n", serialized_string);
-
-		json_free_serialized_string(serialized_string);
-		json_value_free(js);
+		(void) cli_pprint_json(js);
 	}
 	else
 	{
@@ -234,7 +228,6 @@ cli_do_monitor_get_other_node(int argc, char **argv)
 	/* output something easy to parse by another program */
 	if (outputJSON)
 	{
-		char *serialized_string = NULL;
 		JSON_Value *js = json_value_init_object();
 		JSON_Object *root = json_value_get_object(js);
 
@@ -243,12 +236,7 @@ cli_do_monitor_get_other_node(int argc, char **argv)
 		json_object_set_string(root, "host", otherNode.host);
 		json_object_set_number(root, "port", (double) otherNode.port);
 
-		serialized_string = json_serialize_to_string_pretty(js);
-
-		fprintf(stdout, "%s\n", serialized_string);
-
-		json_free_serialized_string(serialized_string);
-		json_value_free(js);
+		(void) cli_pprint_json(js);
 	}
 	else
 	{
@@ -307,7 +295,6 @@ cli_do_monitor_get_coordinator(int argc, char **argv)
 	/* output something easy to parse by another program */
 	if (outputJSON)
 	{
-		char *serialized_string = NULL;
 		JSON_Value *js = json_value_init_object();
 		JSON_Object *root = json_value_get_object(js);
 
@@ -316,12 +303,7 @@ cli_do_monitor_get_coordinator(int argc, char **argv)
 		json_object_set_string(root, "host", coordinatorNode.host);
 		json_object_set_number(root, "port", (double) coordinatorNode.port);
 
-		serialized_string = json_serialize_to_string_pretty(js);
-
-		fprintf(stdout, "%s\n", serialized_string);
-
-		json_free_serialized_string(serialized_string);
-		json_value_free(js);
+		(void) cli_pprint_json(js);
 	}
 	else
 	{
@@ -419,7 +401,6 @@ cli_do_monitor_register_node(int argc, char **argv)
 	/* output something easy to parse by another program */
 	if (outputJSON)
 	{
-		char *serialized_string = NULL;
 		JSON_Value *js = json_value_init_object();
 		JSON_Object *root = json_value_get_object(js);
 
@@ -433,12 +414,7 @@ cli_do_monitor_register_node(int argc, char **argv)
 		json_object_set_string(root, "assigned_role",
 							   NodeStateToString(keeper.state.assigned_role));
 
-		serialized_string = json_serialize_to_string_pretty(js);
-
-		fprintf(stdout, "%s\n", serialized_string);
-
-		json_free_serialized_string(serialized_string);
-		json_value_free(js);
+		(void) cli_pprint_json(js);
 	}
 	else
 	{
@@ -521,7 +497,6 @@ cli_do_monitor_node_active(int argc, char **argv)
 	/* output something easy to parse by another program */
 	if (outputJSON)
 	{
-		char *serialized_string = NULL;
 		JSON_Value *js = json_value_init_object();
 		JSON_Object *root = json_value_get_object(js);
 
@@ -534,12 +509,7 @@ cli_do_monitor_node_active(int argc, char **argv)
 							   "assigned_role",
 							   NodeStateToString(assignedState.state));
 
-		serialized_string = json_serialize_to_string_pretty(js);
-
-		fprintf(stdout, "%s\n", serialized_string);
-
-		json_free_serialized_string(serialized_string);
-		json_value_free(js);
+		(void) cli_pprint_json(js);
 	}
 	else
 	{

--- a/src/bin/pg_autoctl/cli_enable_disable.c
+++ b/src/bin/pg_autoctl/cli_enable_disable.c
@@ -49,17 +49,17 @@ static CommandLine disable_secondary_command =
 static CommandLine enable_maintenance_command =
 	make_command("maintenance",
 				 "Enable Postgres maintenance mode on this node",
-				 " [ --pgdata ]",
-				 KEEPER_CLI_PGDATA_OPTION,
-				 keeper_cli_getopt_pgdata,
+				 CLI_PGDATA_USAGE,
+				 CLI_PGDATA_OPTION,
+				 cli_getopt_pgdata,
 				 cli_enable_maintenance);
 
 static CommandLine disable_maintenance_command =
 	make_command("maintenance",
 				 "Disable Postgres maintenance mode on this node",
-				 " [ --pgdata ]",
-				 KEEPER_CLI_PGDATA_OPTION,
-				 keeper_cli_getopt_pgdata,
+				 CLI_PGDATA_USAGE,
+				 CLI_PGDATA_OPTION,
+				 cli_getopt_pgdata,
 				 cli_disable_maintenance);
 
 static CommandLine *enable_subcommands[] = {
@@ -233,8 +233,9 @@ cli_enable_secondary(int argc, char **argv)
 		exit(EXIT_CODE_MONITOR);
 	}
 
-	log_info("Enabled secondaries for formation \"%s\", make sure to add worker nodes "
-			 "to the formation to have secondaries ready for failover.",
+	log_info("Enabled secondaries for formation \"%s\", make sure to add "
+			 "worker nodes to the formation to have secondaries ready "
+			 "for failover.",
 			 config.formation);
 }
 
@@ -255,10 +256,11 @@ cli_disable_secondary(int argc, char **argv)
 	}
 
 	/*
-	 * disabling secondaries on a formation happens on the monitor. When the formation is
-	 * still operating with secondaries an error will be logged and the function will
-	 * return with a false value. As we will exit the successful info message below is
-	 * only printed if secondaries on the formation have been disabled successfully.
+	 * disabling secondaries on a formation happens on the monitor. When the
+	 * formation is still operating with secondaries an error will be logged
+	 * and the function will return with a false value. As we will exit the
+	 * successful info message below is only printed if secondaries on the
+	 * formation have been disabled successfully.
 	 */
 	if (!monitor_disable_secondary_for_formation(&monitor, config.formation))
 	{

--- a/src/bin/pg_autoctl/cli_get_set_properties.c
+++ b/src/bin/pg_autoctl/cli_get_set_properties.c
@@ -1,3 +1,13 @@
+/*
+ * src/bin/pg_autoctl/cli_get_set_properties.c
+ *     Implementation of a CLI to get and set properties managed by the
+ *     pg_auto_failover monitor.
+ *
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the PostgreSQL License.
+ *
+ */
+#include "parson.h"
 
 #include "cli_common.h"
 #include "parsing.h"
@@ -13,17 +23,17 @@ static void cli_set_formation_property(int arc, char **argv);
 CommandLine get_node_replication_quorum =
 	make_command("replication-quorum",
 				 "get replication-quorum property for a node from the pg_auto_failover monitor",
-				 " [ --pgdata ]",
-				 KEEPER_CLI_PGDATA_OPTION,
-				 keeper_cli_getopt_pgdata,
+				 CLI_PGDATA_USAGE,
+				 CLI_PGDATA_OPTION,
+				 cli_getopt_pgdata,
 				 cli_get_node_replication_quorum);
 
 CommandLine get_node_candidate_priority =
 	make_command("candidate-priority",
 				 "get candidate property for a node from the pg_auto_failover monitor",
-				 " [ --pgdata ]",
-				 KEEPER_CLI_PGDATA_OPTION,
-				 keeper_cli_getopt_pgdata,
+				 CLI_PGDATA_USAGE,
+				 CLI_PGDATA_OPTION,
+				 cli_getopt_pgdata,
 				 cli_get_node_candidate_priority);
 
 
@@ -42,9 +52,9 @@ CommandLine get_node_command =
 CommandLine get_formation_number_sync_standbys =
 	make_command("number-sync-standbys",
 				 "get number_sync_standbys for a formation from the pg_auto_failover monitor",
-				 " [ --pgdata ]",
-				 KEEPER_CLI_PGDATA_OPTION,
-				 keeper_cli_getopt_pgdata,
+				 CLI_PGDATA_USAGE,
+				 CLI_PGDATA_OPTION,
+				 cli_getopt_pgdata,
 				 cli_get_formation_number_sync_standbys);
 
 static CommandLine *get_formation_subcommands[] = {
@@ -74,17 +84,17 @@ CommandLine get_commands =
 CommandLine set_node_command =
 	make_command("node",
 				 "set a property for a node at the pg_auto_failover monitor",
-				 " [ --pgdata ] { candidate-priority | replication-quorum } value",
-				 KEEPER_CLI_PGDATA_OPTION,
-				 keeper_cli_getopt_pgdata,
+				 CLI_PGDATA_USAGE "{ candidate-priority | replication-quorum } value",
+				 CLI_PGDATA_OPTION,
+				 cli_getopt_pgdata,
 				 cli_set_node_property);
 
 CommandLine set_formation_command =
 	make_command("formation",
 				 "set a property for a formation the pg_auto_failover monitor",
-				 " [ --pgdata ] { number-sync-standbys }  value",
-				 KEEPER_CLI_PGDATA_OPTION,
-				 keeper_cli_getopt_pgdata,
+				 CLI_PGDATA_USAGE "{ number-sync-standbys }  value",
+				 CLI_PGDATA_OPTION,
+				 cli_getopt_pgdata,
 				 cli_set_formation_property);
 
 static CommandLine *set_subcommands[] = {
@@ -164,7 +174,27 @@ cli_get_node_replication_quorum(int argc, char **argv)
 		exit(EXIT_CODE_MONITOR);
 	}
 
-	fprintf(stdout, "%s\n", boolToString(settings.replicationQuorum));
+	if (outputJSON)
+	{
+		char *serialized_string = NULL;
+		JSON_Value *js = json_value_init_object();
+		JSON_Object *jsObj = json_value_get_object(js);
+
+		json_object_set_boolean(jsObj,
+								"replication-quorum",
+								settings.replicationQuorum);
+
+		serialized_string = json_serialize_to_string_pretty(js);
+
+		fprintf(stdout, "%s\n", serialized_string);
+
+		json_free_serialized_string(serialized_string);
+		json_value_free(js);
+	}
+	else
+	{
+		fprintf(stdout, "%s\n", boolToString(settings.replicationQuorum));
+	}
 }
 
 
@@ -183,7 +213,27 @@ cli_get_node_candidate_priority(int argc, char **argv)
 		exit(EXIT_CODE_MONITOR);
 	}
 
-	fprintf(stdout, "%d\n", settings.candidatePriority);
+	if (outputJSON)
+	{
+		char *serialized_string = NULL;
+		JSON_Value *js = json_value_init_object();
+		JSON_Object *jsObj = json_value_get_object(js);
+
+		json_object_set_number(jsObj,
+								"candidate-priority",
+							   (double) settings.candidatePriority);
+
+		serialized_string = json_serialize_to_string_pretty(js);
+
+		fprintf(stdout, "%s\n", serialized_string);
+
+		json_free_serialized_string(serialized_string);
+		json_value_free(js);
+	}
+	else
+	{
+		fprintf(stdout, "%d\n", settings.candidatePriority);
+	}
 }
 
 
@@ -231,7 +281,27 @@ cli_get_formation_number_sync_standbys(int argc, char **argv)
 		exit(EXIT_CODE_MONITOR);
 	}
 
-	fprintf(stdout, "%d\n", numberSyncStandbys);
+	if (outputJSON)
+	{
+		char *serialized_string = NULL;
+		JSON_Value *js = json_value_init_object();
+		JSON_Object *jsObj = json_value_get_object(js);
+
+		json_object_set_number(jsObj,
+							   "number-sync-standbys",
+							   (double) numberSyncStandbys);
+
+		serialized_string = json_serialize_to_string_pretty(js);
+
+		fprintf(stdout, "%s\n", serialized_string);
+
+		json_free_serialized_string(serialized_string);
+		json_value_free(js);
+	}
+	else
+	{
+		fprintf(stdout, "%d\n", numberSyncStandbys);
+	}
 }
 
 
@@ -332,7 +402,27 @@ cli_set_node_property(int argc, char **argv)
 			exit(EXIT_CODE_MONITOR);
 		}
 
-		fprintf(stdout, "%s\n", boolToString(replicationQuorum));
+		if (outputJSON)
+		{
+			char *serialized_string = NULL;
+			JSON_Value *js = json_value_init_object();
+			JSON_Object *jsObj = json_value_get_object(js);
+
+			json_object_set_boolean(jsObj,
+									"replication-quorum",
+									replicationQuorum);
+
+			serialized_string = json_serialize_to_string_pretty(js);
+
+			fprintf(stdout, "%s\n", serialized_string);
+
+			json_free_serialized_string(serialized_string);
+			json_value_free(js);
+		}
+		else
+		{
+			fprintf(stdout, "%s\n", boolToString(replicationQuorum));
+		}
 	}
 	else
 	{
@@ -419,5 +509,25 @@ cli_set_formation_property(int argc, char **argv)
 		exit(EXIT_CODE_MONITOR);
 	}
 
-	fprintf(stdout, "%d\n", numberSyncStandbys);
+	if (outputJSON)
+	{
+		char *serialized_string = NULL;
+		JSON_Value *js = json_value_init_object();
+		JSON_Object *jsObj = json_value_get_object(js);
+
+		json_object_set_number(jsObj,
+							   "number-sync-standbys",
+							   (double) numberSyncStandbys);
+
+		serialized_string = json_serialize_to_string_pretty(js);
+
+		fprintf(stdout, "%s\n", serialized_string);
+
+		json_free_serialized_string(serialized_string);
+		json_value_free(js);
+	}
+	else
+	{
+		fprintf(stdout, "%d\n", numberSyncStandbys);
+	}
 }

--- a/src/bin/pg_autoctl/cli_get_set_properties.c
+++ b/src/bin/pg_autoctl/cli_get_set_properties.c
@@ -176,7 +176,6 @@ cli_get_node_replication_quorum(int argc, char **argv)
 
 	if (outputJSON)
 	{
-		char *serialized_string = NULL;
 		JSON_Value *js = json_value_init_object();
 		JSON_Object *jsObj = json_value_get_object(js);
 
@@ -184,12 +183,7 @@ cli_get_node_replication_quorum(int argc, char **argv)
 								"replication-quorum",
 								settings.replicationQuorum);
 
-		serialized_string = json_serialize_to_string_pretty(js);
-
-		fprintf(stdout, "%s\n", serialized_string);
-
-		json_free_serialized_string(serialized_string);
-		json_value_free(js);
+		(void) cli_pprint_json(js);
 	}
 	else
 	{
@@ -215,7 +209,6 @@ cli_get_node_candidate_priority(int argc, char **argv)
 
 	if (outputJSON)
 	{
-		char *serialized_string = NULL;
 		JSON_Value *js = json_value_init_object();
 		JSON_Object *jsObj = json_value_get_object(js);
 
@@ -223,12 +216,7 @@ cli_get_node_candidate_priority(int argc, char **argv)
 								"candidate-priority",
 							   (double) settings.candidatePriority);
 
-		serialized_string = json_serialize_to_string_pretty(js);
-
-		fprintf(stdout, "%s\n", serialized_string);
-
-		json_free_serialized_string(serialized_string);
-		json_value_free(js);
+		(void) cli_pprint_json(js);
 	}
 	else
 	{
@@ -283,7 +271,6 @@ cli_get_formation_number_sync_standbys(int argc, char **argv)
 
 	if (outputJSON)
 	{
-		char *serialized_string = NULL;
 		JSON_Value *js = json_value_init_object();
 		JSON_Object *jsObj = json_value_get_object(js);
 
@@ -291,12 +278,7 @@ cli_get_formation_number_sync_standbys(int argc, char **argv)
 							   "number-sync-standbys",
 							   (double) numberSyncStandbys);
 
-		serialized_string = json_serialize_to_string_pretty(js);
-
-		fprintf(stdout, "%s\n", serialized_string);
-
-		json_free_serialized_string(serialized_string);
-		json_value_free(js);
+		(void) cli_pprint_json(js);
 	}
 	else
 	{
@@ -404,7 +386,6 @@ cli_set_node_property(int argc, char **argv)
 
 		if (outputJSON)
 		{
-			char *serialized_string = NULL;
 			JSON_Value *js = json_value_init_object();
 			JSON_Object *jsObj = json_value_get_object(js);
 
@@ -412,12 +393,7 @@ cli_set_node_property(int argc, char **argv)
 									"replication-quorum",
 									replicationQuorum);
 
-			serialized_string = json_serialize_to_string_pretty(js);
-
-			fprintf(stdout, "%s\n", serialized_string);
-
-			json_free_serialized_string(serialized_string);
-			json_value_free(js);
+			(void) cli_pprint_json(js);
 		}
 		else
 		{
@@ -511,7 +487,6 @@ cli_set_formation_property(int argc, char **argv)
 
 	if (outputJSON)
 	{
-		char *serialized_string = NULL;
 		JSON_Value *js = json_value_init_object();
 		JSON_Object *jsObj = json_value_get_object(js);
 
@@ -519,12 +494,7 @@ cli_set_formation_property(int argc, char **argv)
 							   "number-sync-standbys",
 							   (double) numberSyncStandbys);
 
-		serialized_string = json_serialize_to_string_pretty(js);
-
-		fprintf(stdout, "%s\n", serialized_string);
-
-		json_free_serialized_string(serialized_string);
-		json_value_free(js);
+		(void) cli_pprint_json(js);
 	}
 	else
 	{

--- a/src/bin/pg_autoctl/cli_service.c
+++ b/src/bin/pg_autoctl/cli_service.c
@@ -39,9 +39,9 @@ static void cli_service_stop(int argc, char **argv);
 CommandLine service_run_command =
 	make_command("run",
 				 "Run the pg_autoctl service (monitor or keeper)",
-				 " [ --pgdata ]",
-				 KEEPER_CLI_PGDATA_OPTION,
-				 keeper_cli_getopt_pgdata,
+				 CLI_PGDATA_USAGE,
+				 CLI_PGDATA_OPTION,
+				 cli_getopt_pgdata,
 				 cli_service_run);
 
 CommandLine service_stop_command =
@@ -57,9 +57,9 @@ CommandLine service_stop_command =
 CommandLine service_reload_command =
 	make_command("reload",
 				 "signal the pg_autoctl for it to reload its configuration",
-				 " [ --pgdata ]",
-				 KEEPER_CLI_PGDATA_OPTION,
-				 keeper_cli_getopt_pgdata,
+				 CLI_PGDATA_USAGE,
+				 CLI_PGDATA_OPTION,
+				 cli_getopt_pgdata,
 				 cli_service_reload);
 
 

--- a/src/bin/pg_autoctl/cli_show.c
+++ b/src/bin/pg_autoctl/cli_show.c
@@ -29,7 +29,6 @@
 #include "state.h"
 
 static int eventCount = 10;
-static bool outputJSON = false;
 
 static int cli_show_state_getopts(int argc, char **argv);
 static void cli_show_state(int argc, char **argv);

--- a/src/bin/pg_autoctl/ini_file.h
+++ b/src/bin/pg_autoctl/ini_file.h
@@ -13,6 +13,8 @@
 #include <stdbool.h>
 #include <stdio.h>
 
+#include "parson.h"
+
 #define INI_STRING_T 1          /* char *target */
 #define INI_STRBUF_T 2          /* char target[size] */
 #define INI_INT_T 3             /* int target */
@@ -89,6 +91,7 @@ bool ini_validate_options(IniOption *optionList);
 bool ini_set_option_value(IniOption *option, const char *value);
 bool ini_option_to_string(IniOption *option, char *dest, size_t size);
 bool write_ini_to_stream(FILE *stream, IniOption *optionList);
+bool ini_to_json(JSON_Object *jsRoot, IniOption *optionList);
 IniOption * lookup_ini_option(IniOption *optionList,
 							  const char *section, const char *name);
 IniOption * lookup_ini_path_value(IniOption *optionList, const char *path);

--- a/src/bin/pg_autoctl/keeper.c
+++ b/src/bin/pg_autoctl/keeper.c
@@ -1038,18 +1038,16 @@ keeper_state_as_json(Keeper *keeper, char *json, int size)
     JSON_Value *jsPostgres = json_value_init_object();
     JSON_Value *jsKeeperState = json_value_init_object();
 
-    JSON_Object *root = json_value_get_object(js);
-    JSON_Object *jsPostgresObject = json_value_get_object(jsPostgres);
-    JSON_Object *jsKeeperStateObject = json_value_get_object(jsKeeperState);
+	JSON_Object *jsRoot = json_value_get_object(js);
 
     char *serialized_string = NULL;
 	int len;
 
-	pg_setup_as_json(&(keeper->postgres.postgresSetup), jsPostgresObject);
-	keeperStateAsJSON(&(keeper->state), jsKeeperStateObject);
+	pg_setup_as_json(&(keeper->postgres.postgresSetup), jsPostgres);
+	keeperStateAsJSON(&(keeper->state), jsKeeperState);
 
-    json_object_set_value(root, "postgres", jsPostgres);
-    json_object_set_value(root, "state", jsKeeperState);
+    json_object_set_value(jsRoot, "postgres", jsPostgres);
+    json_object_set_value(jsRoot, "state", jsKeeperState);
 
     serialized_string = json_serialize_to_string_pretty(js);
 

--- a/src/bin/pg_autoctl/keeper_config.c
+++ b/src/bin/pg_autoctl/keeper_config.c
@@ -408,6 +408,20 @@ keeper_config_write(FILE *stream, KeeperConfig *config)
 
 
 /*
+ * keeper_config_to_json populates given jsRoot object with the INI
+ * configuration sections as JSON objects, and the options as keys to those
+ * objects.
+ */
+bool
+keeper_config_to_json(JSON_Object *jsRoot, KeeperConfig *config)
+{
+	IniOption keeperOptions[] = SET_INI_OPTIONS_ARRAY(config);
+
+	return ini_to_json(jsRoot, keeperOptions);
+}
+
+
+/*
  * keeper_config_log_settings outputs a DEBUG line per each config parameter in
  * the given KeeperConfig.
  */

--- a/src/bin/pg_autoctl/keeper_config.c
+++ b/src/bin/pg_autoctl/keeper_config.c
@@ -413,8 +413,9 @@ keeper_config_write(FILE *stream, KeeperConfig *config)
  * objects.
  */
 bool
-keeper_config_to_json(JSON_Object *jsRoot, KeeperConfig *config)
+keeper_config_to_json(KeeperConfig *config, JSON_Value *js)
 {
+	JSON_Object *jsRoot = json_value_get_object(js);
 	IniOption keeperOptions[] = SET_INI_OPTIONS_ARRAY(config);
 
 	return ini_to_json(jsRoot, keeperOptions);

--- a/src/bin/pg_autoctl/keeper_config.h
+++ b/src/bin/pg_autoctl/keeper_config.h
@@ -70,6 +70,7 @@ bool keeper_config_pgsetup_init(KeeperConfig *config,
 								bool pgIsNotRunningIsOk);
 bool keeper_config_write_file(KeeperConfig *config);
 bool keeper_config_write(FILE *stream, KeeperConfig *config);
+bool keeper_config_to_json(JSON_Object *jsRoot, KeeperConfig *config);
 void keeper_config_log_settings(KeeperConfig config);
 
 bool keeper_config_get_setting(KeeperConfig *config,

--- a/src/bin/pg_autoctl/keeper_config.h
+++ b/src/bin/pg_autoctl/keeper_config.h
@@ -70,7 +70,7 @@ bool keeper_config_pgsetup_init(KeeperConfig *config,
 								bool pgIsNotRunningIsOk);
 bool keeper_config_write_file(KeeperConfig *config);
 bool keeper_config_write(FILE *stream, KeeperConfig *config);
-bool keeper_config_to_json(JSON_Object *jsRoot, KeeperConfig *config);
+bool keeper_config_to_json(KeeperConfig *config, JSON_Value *js);
 void keeper_config_log_settings(KeeperConfig config);
 
 bool keeper_config_get_setting(KeeperConfig *config,

--- a/src/bin/pg_autoctl/monitor_config.c
+++ b/src/bin/pg_autoctl/monitor_config.c
@@ -302,6 +302,20 @@ monitor_config_write(FILE *stream, MonitorConfig *config)
 
 
 /*
+ * monitor_config_to_json populates given jsRoot object with the INI
+ * configuration sections as JSON objects, and the options as keys to those
+ * objects.
+ */
+bool
+monitor_config_to_json(JSON_Object *jsRoot, MonitorConfig *config)
+{
+	IniOption monitorOptions[] = SET_INI_OPTIONS_ARRAY(config);
+
+	return ini_to_json(jsRoot, monitorOptions);
+}
+
+
+/*
  * monitor_config_log_settings outputs a DEBUG line per each config parameter
  * in the given MonitorConfig.
  */

--- a/src/bin/pg_autoctl/monitor_config.c
+++ b/src/bin/pg_autoctl/monitor_config.c
@@ -307,8 +307,9 @@ monitor_config_write(FILE *stream, MonitorConfig *config)
  * objects.
  */
 bool
-monitor_config_to_json(JSON_Object *jsRoot, MonitorConfig *config)
+monitor_config_to_json(MonitorConfig *config, JSON_Value *js)
 {
+	JSON_Object *jsRoot = json_value_get_object(js);
 	IniOption monitorOptions[] = SET_INI_OPTIONS_ARRAY(config);
 
 	return ini_to_json(jsRoot, monitorOptions);

--- a/src/bin/pg_autoctl/monitor_config.h
+++ b/src/bin/pg_autoctl/monitor_config.h
@@ -15,6 +15,7 @@
 
 #include "config.h"
 #include "pgctl.h"
+#include "parson.h"
 #include "pgsql.h"
 
 typedef struct MonitorConfig
@@ -46,6 +47,7 @@ bool monitor_config_read_file(MonitorConfig *config,
 							  bool pg_not_running_is_ok);
 bool monitor_config_write_file(MonitorConfig *config);
 bool monitor_config_write(FILE *stream, MonitorConfig *config);
+bool monitor_config_to_json(JSON_Object *jsRoot, MonitorConfig *config);
 void monitor_config_log_settings(MonitorConfig config);
 bool monitor_config_merge_options(MonitorConfig *config,
 								  MonitorConfig *options);

--- a/src/bin/pg_autoctl/monitor_config.h
+++ b/src/bin/pg_autoctl/monitor_config.h
@@ -47,7 +47,7 @@ bool monitor_config_read_file(MonitorConfig *config,
 							  bool pg_not_running_is_ok);
 bool monitor_config_write_file(MonitorConfig *config);
 bool monitor_config_write(FILE *stream, MonitorConfig *config);
-bool monitor_config_to_json(JSON_Object *jsRoot, MonitorConfig *config);
+bool monitor_config_to_json(MonitorConfig *config, JSON_Value *js);
 void monitor_config_log_settings(MonitorConfig config);
 bool monitor_config_merge_options(MonitorConfig *config,
 								  MonitorConfig *options);

--- a/src/bin/pg_autoctl/pgsetup.c
+++ b/src/bin/pg_autoctl/pgsetup.c
@@ -574,8 +574,9 @@ fprintf_pg_setup(FILE *stream, PostgresSetup *pgSetup)
  * representation of the pgSetup.
  */
 bool
-pg_setup_as_json(PostgresSetup *pgSetup, JSON_Object *jsobj)
+pg_setup_as_json(PostgresSetup *pgSetup, JSON_Value *js)
 {
+	JSON_Object *jsobj = json_value_get_object(js);
 	char system_identifier[BUFSIZE];
 
 	json_object_set_string(jsobj, "pgdata", pgSetup->pgdata);

--- a/src/bin/pg_autoctl/pgsetup.h
+++ b/src/bin/pg_autoctl/pgsetup.h
@@ -136,7 +136,7 @@ bool pg_setup_init(PostgresSetup *pgSetup,
 bool read_pg_pidfile(PostgresSetup *pgSetup, bool pg_is_not_running_is_ok);
 
 void fprintf_pg_setup(FILE *stream, PostgresSetup *pgSetup);
-bool pg_setup_as_json(PostgresSetup *pgSetup, JSON_Object *jsobj);
+bool pg_setup_as_json(PostgresSetup *pgSetup, JSON_Value *js);
 
 bool pg_setup_get_local_connection_string(PostgresSetup *pgSetup,
 										  char *connectionString);

--- a/src/bin/pg_autoctl/state.c
+++ b/src/bin/pg_autoctl/state.c
@@ -293,8 +293,9 @@ print_keeper_state(KeeperStateData *keeperState, FILE *stream)
  * keeperStateAsJSON
  */
 bool
-keeperStateAsJSON(KeeperStateData *keeperState, JSON_Object *jsobj)
+keeperStateAsJSON(KeeperStateData *keeperState, JSON_Value *js)
 {
+	JSON_Object *jsobj = json_value_get_object(js);
 	const char *current_role = NodeStateToString(keeperState->current_role);
 	const char *assigned_role = NodeStateToString(keeperState->assigned_role);
 

--- a/src/bin/pg_autoctl/state.h
+++ b/src/bin/pg_autoctl/state.h
@@ -125,7 +125,7 @@ bool keeper_state_write(KeeperStateData *keeperState, const char *filename);
 
 void log_keeper_state(KeeperStateData *keeperState);
 void print_keeper_state(KeeperStateData *keeperState, FILE *fp);
-bool keeperStateAsJSON(KeeperStateData *keeperState, JSON_Object *jsobj);
+bool keeperStateAsJSON(KeeperStateData *keeperState, JSON_Value *js);
 void print_keeper_init_state(KeeperStateInit *initState, FILE *stream);
 
 char *PreInitPostgreInstanceStateToString(PreInitPostgreInstanceState pgInitState);


### PR DESCRIPTION
Have the option parsing for --json implemented in the common function
cli_getopt_pgdata and implement JSON formatted output in (almost) all
commands.