### PR TITLE
Refrain from setting pgSetup.pg_ctl for pg_autoctl show state|nodes.

### DIFF
--- a/src/bin/pg_autoctl/cli_show.c
+++ b/src/bin/pg_autoctl/cli_show.c
@@ -277,12 +277,6 @@ cli_show_state_getopts(int argc, char **argv)
 		strlcpy(options.pgSetup.pgdata, pgdata, MAXPGPATH);
 	}
 
-	/*
-	 * pg_setup_init wants a single pg_ctl, and we don't use it here: pretend
-	 * we had a --pgctl option and processed it.
-	 */
-	set_first_pgctl(&(options.pgSetup));
-
 	keeperOptions = options;
 
 	return optind;
@@ -497,12 +491,6 @@ cli_show_nodes_getopts(int argc, char **argv)
 
 		strlcpy(options.pgSetup.pgdata, pgdata, MAXPGPATH);
 	}
-
-	/*
-	 * pg_setup_init wants a single pg_ctl, and we don't use it here: pretend
-	 * we had a --pgctl option and processed it.
-	 */
-	set_first_pgctl(&(options.pgSetup));
 
 	keeperOptions = options;
 


### PR DESCRIPTION
We don't actually call into the pg_ctl client in those code paths, so trying
to initialise this setting is not doing us any good and opens an error
condition.