### PR TITLE
Fix/cli perform destroy

### DIFF
--- a/src/bin/pg_autoctl/cli_common.c
+++ b/src/bin/pg_autoctl/cli_common.c
@@ -630,9 +630,13 @@ monitor_init_from_pgsetup(Monitor *monitor, PostgresSetup *pgSetup)
 			char connInfo[MAXCONNINFO];
 			MonitorConfig mconfig = { 0 };
 
-			(void) monitor_config_init_from_pgsetup(&mconfig, pgSetup,
-													missingPgdataIsOk,
-													pgIsNotRunningIsOk);
+			if (!monitor_config_init_from_pgsetup(&mconfig, pgSetup,
+												  missingPgdataIsOk,
+												  pgIsNotRunningIsOk))
+			{
+				/* errors have already been logged */
+				return false;
+			}
 
 			pg_setup_get_local_connection_string(&mconfig.pgSetup, connInfo);
 			monitor_init(monitor, connInfo);

--- a/src/bin/pg_autoctl/cli_common.c
+++ b/src/bin/pg_autoctl/cli_common.c
@@ -501,7 +501,24 @@ keeper_cli_getopt_pgdata(int argc, char **argv)
 		exit(EXIT_CODE_BAD_ARGS);
 	}
 
-	if (IS_EMPTY_STRING_BUFFER(options.pgSetup.pgdata))
+	/* now that we have the command line parameters, prepare the options */
+	(void) prepare_keeper_options(&options);
+
+	/* publish our option parsing in the global variable */
+	keeperOptions = options;
+
+	return optind;
+}
+
+
+/*
+ * prepare_keeper_options finishes the preparation of the keeperOptions that
+ * hosts the command line options.
+ */
+void
+prepare_keeper_options(KeeperConfig *options)
+{
+	if (IS_EMPTY_STRING_BUFFER(options->pgSetup.pgdata))
 	{
 		char *pgdata = getenv("PGDATA");
 
@@ -512,14 +529,14 @@ keeper_cli_getopt_pgdata(int argc, char **argv)
 			exit(EXIT_CODE_BAD_ARGS);
 		}
 
-		strlcpy(options.pgSetup.pgdata, pgdata, MAXPGPATH);
+		strlcpy(options->pgSetup.pgdata, pgdata, MAXPGPATH);
 	}
 
 	log_debug("Managing PostgreSQL installation at \"%s\"",
-			  options.pgSetup.pgdata);
+			  options->pgSetup.pgdata);
 
-	if (!keeper_config_set_pathnames_from_pgdata(&options.pathnames,
-												 options.pgSetup.pgdata))
+	if (!keeper_config_set_pathnames_from_pgdata(&options->pathnames,
+												 options->pgSetup.pgdata))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_BAD_ARGS);
@@ -542,24 +559,19 @@ keeper_cli_getopt_pgdata(int argc, char **argv)
 	 * filename from the PGDATA value. So we're going to go a little out of our
 	 * way and be helpful to the user.
 	 */
-	if (!file_exists(options.pathnames.config))
+	if (!file_exists(options->pathnames.config))
 	{
 		log_fatal("Expected configuration file does not exists: \"%s\"",
-				  options.pathnames.config);
+				  options->pathnames.config);
 
-		if (!directory_exists(options.pgSetup.pgdata))
+		if (!directory_exists(options->pgSetup.pgdata))
 		{
 			log_warn("HINT: Check your PGDATA setting: \"%s\"",
-					 options.pgSetup.pgdata);
+					 options->pgSetup.pgdata);
 		}
 
 		exit(EXIT_CODE_BAD_ARGS);
 	}
-
-	/* publish our option parsing in the global variable */
-	keeperOptions = options;
-
-	return optind;
 }
 
 

--- a/src/bin/pg_autoctl/cli_common.h
+++ b/src/bin/pg_autoctl/cli_common.h
@@ -109,6 +109,7 @@ int cli_create_node_getopts(int argc, char **argv,
 							const char *optstring,
 							KeeperConfig *options);
 int keeper_cli_getopt_pgdata(int argc, char **argv);
+void prepare_keeper_options(KeeperConfig *options);
 
 void set_first_pgctl(PostgresSetup *pgSetup);
 bool monitor_init_from_pgsetup(Monitor *monitor, PostgresSetup *pgSetup);

--- a/src/bin/pg_autoctl/cli_common.h
+++ b/src/bin/pg_autoctl/cli_common.h
@@ -70,8 +70,8 @@ extern CommandLine drop_node_command;
 extern CommandLine destroy_command;
 
 /* cli_get_set_properties.c */
-extern CommandLine get_command;
-extern CommandLine set_command;
+extern CommandLine get_commands;
+extern CommandLine set_commands;
 
 /* cli_enable_disable.c */
 extern CommandLine enable_commands;
@@ -80,6 +80,11 @@ extern CommandLine disable_commands;
 /* cli_formation.c */
 extern CommandLine create_formation_command;
 extern CommandLine drop_formation_command;
+
+/* cli_perform.c */
+extern CommandLine perform_failover_command;
+extern CommandLine perform_switchover_command;
+
 
 /* cli_service.c */
 extern CommandLine service_run_command;
@@ -114,9 +119,5 @@ void exit_unless_role_is_keeper(KeeperConfig *kconfig);
 bool cli_create_config(Keeper *keeper, KeeperConfig *config);
 void cli_create_pg(Keeper *keeper, KeeperConfig *config);
 bool check_or_discover_nodename(KeeperConfig *config);
-void keeper_cli_destroy_node(int argc, char **argv);
-void keeper_cli_destroy_keeper_node(Keeper *keeper,
-									KeeperConfig *config);
-void stop_postgres_and_remove_pgdata_and_config(ConfigFilePaths *pathnames,
-												PostgresSetup *pgSetup);
+
 #endif  /* CLI_COMMON_H */

--- a/src/bin/pg_autoctl/cli_create_drop_node.c
+++ b/src/bin/pg_autoctl/cli_create_drop_node.c
@@ -32,8 +32,12 @@
 #include "pgctl.h"
 #include "primary_standby.h"
 
+/*
+ * Global variables that we're going to use to "communicate" in between getopts
+ * functions and their command implementation. We can't pass parameters around.
+ */
 MonitorConfig monitorOptions;
-bool dropAndDestroy = false;
+static bool dropAndDestroy = false;
 
 static int cli_create_postgres_getopts(int argc, char **argv);
 static void cli_create_postgres(int argc, char **argv);
@@ -792,6 +796,9 @@ cli_drop_node(int argc, char **argv)
 	{
 		/* all we really need now is pg_ctl */
 		set_first_pgctl(&(config.pgSetup));
+		log_info("Configuration file \"%s\" does not exists, using %s",
+				 config.pathnames.config,
+				 config.pgSetup.pg_ctl);
 	}
 
 	/*

--- a/src/bin/pg_autoctl/cli_get_set_properties.c
+++ b/src/bin/pg_autoctl/cli_get_set_properties.c
@@ -64,10 +64,10 @@ static CommandLine *get_subcommands[] = {
 	NULL
 };
 
-CommandLine get_command =
+CommandLine get_commands =
 	make_command_set("get",
-					 "Get a pg_auto_failover node, or formation setting", NULL, NULL,
-					 NULL, get_subcommands);
+					 "Get a pg_auto_failover node, or formation setting",
+					 NULL, NULL, NULL, get_subcommands);
 
 /* set commands */
 
@@ -93,10 +93,10 @@ static CommandLine *set_subcommands[] = {
 	NULL
 };
 
-CommandLine set_command =
+CommandLine set_commands =
 	make_command_set("set",
-					 "Set a pg_auto_failover node, or formation setting", NULL, NULL,
-					 NULL, set_subcommands);
+					 "Set a pg_auto_failover node, or formation setting",
+					 NULL, NULL, NULL, set_subcommands);
 
 
 /*

--- a/src/bin/pg_autoctl/cli_perform.c
+++ b/src/bin/pg_autoctl/cli_perform.c
@@ -1,0 +1,211 @@
+/*
+ * src/bin/pg_autoctl/cli_perform.c
+ *     Implementation of the pg_autoctl perform CLI for the pg_auto_failover
+ *     nodes (monitor, coordinator, worker, postgres).
+ *
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the PostgreSQL License.
+ *
+ */
+
+#include "cli_common.h"
+#include "commandline.h"
+#include "defaults.h"
+#include "ini_file.h"
+#include "keeper_config.h"
+#include "keeper.h"
+#include "monitor.h"
+#include "monitor_config.h"
+
+static int cli_perform_failover_getopts(int argc, char **argv);
+static void cli_perform_failover(int argc, char **argv);
+
+CommandLine perform_failover_command =
+	make_command("failover",
+				 "Perform a failover for given formation and group",
+				 " [ --pgdata --formation --group ] ",
+				 "  --pgdata      path to data directory	 \n"		\
+				 "  --formation   formation to target, defaults to 'default' \n" \
+				 "  --group       group to target, defaults to 0 \n",
+				 cli_perform_failover_getopts,
+				 cli_perform_failover);
+
+CommandLine perform_switchover_command =
+	make_command("switchover",
+				 "Perform a switchover for given formation and group",
+				 " [ --pgdata --formation --group ] ",
+				 "  --pgdata      path to data directory	 \n"		\
+				 "  --formation   formation to target, defaults to 'default' \n" \
+				 "  --group       group to target, defaults to 0 \n",
+				 cli_perform_failover_getopts,
+				 cli_perform_failover);
+
+
+/*
+ * cli_perform_failover_getopts parses the command line options for the
+ * command `pg_autoctl perform failover`.
+ */
+static int
+cli_perform_failover_getopts(int argc, char **argv)
+{
+	KeeperConfig options = { 0 };
+	int c, option_index = 0, errors = 0;
+	int verboseCount = 0;
+
+	static struct option long_options[] = {
+		{ "pgdata", required_argument, NULL, 'D' },
+		{ "formation", required_argument, NULL, 'f' },
+		{ "group", required_argument, NULL, 'g' },
+		{ "version", no_argument, NULL, 'V' },
+		{ "verbose", no_argument, NULL, 'v' },
+		{ "quiet", no_argument, NULL, 'q' },
+		{ "help", no_argument, NULL, 'h' },
+		{ NULL, 0, NULL, 0 }
+	};
+
+	/* set default values for our options, when we have some */
+	options.groupId = 0;
+	options.network_partition_timeout = -1;
+	options.prepare_promotion_catchup = -1;
+	options.prepare_promotion_walreceiver = -1;
+	options.postgresql_restart_failure_timeout = -1;
+	options.postgresql_restart_failure_max_retries = -1;
+
+	strlcpy(options.formation, "default", NAMEDATALEN);
+
+	optind = 0;
+
+	while ((c = getopt_long(argc, argv, "D:f:g:n:Vvqh",
+							long_options, &option_index)) != -1)
+	{
+		switch (c)
+		{
+			case 'D':
+			{
+				strlcpy(options.pgSetup.pgdata, optarg, MAXPGPATH);
+				log_trace("--pgdata %s", options.pgSetup.pgdata);
+				break;
+			}
+
+			case 'f':
+			{
+				strlcpy(options.formation, optarg, NAMEDATALEN);
+				log_trace("--formation %s", options.formation);
+				break;
+			}
+
+			case 'g':
+			{
+				int scanResult = sscanf(optarg, "%d", &options.groupId);
+				if (scanResult == 0)
+				{
+					log_fatal("--group argument is not a valid group ID: \"%s\"",
+							  optarg);
+					exit(EXIT_CODE_BAD_ARGS);
+				}
+				log_trace("--group %d", options.groupId);
+				break;
+			}
+
+			case 'V':
+			{
+				/* keeper_cli_print_version prints version and exits. */
+				keeper_cli_print_version(argc, argv);
+				break;
+			}
+
+			case 'v':
+			{
+				++verboseCount;
+				switch (verboseCount)
+				{
+					case 1:
+						log_set_level(LOG_INFO);
+						break;
+
+					case 2:
+						log_set_level(LOG_DEBUG);
+						break;
+
+					default:
+						log_set_level(LOG_TRACE);
+						break;
+				}
+				break;
+			}
+
+			case 'q':
+			{
+				log_set_level(LOG_ERROR);
+				break;
+			}
+
+			case 'h':
+			{
+				commandline_help(stderr);
+				exit(EXIT_CODE_QUIT);
+				break;
+			}
+
+			default:
+			{
+				/* getopt_long already wrote an error message */
+				errors++;
+			}
+		}
+	}
+
+	if (errors > 0)
+	{
+		commandline_help(stderr);
+		exit(EXIT_CODE_BAD_ARGS);
+	}
+
+	if (IS_EMPTY_STRING_BUFFER(options.pgSetup.pgdata))
+	{
+		char *pgdata = getenv("PGDATA");
+
+		if (pgdata == NULL)
+		{
+			log_fatal("Failed to get PGDATA either from the environment "
+					  "or from --pgdata");
+			exit(EXIT_CODE_BAD_ARGS);
+		}
+
+		strlcpy(options.pgSetup.pgdata, pgdata, MAXPGPATH);
+	}
+
+	/*
+	 * pg_setup_init wants a single pg_ctl, and we don't use it here: pretend
+	 * we had a --pgctl option and processed it.
+	 */
+	set_first_pgctl(&(options.pgSetup));
+
+	keeperOptions = options;
+
+	return optind;
+}
+
+
+/*
+ * cli_perform_failover calls the SQL function
+ * pgautofailover.perform_failover() on the monitor.
+ */
+static void
+cli_perform_failover(int argc, char **argv)
+{
+	KeeperConfig config = keeperOptions;
+	Monitor monitor = { 0 };
+
+	if (!monitor_init_from_pgsetup(&monitor, &config.pgSetup))
+	{
+		/* errors have already been logged */
+		exit(EXIT_CODE_BAD_ARGS);
+	}
+
+	if (!monitor_perform_failover(&monitor, config.formation, config.groupId))
+	{
+		/* errors have already been logged */
+		exit(EXIT_CODE_MONITOR);
+	}
+}

--- a/src/bin/pg_autoctl/cli_root.c
+++ b/src/bin/pg_autoctl/cli_root.c
@@ -58,6 +58,16 @@ CommandLine drop_commands =
 					 "Drop a pg_auto_failover node, or formation", NULL, NULL,
 					 NULL, drop_subcommands);
 
+CommandLine *perform_subcommands[] = {
+	&perform_failover_command,
+	&perform_switchover_command,
+	NULL,
+};
+
+CommandLine perform_commands =
+	make_command_set("perform", "Perform an action orchestrated by the monitor",
+					 NULL, NULL, NULL, perform_subcommands);
+
 /*
  * Binding them all into the top-level command:
  */
@@ -68,15 +78,15 @@ CommandLine *root_subcommands_with_debug[] = {
 	&show_commands,
 	&enable_commands,
 	&disable_commands,
+	&get_commands,
+	&set_commands,
+	&perform_commands,
 	&do_commands,
-	&destroy_command,
 	&service_run_command,
 	&service_stop_command,
 	&service_reload_command,
 	&help,
 	&version,
-	&get_command,
-	&set_command,
 	NULL
 };
 
@@ -94,14 +104,14 @@ CommandLine *root_subcommands[] = {
 	&show_commands,
 	&enable_commands,
 	&disable_commands,
-	&destroy_command,
+	&get_commands,
+	&set_commands,
+	&perform_commands,
 	&service_run_command,
 	&service_stop_command,
 	&service_reload_command,
 	&help,
 	&version,
-	&get_command,
-	&set_command,
 	NULL
 };
 

--- a/src/bin/pg_autoctl/cli_service.c
+++ b/src/bin/pg_autoctl/cli_service.c
@@ -346,28 +346,8 @@ cli_getopt_pgdata_and_mode(int argc, char **argv)
 		}
 	}
 
-	if (IS_EMPTY_STRING_BUFFER(options.pgSetup.pgdata))
-	{
-		char *pgdata = getenv("PGDATA");
-
-		if (pgdata == NULL)
-		{
-			log_fatal("Failed to get PGDATA either from the environment "
-					  "or from --pgdata");
-			exit(EXIT_CODE_BAD_ARGS);
-		}
-
-		strlcpy(options.pgSetup.pgdata, pgdata, MAXPGPATH);
-	}
-
-	log_info("Managing PostgreSQL installation at \"%s\"",
-			 options.pgSetup.pgdata);
-
-	if (!keeper_config_set_pathnames_from_pgdata(&options.pathnames, options.pgSetup.pgdata))
-	{
-		/* errors have already been logged */
-		exit(EXIT_CODE_BAD_ARGS);
-	}
+	/* now that we have the command line parameters, prepare the options */
+	(void) prepare_keeper_options(&options);
 
 	keeperOptions = options;
 

--- a/src/bin/pg_autoctl/monitor.c
+++ b/src/bin/pg_autoctl/monitor.c
@@ -667,6 +667,41 @@ monitor_remove(Monitor *monitor, char *host, int port)
 
 
 /*
+ * monitor_perform_failover calls the pgautofailover.monitor_perform_failover
+ * function on the monitor.
+ */
+bool
+monitor_perform_failover(Monitor *monitor, char *formation, int group)
+{
+	PGSQL *pgsql = &monitor->pgsql;
+	const char *sql = "SELECT pgautofailover.perform_failover($1, $2)";
+	int paramCount = 2;
+	Oid paramTypes[2] = { TEXTOID, INT4OID };
+	const char *paramValues[2];
+
+	paramValues[0] = formation;
+	paramValues[1] = intToString(group).strValue;
+
+	/*
+	 * pgautofailover.perform_failover() returns VOID.
+	 */
+	if (!pgsql_execute_with_params(pgsql, sql,
+								   paramCount, paramTypes, paramValues,
+								   NULL, NULL))
+	{
+		log_error("Failed to perform failover for formation %s and group %d",
+				  formation, group);
+		return false;
+	}
+
+	/* disconnect from PostgreSQL now */
+	pgsql_finish(&monitor->pgsql);
+
+	return true;
+}
+
+
+/*
  * parseNode parses a hostname and a port from the libpq result and writes
  * it to the NodeAddressParseContext pointed to by ctx.
  */

--- a/src/bin/pg_autoctl/monitor.h
+++ b/src/bin/pg_autoctl/monitor.h
@@ -82,6 +82,8 @@ bool monitor_set_formation_number_sync_standbys(Monitor *monitor, char *formatio
 										   int numberSyncStandbys);
 
 bool monitor_remove(Monitor *monitor, char *host, int port);
+bool monitor_perform_failover(Monitor *monitor, char *formation, int group);
+
 bool monitor_print_state(Monitor *monitor, char *formation, int group);
 bool monitor_print_last_events(Monitor *monitor,
 							   char *formation, int group, int count);

--- a/src/bin/pg_autoctl/pgsetup.c
+++ b/src/bin/pg_autoctl/pgsetup.c
@@ -265,29 +265,7 @@ pg_setup_init(PostgresSetup *pgSetup,
 			/*
 			 * no running cluster, what about using PGPORT then?
 			 */
-			char *pgport_env = getenv("PGPORT");
-			int pgport = 0;
-
-			if (pgport_env)
-			{
-				pgport = strtol(pgport_env, NULL, 10);
-
-				if (pgport > 0 && errno != EINVAL)
-				{
-					pgSetup->pgport = pgport;
-				}
-				else
-				{
-					pgSetup->pgport = POSTGRES_PORT;
-					log_warn("Failed to parse PGPORT value \"%s\", using %d",
-							 pgport_env, pgSetup->pgport);
-				}
-			}
-			else
-			{
-				/* no PGPORT, no running cluster, no --pgport, ok */
-				pgSetup->pgport = POSTGRES_PORT;
-			}
+			pgSetup->pgport = pgsetup_get_pgport();
 		}
 	}
 
@@ -1068,4 +1046,37 @@ pmStatusToString(PostmasterStatus pm_status)
 
 	/* keep compiler happy */
 	return "unknown";
+}
+
+
+/*
+ * pgsetup_get_pgport returns the port to use either from the PGPORT
+ * environment variable, or from our default hard-coded value of 5432.
+ */
+int
+pgsetup_get_pgport()
+{
+	char *pgport_env = getenv("PGPORT");
+	int pgport = 0;
+
+	if (pgport_env)
+	{
+		pgport = strtol(pgport_env, NULL, 10);
+
+		if (pgport > 0 && errno != EINVAL)
+		{
+			return pgport;
+		}
+		else
+		{
+			log_warn("Failed to parse PGPORT value \"%s\", using %d",
+					 pgport_env, POSTGRES_PORT);
+			return POSTGRES_PORT;
+		}
+	}
+	else
+	{
+		/* no PGPORT */
+		return POSTGRES_PORT;
+	}
 }

--- a/src/bin/pg_autoctl/pgsetup.h
+++ b/src/bin/pg_autoctl/pgsetup.h
@@ -150,5 +150,6 @@ bool pg_setup_set_absolute_pgdata(PostgresSetup *pgSetup);
 
 PgInstanceKind nodeKindFromString(const char *nodeKind);
 char *nodeKindToString(PgInstanceKind kind);
+int pgsetup_get_pgport(void);
 
 #endif /* PGSETUP_H */

--- a/src/monitor/pgautofailover.sql
+++ b/src/monitor/pgautofailover.sql
@@ -249,6 +249,9 @@ AS 'MODULE_PATHNAME', $$remove_node$$;
 comment on function pgautofailover.remove_node(text,int)
         is 'remove a node from the monitor';
 
+grant execute on function pgautofailover.remove_node(text,int)
+   to autoctl_node;
+
 CREATE FUNCTION pgautofailover.perform_failover
  (
   formation_id text default 'default',
@@ -259,6 +262,9 @@ AS 'MODULE_PATHNAME', $$perform_failover$$;
 
 comment on function pgautofailover.perform_failover(text,int)
         is 'manually failover from the primary to the secondary';
+
+grant execute on function pgautofailover.perform_failover(text,int)
+   to autoctl_node;
 
 CREATE FUNCTION pgautofailover.start_maintenance
  (
@@ -271,6 +277,9 @@ AS 'MODULE_PATHNAME', $$start_maintenance$$;
 comment on function pgautofailover.start_maintenance(text,int)
         is 'set a node in maintenance state';
 
+grant execute on function pgautofailover.start_maintenance(text,int)
+   to autoctl_node;
+
 CREATE FUNCTION pgautofailover.stop_maintenance
  (
    node_name text,
@@ -282,6 +291,8 @@ AS 'MODULE_PATHNAME', $$stop_maintenance$$;
 comment on function pgautofailover.stop_maintenance(text,int)
         is 'set a node out of maintenance state';
 
+grant execute on function pgautofailover.stop_maintenance(text,int)
+   to autoctl_node;
 
 CREATE FUNCTION pgautofailover.last_events
  (

--- a/src/monitor/pgautofailover.sql
+++ b/src/monitor/pgautofailover.sql
@@ -257,7 +257,7 @@ CREATE FUNCTION pgautofailover.perform_failover
   formation_id text default 'default',
   group_id     int  default 0
  )
-RETURNS void LANGUAGE C STRICT
+RETURNS void LANGUAGE C STRICT SECURITY DEFINER
 AS 'MODULE_PATHNAME', $$perform_failover$$;
 
 comment on function pgautofailover.perform_failover(text,int)

--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -687,7 +687,7 @@ class PGAutoCtl():
 
             try:
                 pgid = os.getpgid(self.run_proc.pid)
-                os.killpg(pgid, signal.SIGTERM)
+                os.killpg(pgid, signal.SIGQUIT)
 
                 self.communicate()
                 self.run_proc.wait()

--- a/tests/test_create_run.py
+++ b/tests/test_create_run.py
@@ -16,11 +16,11 @@ def teardown_module():
 
 def test_000_create_monitor():
     global monitor
-    monitor = cluster.create_monitor("/tmp/create--run/monitor")
+    monitor = cluster.create_monitor("/tmp/create-run/monitor")
 
 def test_001_init_primary():
     global node1
-    node1 = cluster.create_datanode("/tmp/create--run/node1")
+    node1 = cluster.create_datanode("/tmp/create-run/node1")
     node1.create(run = True)
     assert node1.wait_until_state(target_state="single")
 
@@ -30,7 +30,7 @@ def test_002_create_t1():
 
 def test_003_init_secondary():
     global node2
-    node2 = cluster.create_datanode("/tmp/create--run/node2")
+    node2 = cluster.create_datanode("/tmp/create-run/node2")
     node2.create(run = True)
     assert node2.wait_until_state(target_state="secondary")
     assert node1.wait_until_state(target_state="primary")

--- a/tests/test_create_run.py
+++ b/tests/test_create_run.py
@@ -16,11 +16,11 @@ def teardown_module():
 
 def test_000_create_monitor():
     global monitor
-    monitor = cluster.create_monitor("/tmp/basic/monitor")
+    monitor = cluster.create_monitor("/tmp/create--run/monitor")
 
 def test_001_init_primary():
     global node1
-    node1 = cluster.create_datanode("/tmp/basic/node1")
+    node1 = cluster.create_datanode("/tmp/create--run/node1")
     node1.create(run = True)
     assert node1.wait_until_state(target_state="single")
 
@@ -30,7 +30,7 @@ def test_002_create_t1():
 
 def test_003_init_secondary():
     global node2
-    node2 = cluster.create_datanode("/tmp/basic/node2")
+    node2 = cluster.create_datanode("/tmp/create--run/node2")
     node2.create(run = True)
     assert node2.wait_until_state(target_state="secondary")
     assert node1.wait_until_state(target_state="primary")


### PR DESCRIPTION
  - Add `pg_autoctl perform failover` as a CLI operation
  - Add `pg_autoctl perform switchover` as a synonym to it: when done in a controlled way what we implement is actually a switch-over, thanks to the careful implementation of the FSM on the monitor and to the default to synchronous replication
  - Remove `pg_autoctl destroy` and make it an option to `pg_autoctl drop node --destroy` instead, that fits better with the spirit of our CLI
  - Re-order get/set commands so that they are listed with the command that have sub-commands, before the final commands

In passing, we fix #94 by making `pgautofailover.perform_failover()` a SECURITY DEFINER function.