### PR TITLE
Fix a race condition at initialization time.

### DIFF
--- a/src/monitor/expected/monitor.out
+++ b/src/monitor/expected/monitor.out
@@ -1,7 +1,8 @@
 -- Copyright (c) Microsoft Corporation. All rights reserved.
 -- Licensed under the PostgreSQL License.
 \x on
-select * from pgautofailover.register_node('default', 'localhost', 9876, 'postgres');
+select *
+  from pgautofailover.register_node('default', 'localhost', 9876, 'postgres');
 -[ RECORD 1 ]---------------+-------
 assigned_node_id            | 1
 assigned_group_id           | 0
@@ -9,10 +10,13 @@ assigned_group_state        | single
 assigned_candidate_priority | 100
 assigned_replication_quorum | t
 
-select * from pgautofailover.register_node('default', 'localhost', 9877, 'postgres');
-ERROR:  ProceedGroupState couldn't find the primary node in formation "default", group 0
-DETAIL:  activeNode is localhost:9877 in state wait_standby
-select * from pgautofailover.node_active('default', 'localhost', 9876);
+select *
+  from pgautofailover.register_node('default', 'localhost', 9877, 'postgres');
+ERROR:  primary node is still initializing
+HINT:  Retry registering in a moment
+select *
+  from pgautofailover.node_active('default', 'localhost', 9876,
+                                  current_group_role => 'single');
 -[ RECORD 1 ]---------------+-------
 assigned_node_id            | 1
 assigned_group_id           | 0
@@ -20,8 +24,15 @@ assigned_group_state        | single
 assigned_candidate_priority | 100
 assigned_replication_quorum | t
 
-select * from pgautofailover.node_active('default', 'localhost', 9877);
-ERROR:  node localhost:9877 is not registered
+select *
+  from pgautofailover.register_node('default', 'localhost', 9877, 'postgres');
+-[ RECORD 1 ]---------------+-------------
+assigned_node_id            | 2
+assigned_group_id           | 0
+assigned_group_state        | wait_standby
+assigned_candidate_priority | 100
+assigned_replication_quorum | t
+
 table pgautofailover.formation;
 -[ RECORD 1 ]--------+---------
 formationid          | default
@@ -34,30 +45,51 @@ number_sync_standbys | 1
 select formationid, nodeid, groupid, nodename, nodeport,
        goalstate, reportedstate, reportedpgisrunning, reportedrepstate
   from pgautofailover.node;
--[ RECORD 1 ]-------+----------
+-[ RECORD 1 ]-------+-------------
 formationid         | default
 nodeid              | 1
 groupid             | 0
 nodename            | localhost
 nodeport            | 9876
 goalstate           | single
-reportedstate       | init
+reportedstate       | single
 reportedpgisrunning | t
 reportedrepstate    | unknown
+-[ RECORD 2 ]-------+-------------
+formationid         | default
+nodeid              | 2
+groupid             | 0
+nodename            | localhost
+nodeport            | 9877
+goalstate           | wait_standby
+reportedstate       | init
+reportedpgisrunning | t
+reportedrepstate    | async
 
 select * from pgautofailover.get_primary('unknown formation');
 ERROR:  group has no writable node right now
 select * from pgautofailover.get_primary(group_id => -10);
 ERROR:  group has no writable node right now
 select * from pgautofailover.get_primary();
-ERROR:  group has no writable node right now
+-[ RECORD 1 ]---+----------
+primary_node_id | 1
+primary_name    | localhost
+primary_port    | 9876
+
 select * from pgautofailover.get_primary('default', 0);
-ERROR:  group has no writable node right now
-select * from pgautofailover.get_other_node('localhost', 9876);
-ERROR:  function pgautofailover.get_other_node(unknown, integer) does not exist
-LINE 1: select * from pgautofailover.get_other_node('localhost', 987...
-                      ^
-HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+-[ RECORD 1 ]---+----------
+primary_node_id | 1
+primary_name    | localhost
+primary_port    | 9876
+
+select * from pgautofailover.get_other_nodes('localhost', 9876);
+-[ RECORD 1 ]---+----------
+node_id         | 2
+node_name       | localhost
+node_port       | 9877
+node_lsn        | 0/0
+node_is_primary | f
+
 select pgautofailover.remove_node('localhost', 9876);
 -[ RECORD 1 ]--
 remove_node | t
@@ -74,10 +106,25 @@ number_sync_standbys | 1
 select formationid, nodeid, groupid, nodename, nodeport,
        goalstate, reportedstate, reportedpgisrunning, reportedrepstate
   from pgautofailover.node;
-(0 rows)
+-[ RECORD 1 ]-------+----------
+formationid         | default
+nodeid              | 2
+groupid             | 0
+nodename            | localhost
+nodeport            | 9877
+goalstate           | single
+reportedstate       | init
+reportedpgisrunning | t
+reportedrepstate    | async
 
-select * from pgautofailover.node_active('default', 'localhost', 9876);
-ERROR:  node localhost:9876 is not registered
+select * from pgautofailover.node_active('default', 'localhost', 9877);
+-[ RECORD 1 ]---------------+-------
+assigned_node_id            | 2
+assigned_group_id           | 0
+assigned_group_state        | single
+assigned_candidate_priority | 100
+assigned_replication_quorum | t
+
 -- should fail as there's no primary at this point
 select pgautofailover.perform_failover();
 ERROR:  cannot fail over: group does not have 2 nodes

--- a/src/monitor/sql/monitor.sql
+++ b/src/monitor/sql/monitor.sql
@@ -3,11 +3,18 @@
 
 \x on
 
-select * from pgautofailover.register_node('default', 'localhost', 9876, 'postgres');
-select * from pgautofailover.register_node('default', 'localhost', 9877, 'postgres');
+select *
+  from pgautofailover.register_node('default', 'localhost', 9876, 'postgres');
 
-select * from pgautofailover.node_active('default', 'localhost', 9876);
-select * from pgautofailover.node_active('default', 'localhost', 9877);
+select *
+  from pgautofailover.register_node('default', 'localhost', 9877, 'postgres');
+
+select *
+  from pgautofailover.node_active('default', 'localhost', 9876,
+                                  current_group_role => 'single');
+
+select *
+  from pgautofailover.register_node('default', 'localhost', 9877, 'postgres');
 
 table pgautofailover.formation;
 
@@ -21,7 +28,7 @@ select * from pgautofailover.get_primary(group_id => -10);
 select * from pgautofailover.get_primary();
 
 select * from pgautofailover.get_primary('default', 0);
-select * from pgautofailover.get_other_node('localhost', 9876);
+select * from pgautofailover.get_other_nodes('localhost', 9876);
 
 select pgautofailover.remove_node('localhost', 9876);
 
@@ -32,7 +39,7 @@ select formationid, nodeid, groupid, nodename, nodeport,
        goalstate, reportedstate, reportedpgisrunning, reportedrepstate
   from pgautofailover.node;
 
-select * from pgautofailover.node_active('default', 'localhost', 9876);
+select * from pgautofailover.node_active('default', 'localhost', 9877);
 
 -- should fail as there's no primary at this point
 select pgautofailover.perform_failover();


### PR DESCRIPTION
When registering a standby, we need the primary node to have reached the
SINGLE state already. There's a possibility that the primary has been
registered (INIT/SINGLE), but has not reached the SINGLE state yet.