### PR TITLE
Fix/json

### DIFF
--- a/src/bin/pg_autoctl/cli_do_monitor.c
+++ b/src/bin/pg_autoctl/cli_do_monitor.c
@@ -223,17 +223,16 @@ cli_do_monitor_get_other_nodes(int argc, char **argv)
 	{
 		char json[BUFSIZE];
 
-		if (!monitor_get_other_nodes_as_json(&monitor,
-											 config.nodename,
-											 config.pgSetup.pgport,
-											 ANY_STATE,
-											 json, BUFSIZE))
+		if (!monitor_print_other_nodes_as_json(&monitor,
+											   config.nodename,
+											   config.pgSetup.pgport,
+											   ANY_STATE,
+											   stdout))
 		{
 			log_fatal("Failed to get the other nodes from the monitor, "
 					  "see above for details");
 			exit(EXIT_CODE_MONITOR);
 		}
-		fprintf(stdout, "%s\n", json);
 	}
 	else
 	{

--- a/src/bin/pg_autoctl/cli_do_monitor.c
+++ b/src/bin/pg_autoctl/cli_do_monitor.c
@@ -195,10 +195,6 @@ cli_do_monitor_get_other_nodes(int argc, char **argv)
 
 	Monitor monitor = { 0 };
 
-	/* arbitrary limit to 12 other nodes */
-	int nodeIndex = 0;
-	NodeAddressArray otherNodesArray;
-
 	bool missingPgdataIsOk = true;
 	bool pgIsNotRunningIsOk = true;
 	bool monitorDisabledIsOk = false;
@@ -224,8 +220,7 @@ cli_do_monitor_get_other_nodes(int argc, char **argv)
 		if (!monitor_print_other_nodes_as_json(&monitor,
 											   config.nodename,
 											   config.pgSetup.pgport,
-											   ANY_STATE,
-											   stdout))
+											   ANY_STATE))
 		{
 			log_fatal("Failed to get the other nodes from the monitor, "
 					  "see above for details");
@@ -234,18 +229,15 @@ cli_do_monitor_get_other_nodes(int argc, char **argv)
 	}
 	else
 	{
-		if (!monitor_get_other_nodes(&monitor,
-									 config.nodename,
-									 config.pgSetup.pgport,
-									 ANY_STATE,
-									 &otherNodesArray))
+		if (!monitor_print_other_nodes(&monitor,
+									   config.nodename,
+									   config.pgSetup.pgport,
+									   ANY_STATE))
 		{
 			log_fatal("Failed to get the other nodes from the monitor, "
 					  "see above for details");
 			exit(EXIT_CODE_MONITOR);
 		}
-
-		(void) printNodeArray(&otherNodesArray);
 	}
 }
 

--- a/src/bin/pg_autoctl/cli_do_monitor.c
+++ b/src/bin/pg_autoctl/cli_do_monitor.c
@@ -221,8 +221,6 @@ cli_do_monitor_get_other_nodes(int argc, char **argv)
 
 	if (outputJSON)
 	{
-		char json[BUFSIZE];
-
 		if (!monitor_print_other_nodes_as_json(&monitor,
 											   config.nodename,
 											   config.pgSetup.pgport,

--- a/src/bin/pg_autoctl/cli_show.c
+++ b/src/bin/pg_autoctl/cli_show.c
@@ -330,14 +330,13 @@ cli_show_state(int argc, char **argv)
 	{
 		char json[BUFSIZE];
 
-		if (!monitor_get_state_as_json(&monitor,
-									   config.formation, config.groupId,
-									   json, BUFSIZE))
+		if (!monitor_print_state_as_json(&monitor,
+										 config.formation, config.groupId,
+										 stdout))
 		{
 			/* errors have already been logged */
 			exit(EXIT_CODE_MONITOR);
 		}
-		fprintf(stdout, "%s\n", json);
 	}
 	else
 	{
@@ -519,15 +518,14 @@ cli_show_nodes(int argc, char **argv)
 	{
 		char json[BUFSIZE];
 
-		if (!monitor_get_nodes_as_json(&monitor,
-									   config.formation,
-									   config.groupId,
-									   json, BUFSIZE))
+		if (!monitor_print_nodes_as_json(&monitor,
+										 config.formation,
+										 config.groupId,
+										 stdout))
 		{
 			/* errors have already been logged */
 			exit(EXIT_CODE_MONITOR);
 		}
-		fprintf(stdout, "%s\n", json);
 	}
 	else
 	{

--- a/src/bin/pg_autoctl/cli_show.c
+++ b/src/bin/pg_autoctl/cli_show.c
@@ -307,8 +307,6 @@ cli_show_events(int argc, char **argv)
 
 	if (outputJSON)
 	{
-		char json[BUFSIZE];
-
 		if (!monitor_print_last_events_as_json(&monitor,
 											   config.formation,
 											   config.groupId,
@@ -351,8 +349,6 @@ cli_show_state(int argc, char **argv)
 
 	if (outputJSON)
 	{
-		char json[BUFSIZE];
-
 		if (!monitor_print_state_as_json(&monitor,
 										 config.formation, config.groupId,
 										 stdout))
@@ -538,8 +534,6 @@ cli_show_nodes(int argc, char **argv)
 
 	if (outputJSON)
 	{
-		char json[BUFSIZE];
-
 		if (!monitor_print_nodes_as_json(&monitor,
 										 config.formation,
 										 config.groupId))

--- a/src/bin/pg_autoctl/cli_show.c
+++ b/src/bin/pg_autoctl/cli_show.c
@@ -527,7 +527,6 @@ cli_show_nodes_getopts(int argc, char **argv)
 static void
 cli_show_nodes(int argc, char **argv)
 {
-	NodeAddressArray nodesArray;
 	KeeperConfig config = keeperOptions;
 	Monitor monitor = { 0 };
 
@@ -543,8 +542,7 @@ cli_show_nodes(int argc, char **argv)
 
 		if (!monitor_print_nodes_as_json(&monitor,
 										 config.formation,
-										 config.groupId,
-										 stdout))
+										 config.groupId))
 		{
 			/* errors have already been logged */
 			exit(EXIT_CODE_MONITOR);
@@ -552,17 +550,14 @@ cli_show_nodes(int argc, char **argv)
 	}
 	else
 	{
-		if (!monitor_get_nodes(&monitor,
-							   config.formation,
-							   config.groupId,
-							   &nodesArray))
+		if (!monitor_print_nodes(&monitor,
+								 config.formation,
+								 config.groupId))
 		{
 			log_fatal("Failed to get the other nodes from the monitor, "
 					  "see above for details");
 			exit(EXIT_CODE_MONITOR);
 		}
-
-		(void) printNodeArray(&nodesArray);
 	}
 }
 

--- a/src/bin/pg_autoctl/cli_show.c
+++ b/src/bin/pg_autoctl/cli_show.c
@@ -299,13 +299,30 @@ cli_show_events(int argc, char **argv)
 		exit(EXIT_CODE_BAD_ARGS);
 	}
 
-	if (!monitor_print_last_events(&monitor,
-								   config.formation,
-								   config.groupId,
-								   eventCount))
+	if (outputJSON)
 	{
-		/* errors have already been logged */
-		exit(EXIT_CODE_MONITOR);
+		char json[BUFSIZE];
+
+		if (!monitor_print_last_events_as_json(&monitor,
+											   config.formation,
+											   config.groupId,
+											   eventCount,
+											   stdout))
+		{
+			/* errors have already been logged */
+			exit(EXIT_CODE_MONITOR);
+		}
+	}
+	else
+	{
+		if (!monitor_print_last_events(&monitor,
+									   config.formation,
+									   config.groupId,
+									   eventCount))
+		{
+			/* errors have already been logged */
+			exit(EXIT_CODE_MONITOR);
+		}
 	}
 }
 

--- a/src/bin/pg_autoctl/cli_show.c
+++ b/src/bin/pg_autoctl/cli_show.c
@@ -63,10 +63,11 @@ CommandLine show_events_command =
 	make_command("events",
 				 "Prints monitor's state of nodes in a given formation and group",
 				 " [ --pgdata --formation --group --count ] ",
-				 "  --pgdata      path to data directory	 \n"		\
-				 "  --formation   formation to query, defaults to 'default' \n" \
-				 "  --group       group to query formation, defaults to all \n" \
-				 "  --count       how many events to fetch, defaults to 10 \n",
+				 "  --pgdata      path to data directory	 \n"
+				 "  --formation   formation to query, defaults to 'default' \n"
+				 "  --group       group to query formation, defaults to all \n"
+				 "  --count       how many events to fetch, defaults to 10 \n"
+				 "  --json        output data in the JSON format\n",
 				 cli_show_state_getopts,
 				 cli_show_events);
 
@@ -74,9 +75,9 @@ CommandLine show_state_command =
 	make_command("state",
 				 "Prints monitor's state of nodes in a given formation and group",
 				 " [ --pgdata --formation --group ] ",
-				 "  --pgdata      path to data directory	 \n"		\
-				 "  --formation   formation to query, defaults to 'default' \n" \
-				 "  --group       group to query formation, defaults to all \n" \
+				 "  --pgdata      path to data directory	 \n"
+				 "  --formation   formation to query, defaults to 'default' \n"
+				 "  --group       group to query formation, defaults to all \n"
 				 "  --json        output data in the JSON format\n",
 				 cli_show_state_getopts,
 				 cli_show_state);

--- a/src/bin/pg_autoctl/cli_show.c
+++ b/src/bin/pg_autoctl/cli_show.c
@@ -350,8 +350,7 @@ cli_show_state(int argc, char **argv)
 	if (outputJSON)
 	{
 		if (!monitor_print_state_as_json(&monitor,
-										 config.formation, config.groupId,
-										 stdout))
+										 config.formation, config.groupId))
 		{
 			/* errors have already been logged */
 			exit(EXIT_CODE_MONITOR);

--- a/src/bin/pg_autoctl/monitor.c
+++ b/src/bin/pg_autoctl/monitor.c
@@ -1452,8 +1452,7 @@ printCurrentState(void *ctx, PGresult *result)
  * contains the JSON representation of the current state on the monitor.
  */
 bool
-monitor_print_state_as_json(Monitor *monitor, char *formation, int group,
-							FILE *stream)
+monitor_print_state_as_json(Monitor *monitor, char *formation, int group)
 {
 	SingleValueResultContext context = { 0 };
 	PGSQL *pgsql = &monitor->pgsql;
@@ -1517,7 +1516,7 @@ monitor_print_state_as_json(Monitor *monitor, char *formation, int group,
 		return false;
 	}
 
-	fprintf(stream, "%s\n", context.strVal);
+	fprintf(stdout, "%s\n", context.strVal);
 
 	return true;
 }

--- a/src/bin/pg_autoctl/monitor.c
+++ b/src/bin/pg_autoctl/monitor.c
@@ -101,8 +101,8 @@ monitor_init(Monitor *monitor, char *url)
 
 
 /*
- * monitor_get_other_node gets the hostname and port of the other node
- * in the group.
+ * monitor_get_nodes gets the hostname and port of all the nodes in the given
+ * group.
  */
 bool
 monitor_get_nodes(Monitor *monitor, char *formation, int groupId,
@@ -156,12 +156,32 @@ monitor_get_nodes(Monitor *monitor, char *formation, int groupId,
 
 
 /*
- * monitor_get_other_node gets the hostname and port of the other node
- * in the group.
+ * monitor_print_nodes gets all the nodes in the given group and prints them
+ * out to stdout in a human-friendly tabular format.
  */
 bool
-monitor_print_nodes_as_json(Monitor *monitor, char *formation, int groupId,
-							FILE *stream)
+monitor_print_nodes(Monitor *monitor, char *formation, int groupId)
+{
+	NodeAddressArray nodesArray;
+
+	if (!monitor_get_nodes(monitor, formation, groupId, &nodesArray))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	(void) printNodeArray(&nodesArray);
+
+	return true;
+}
+
+
+/*
+ * monitor_get_other_nodes_as_json gets the hostname and port of the other node
+ * in the group and prints them out in JSON format.
+ */
+bool
+monitor_print_nodes_as_json(Monitor *monitor, char *formation, int groupId)
 {
 	PGSQL *pgsql = &monitor->pgsql;
 	SingleValueResultContext context = { { 0 }, PGSQL_RESULT_STRING, false };
@@ -212,15 +232,15 @@ monitor_print_nodes_as_json(Monitor *monitor, char *formation, int groupId,
 		return false;
 	}
 
-	fprintf(stream, "%s\n", context.strVal);
+	fprintf(stdout, "%s\n", context.strVal);
 
 	return true;
 }
 
 
 /*
- * monitor_get_other_node gets the hostname and port of the other node
- * in the group.
+ * monitor_get_other_nodes gets the hostname and port of the other node in the
+ * group.
  */
 bool
 monitor_get_other_nodes(Monitor *monitor,
@@ -274,14 +294,37 @@ monitor_get_other_nodes(Monitor *monitor,
 
 
 /*
+ * monitor_print_other_nodes gets the other nodes from the monitor and then
+ * prints them to stdout in a human-friendly tabular format.
+ */
+bool
+monitor_print_other_nodes(Monitor *monitor,
+						  char *myHost, int myPort, NodeState currentState)
+{
+	NodeAddressArray otherNodesArray;
+
+	if (!monitor_get_other_nodes(monitor,
+								 myHost, myPort, currentState,
+								 &otherNodesArray))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	(void) printNodeArray(&otherNodesArray);
+
+	return true;
+}
+
+
+/*
  * monitor_print_other_node_as_json gets the hostname and port of the other
  * node in the group as a JSON string and prints it to given stream.
  */
 bool
 monitor_print_other_nodes_as_json(Monitor *monitor,
 								  char *myHost, int myPort,
-								  NodeState currentState,
-								  FILE *stream)
+								  NodeState currentState)
 {
 	PGSQL *pgsql = &monitor->pgsql;
 	SingleValueResultContext context = { { 0 }, PGSQL_RESULT_STRING, false };
@@ -331,7 +374,7 @@ monitor_print_other_nodes_as_json(Monitor *monitor,
 		return false;
 	}
 
-	fprintf(stream, "%s\n", context.strVal);
+	fprintf(stdout, "%s\n", context.strVal);
 
 	return true;
 }

--- a/src/bin/pg_autoctl/monitor.h
+++ b/src/bin/pg_autoctl/monitor.h
@@ -104,6 +104,10 @@ bool monitor_print_last_events(Monitor *monitor,
 							   char *formation, int group, int count);
 bool monitor_print_state_as_json(Monitor *monitor, char *formation, int group,
 								 FILE *stream);
+bool monitor_print_last_events_as_json(Monitor *monitor,
+									   char *formation, int group,
+									   int count,
+									   FILE *stream);
 
 bool monitor_create_formation(Monitor *monitor, char *formation, char *kind,
 							  char *dbname, bool ha, int numberSyncStandbys);

--- a/src/bin/pg_autoctl/monitor.h
+++ b/src/bin/pg_autoctl/monitor.h
@@ -109,10 +109,16 @@ bool monitor_print_last_events_as_json(Monitor *monitor,
 									   int count,
 									   FILE *stream);
 
+bool monitor_print_every_formation_uri(Monitor *monitor);
+bool monitor_print_every_formation_uri_as_json(Monitor *monitor, FILE *stream);
+
 bool monitor_create_formation(Monitor *monitor, char *formation, char *kind,
 							  char *dbname, bool ha, int numberSyncStandbys);
-bool monitor_enable_secondary_for_formation(Monitor *monitor, const char *formation);
-bool monitor_disable_secondary_for_formation(Monitor *monitor, const char *formation);
+bool monitor_enable_secondary_for_formation(Monitor *monitor,
+											const char *formation);
+bool monitor_disable_secondary_for_formation(Monitor *monitor,
+											 const char *formation);
+
 bool monitor_drop_formation(Monitor *monitor, char *formation);
 bool monitor_formation_uri(Monitor *monitor, const char *formation,
 						   char *connectionString, size_t size);

--- a/src/bin/pg_autoctl/monitor.h
+++ b/src/bin/pg_autoctl/monitor.h
@@ -58,15 +58,16 @@ void printNodeEntry(NodeAddress *node);
 
 bool monitor_get_nodes(Monitor *monitor, char *formation, int groupId,
 					   NodeAddressArray *nodeArray);
-bool monitor_print_nodes_as_json(Monitor *monitor, char *formation, int groupId,
-								 FILE *stream);
+bool monitor_print_nodes(Monitor *monitor, char *formation, int groupId);
+bool monitor_print_nodes_as_json(Monitor *monitor, char *formation, int groupId);
 bool monitor_get_other_nodes(Monitor *monitor,
 							 char *myHost, int myPort, NodeState currentState,
 							 NodeAddressArray *nodeArray);
+bool monitor_print_other_nodes(Monitor *monitor,
+							   char *myHost, int myPort, NodeState currentState);
 bool monitor_print_other_nodes_as_json(Monitor *monitor,
 									   char *myHost, int myPort,
-									   NodeState currentState,
-									   FILE *stream);
+									   NodeState currentState);
 void printNodeArray(NodeAddressArray *nodesArray);
 
 bool monitor_get_primary(Monitor *monitor, char *formation, int groupId,

--- a/src/bin/pg_autoctl/monitor.h
+++ b/src/bin/pg_autoctl/monitor.h
@@ -58,15 +58,15 @@ void printNodeEntry(NodeAddress *node);
 
 bool monitor_get_nodes(Monitor *monitor, char *formation, int groupId,
 					   NodeAddressArray *nodeArray);
-bool monitor_get_nodes_as_json(Monitor *monitor, char *formation, int groupId,
-							   char *json, int size);
+bool monitor_print_nodes_as_json(Monitor *monitor, char *formation, int groupId,
+								 FILE *stream);
 bool monitor_get_other_nodes(Monitor *monitor,
 							 char *myHost, int myPort, NodeState currentState,
 							 NodeAddressArray *nodeArray);
-bool monitor_get_other_nodes_as_json(Monitor *monitor,
-									 char *myHost, int myPort,
-									 NodeState currentState,
-									 char *json, int size);
+bool monitor_print_other_nodes_as_json(Monitor *monitor,
+									   char *myHost, int myPort,
+									   NodeState currentState,
+									   FILE *stream);
 void printNodeArray(NodeAddressArray *nodesArray);
 
 bool monitor_get_primary(Monitor *monitor, char *formation, int groupId,
@@ -102,8 +102,8 @@ bool monitor_perform_failover(Monitor *monitor, char *formation, int group);
 bool monitor_print_state(Monitor *monitor, char *formation, int group);
 bool monitor_print_last_events(Monitor *monitor,
 							   char *formation, int group, int count);
-bool monitor_get_state_as_json(Monitor *monitor, char *formation, int group,
-							   char *json, int size);
+bool monitor_print_state_as_json(Monitor *monitor, char *formation, int group,
+								 FILE *stream);
 
 bool monitor_create_formation(Monitor *monitor, char *formation, char *kind,
 							  char *dbname, bool ha, int numberSyncStandbys);

--- a/src/bin/pg_autoctl/monitor.h
+++ b/src/bin/pg_autoctl/monitor.h
@@ -103,8 +103,7 @@ bool monitor_perform_failover(Monitor *monitor, char *formation, int group);
 bool monitor_print_state(Monitor *monitor, char *formation, int group);
 bool monitor_print_last_events(Monitor *monitor,
 							   char *formation, int group, int count);
-bool monitor_print_state_as_json(Monitor *monitor, char *formation, int group,
-								 FILE *stream);
+bool monitor_print_state_as_json(Monitor *monitor, char *formation, int group);
 bool monitor_print_last_events_as_json(Monitor *monitor,
 									   char *formation, int group,
 									   int count,

--- a/src/monitor/node_active_protocol.c
+++ b/src/monitor/node_active_protocol.c
@@ -1259,7 +1259,7 @@ set_node_candidate_priority(PG_FUNCTION_ARGS)
 	nodesGroupList =
 		AutoFailoverNodeGroup(currentNode->formationId, currentNode->groupId);
 	nodesCount = list_length(nodesGroupList);
-	
+
 	if (candidatePriority < 0 || candidatePriority > 100)
 	{
 		ereport(ERROR, (ERRCODE_INVALID_PARAMETER_VALUE,


### PR DESCRIPTION
Implement more JSON support for the `pg_autoctl show` commands, and fix a buffer shortage problem for JSON output that does not fit in BUFSIZE, which is only 1024 bytes.

  - fix pg_autoctl show state --json
  - implement pg_autoctl show events --json
  - implement pg_autoctl show uri --json

Also in passing make the default output for `pg_autoctl show uri` more useful:

```
$ pg_autoctl show uri 
      Type |    Name | Connection String
-----------+---------+-------------------------------
   monitor | monitor | port=4000 dbname=pg_auto_failover host=/tmp user=autoctl_node
 formation | default | postgres://localhost:4002,localhost:4003,localhost:4001/postgres?target_session_attrs=read-write
```