### PR TITLE
Ensure current state before reaching the assigned state.

### DIFF
--- a/src/bin/pg_autoctl/keeper.c
+++ b/src/bin/pg_autoctl/keeper.c
@@ -134,29 +134,33 @@ keeper_should_ensure_current_state_before_transition(Keeper *keeper)
 {
 	KeeperStateData *keeperState = &(keeper->state);
 
-	if (keeperState->assigned_role != keeperState->current_role)
+	if (keeperState->assigned_role == keeperState->current_role)
 	{
-		if (keeperState->assigned_role == DEMOTED_STATE
-			|| keeperState->assigned_role == DEMOTE_TIMEOUT_STATE
-			|| keeperState->assigned_role == DEMOTED_STATE)
-		{
-			/* don't ensure Postgres is running before shutting it down */
-			return false;
-		}
-
-		if (keeperState->current_role == DEMOTED_STATE
-			|| keeperState->current_role == DEMOTE_TIMEOUT_STATE
-			|| keeperState->current_role == DEMOTED_STATE)
-		{
-			/* don't ensure Postgres is down before starting it again */
-			return false;
-		}
-
-		/* in all other cases, yes please ensure the current state */
-		return true;
+		/* this function should not be called in that case */
+		log_debug("BUG: keeper_should_ensure_current_state_before_transition "
+				  "called with assigned role == current role == %s",
+				  NodeStateToString(keeperState->assigned_role));
+		return false;
 	}
 
-	return false;
+	if (keeperState->assigned_role == DEMOTED_STATE
+		|| keeperState->assigned_role == DEMOTE_TIMEOUT_STATE
+		|| keeperState->assigned_role == DEMOTED_STATE)
+	{
+		/* don't ensure Postgres is running before shutting it down */
+		return false;
+	}
+
+	if (keeperState->current_role == DEMOTED_STATE
+		|| keeperState->current_role == DEMOTE_TIMEOUT_STATE
+		|| keeperState->current_role == DEMOTED_STATE)
+	{
+		/* don't ensure Postgres is down before starting it again */
+		return false;
+	}
+
+	/* in all other cases, yes please ensure the current state */
+	return true;
 }
 
 

--- a/src/bin/pg_autoctl/keeper.c
+++ b/src/bin/pg_autoctl/keeper.c
@@ -114,6 +114,53 @@ keeper_update_state(Keeper *keeper, int node_id, int group_id,
 
 
 /*
+ * keeper_should_ensure_current_state returns true when pg_autoctl should
+ * ensure that Postgres is running, or not running, depending on the current
+ * FSM state, before calling the transition function to the next state.
+ *
+ * At the moment, the only cases when we DON'T want to ensure the current state
+ * are when either the current state or the goal state are one of the following:
+ *
+ *  - DRAINING
+ *  - DEMOTED
+ *  - DEMOTE TIMEOUT
+ *
+ * That's because we would then stop Postgres first when going from DEMOTED to
+ * SINGLE, or ensure Postgres is running when going from PRIMARY to DEMOTED.
+ * This last example is a split-brain hazard, too.
+ */
+bool
+keeper_should_ensure_current_state_before_transition(Keeper *keeper)
+{
+	KeeperStateData *keeperState = &(keeper->state);
+
+	if (keeperState->assigned_role != keeperState->current_role)
+	{
+		if (keeperState->assigned_role == DEMOTED_STATE
+			|| keeperState->assigned_role == DEMOTE_TIMEOUT_STATE
+			|| keeperState->assigned_role == DEMOTED_STATE)
+		{
+			/* don't ensure Postgres is running before shutting it down */
+			return false;
+		}
+
+		if (keeperState->current_role == DEMOTED_STATE
+			|| keeperState->current_role == DEMOTE_TIMEOUT_STATE
+			|| keeperState->current_role == DEMOTED_STATE)
+		{
+			/* don't ensure Postgres is down before starting it again */
+			return false;
+		}
+
+		/* in all other cases, yes please ensure the current state */
+		return true;
+	}
+
+	return false;
+}
+
+
+/*
  * keeper_ensure_current_state ensures that the current keeper's state is met
  * with the current PostgreSQL status, at minimum that PostgreSQL is running
  * when it's expected to be, etc.

--- a/src/bin/pg_autoctl/keeper.h
+++ b/src/bin/pg_autoctl/keeper.h
@@ -43,6 +43,7 @@ bool keeper_update_state(Keeper *keeper, int node_id, int group_id, NodeState st
 						 bool update_last_monitor_contact);
 bool keeper_start_postgres(Keeper *keeper);
 bool keeper_restart_postgres(Keeper *keeper);
+bool keeper_should_ensure_current_state_before_transition(Keeper *keeper);
 bool keeper_ensure_current_state(Keeper *keeper);
 bool keeper_update_pg_state(Keeper *keeper);
 bool ReportPgIsRunning(Keeper *keeper);

--- a/src/bin/pg_autoctl/loop.c
+++ b/src/bin/pg_autoctl/loop.c
@@ -265,6 +265,21 @@ keeper_service_run(Keeper *keeper, pid_t *start_pid)
 		 */
 		if (needStateChange)
 		{
+			/*
+			 * First, ensure the current state (make sure Postgres is running
+			 * if it should, or Postgres is stopped if it should not run).
+			 *
+			 * The transition function we call next might depend on our
+			 * assumption that Postgres is running in the current state.
+			 */
+			if (!keeper_ensure_current_state(keeper))
+			{
+				log_warn("pg_autoctl failed to ensure current state \"%s\": "
+						 "PostgreSQL %s running",
+						 NodeStateToString(keeperState->current_role),
+						 postgres->pgIsRunning ? "is" : "is not");
+			}
+
 			if (!keeper_fsm_reach_assigned_state(keeper))
 			{
 				log_error("Failed to transition to state \"%s\", retrying... ",

--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -331,7 +331,10 @@ class DataNode(PGNode):
         prev_state = None
         for i in range(timeout):
             # ensure we read from the pg_autoctl process pipe
-            self.pg_autoctl.consume_output(1)
+            if self.pg_autoctl and self.pg_autoctl.run_proc:
+                self.pg_autoctl.consume_output(1)
+            else:
+                time.sleep(1)
 
             current_state = self.get_state()
 
@@ -354,11 +357,16 @@ class DataNode(PGNode):
                 (self.datadir, target_state, timeout))
 
             events = self.get_events_str()
-            out, err = self.stop_pg_autoctl()
-            raise Exception("%s failed to reach %s after %d attempts: " \
-                            "\n%s\n%s\n%s" %
-                            (self.datadir, target_state, timeout,
-                             out, err, events))
+
+            if self.pg_autoctl and self.pg_autoctl.run_proc:
+                out, err = self.stop_pg_autoctl()
+                raise Exception("%s failed to reach %s after %d attempts: " \
+                                "\n%s\n%s\n%s" %
+                                (self.datadir, target_state, timeout,
+                                 out, err, events))
+            else:
+                raise Exception("%s failed to reach %s after %d attempts:\n%s" %
+                                (self.datadir, target_state, timeout, events))
             return False
 
     def get_state(self):

--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -337,11 +337,16 @@ class DataNode(PGNode):
 
             # only log the state if it has changed
             if current_state != prev_state:
-                print("state of %s is '%s', waiting for '%s' ..." %
-                    (self.datadir, current_state, target_state))
+                if current_state == target_state:
+                    print("state of %s is '%s', done waiting" %
+                          (self.datadir, current_state))
+                else:
+                    print("state of %s is '%s', waiting for '%s' ..." %
+                          (self.datadir, current_state, target_state))
 
             if current_state == target_state:
                 return True
+
             prev_state = current_state
 
         else:

--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -323,7 +323,8 @@ class DataNode(PGNode):
             self.pg_autoctl.execute("pg_autoctl create")
 
 
-    def wait_until_state(self, target_state, timeout=STATE_CHANGE_TIMEOUT):
+    def wait_until_state(self, target_state,
+                         timeout=STATE_CHANGE_TIMEOUT, sleep_time=1):
         """
         Waits until this data node reaches the target state, and then returns
         True. If this doesn't happen until "timeout" seconds, returns False.
@@ -332,9 +333,9 @@ class DataNode(PGNode):
         for i in range(timeout):
             # ensure we read from the pg_autoctl process pipe
             if self.pg_autoctl and self.pg_autoctl.run_proc:
-                self.pg_autoctl.consume_output(1)
+                self.pg_autoctl.consume_output(sleep_time)
             else:
-                time.sleep(1)
+                time.sleep(sleep_time)
 
             current_state = self.get_state()
 

--- a/tests/test_ensure.py
+++ b/tests/test_ensure.py
@@ -49,7 +49,10 @@ def test_004_demoted():
     print("stopped pg_autoctl and postgres, now waiting for 30s")
     time.sleep(30)
     node1.run()
-    assert node1.wait_until_state(target_state="demoted")
+
+    # we might miss DEMOTE_TIMEOUT -> DEMOTED if we wait for a full second
+    # here
+    assert node1.wait_until_state(target_state="demoted", sleep_time=0.1)
 
     # ideally we should be able to check that we refrain from starting
     # postgres again before calling the transition function

--- a/tests/test_ensure.py
+++ b/tests/test_ensure.py
@@ -1,0 +1,57 @@
+import pgautofailover_utils as pgautofailover
+from nose.tools import *
+
+import time
+
+cluster = None
+node1 = None
+node2 = None
+
+def setup_module():
+    global cluster
+    cluster = pgautofailover.Cluster()
+
+def teardown_module():
+    cluster.destroy()
+
+def test_000_create_monitor():
+    monitor = cluster.create_monitor("/tmp/ensure/monitor")
+    monitor.wait_until_pg_is_running()
+
+def test_001_init_primary():
+    global node1
+    node1 = cluster.create_datanode("/tmp/ensure/node1")
+    node1.create()
+    node1.stop_postgres()
+    node1.run()
+    assert node1.wait_until_state(target_state="single")
+
+def test_002_create_t1():
+    node1.run_sql_query("CREATE TABLE t1(a int)")
+    node1.run_sql_query("INSERT INTO t1 VALUES (1), (2)")
+
+def test_003_init_secondary():
+    global node2
+    node2 = cluster.create_datanode("/tmp/ensure/node2")
+    node2.create()
+    node2.stop_postgres()
+    node2.run()
+    assert node2.wait_until_state(target_state="secondary")
+    assert node1.wait_until_state(target_state="primary")
+
+def test_004_demoted():
+    print()
+    node1.stop_postgres()
+    node1.stop_pg_autoctl()
+    # we need the pg_autoctl process to run to reach the state demoted,
+    # otherwise the monitor assigns that state to node1 but we never reach
+    # it
+    print("stopped pg_autoctl and postgres, now waiting for 30s")
+    time.sleep(30)
+    node1.run()
+    assert node1.wait_until_state(target_state="demoted")
+
+    # ideally we should be able to check that we refrain from starting
+    # postgres again before calling the transition function
+    print("re-starting pg_autoctl on node1")
+    assert node1.wait_until_state(target_state="secondary")


### PR DESCRIPTION
Even at pg_autoctl start we might be given a transition order by the
monitor, such as SINGLE to WAIT_PRIMARY. We should make sure that Postgres
is running (as per the current state SINGLE) before calling the transition
function, as it might need that pre-condition to be true.