### PR TITLE
Feature/application name

### DIFF
--- a/src/bin/pg_autoctl/cli_common.h
+++ b/src/bin/pg_autoctl/cli_common.h
@@ -101,6 +101,7 @@ extern CommandLine show_events_command;
 extern CommandLine show_state_command;
 extern CommandLine show_nodes_command;
 extern CommandLine show_file_command;
+extern CommandLine show_standby_names_command;
 
 /* cli_systemd.c */
 extern CommandLine systemd_cat_service_file_command;

--- a/src/bin/pg_autoctl/cli_common.h
+++ b/src/bin/pg_autoctl/cli_common.h
@@ -101,6 +101,7 @@ extern CommandLine show_events_command;
 extern CommandLine show_state_command;
 extern CommandLine show_nodes_command;
 extern CommandLine show_file_command;
+extern CommandLine show_sync_standby_names_command;
 extern CommandLine show_standby_names_command;
 
 /* cli_systemd.c */

--- a/src/bin/pg_autoctl/cli_do_misc.c
+++ b/src/bin/pg_autoctl/cli_do_misc.c
@@ -380,6 +380,7 @@ keeper_cli_rewind_old_primary(int argc, char **argv)
 	replicationSource.userName = PG_AUTOCTL_REPLICA_USERNAME;
 	replicationSource.password = config.replication_password;
 	replicationSource.slotName = config.replication_slot_name;
+	replicationSource.applicationName = config.replication_slot_name;
 	replicationSource.maximumBackupRate = MAXIMUM_BACKUP_RATE;
 
 	if (!primary_rewind_to_standby(&postgres, &replicationSource))

--- a/src/bin/pg_autoctl/cli_root.c
+++ b/src/bin/pg_autoctl/cli_root.c
@@ -38,6 +38,7 @@ CommandLine *show_subcommands[] = {
 	&show_events_command,
 	&show_state_command,
 	&show_nodes_command,
+	&show_standby_names_command,
 	&show_file_command,
 	&systemd_cat_service_file_command,
 	NULL

--- a/src/bin/pg_autoctl/cli_root.c
+++ b/src/bin/pg_autoctl/cli_root.c
@@ -38,6 +38,7 @@ CommandLine *show_subcommands[] = {
 	&show_events_command,
 	&show_state_command,
 	&show_nodes_command,
+	&show_sync_standby_names_command,
 	&show_standby_names_command,
 	&show_file_command,
 	&systemd_cat_service_file_command,

--- a/src/bin/pg_autoctl/cli_show.c
+++ b/src/bin/pg_autoctl/cli_show.c
@@ -37,6 +37,9 @@ static void cli_show_events(int argc, char **argv);
 static int cli_show_nodes_getopts(int argc, char **argv);
 static void cli_show_nodes(int argc, char **argv);
 
+static int cli_show_standby_names_getopts(int argc, char **argv);
+static void cli_show_standby_names(int argc, char **argv);
+
 static int cli_show_file_getopts(int argc, char **argv);
 static void cli_show_file(int argc, char **argv);
 static bool fprint_file_contents(const char *filename);
@@ -93,6 +96,16 @@ CommandLine show_nodes_command =
 				 "  --json        output data in the JSON format\n",
 				 cli_show_nodes_getopts,
 				 cli_show_nodes);
+
+CommandLine show_standby_names_command =
+	make_command("synchronous_standby_names",
+				 "Prints synchronous_standby_names for a given group",
+				 " [ --pgdata ] --formation --group",
+				 "  --pgdata      path to data directory	 \n"		\
+				 "  --formation   formation to query, defaults to 'default'\n" \
+				 "  --group       group to query formation, defaults to all\n",
+				 cli_show_standby_names_getopts,
+				 cli_show_standby_names);
 
 CommandLine show_file_command =
 	make_command("file",
@@ -552,6 +565,184 @@ cli_show_nodes(int argc, char **argv)
 			exit(EXIT_CODE_MONITOR);
 		}
 	}
+}
+
+
+/*
+ * cli_show_nodes_getopts parses the command line options for the
+ * command `pg_autoctl show nodes`.
+ */
+static int
+cli_show_standby_names_getopts(int argc, char **argv)
+{
+	KeeperConfig options = { 0 };
+	int c, option_index = 0, errors = 0;
+	int verboseCount = 0;
+
+	static struct option long_options[] = {
+		{ "pgdata", required_argument, NULL, 'D' },
+		{ "formation", required_argument, NULL, 'f' },
+		{ "group", required_argument, NULL, 'g' },
+		{ "version", no_argument, NULL, 'V' },
+		{ "verbose", no_argument, NULL, 'v' },
+		{ "quiet", no_argument, NULL, 'q' },
+		{ "help", no_argument, NULL, 'h' },
+		{ NULL, 0, NULL, 0 }
+	};
+
+	/* set default values for our options, when we have some */
+	options.network_partition_timeout = -1;
+	options.prepare_promotion_catchup = -1;
+	options.prepare_promotion_walreceiver = -1;
+	options.postgresql_restart_failure_timeout = -1;
+	options.postgresql_restart_failure_max_retries = -1;
+
+	strlcpy(options.formation, "default", NAMEDATALEN);
+
+	optind = 0;
+
+	while ((c = getopt_long(argc, argv, "D:f:g:n:Vvqh",
+							long_options, &option_index)) != -1)
+	{
+		switch (c)
+		{
+			case 'D':
+			{
+				strlcpy(options.pgSetup.pgdata, optarg, MAXPGPATH);
+				log_trace("--pgdata %s", options.pgSetup.pgdata);
+				break;
+			}
+
+			case 'f':
+			{
+				strlcpy(options.formation, optarg, NAMEDATALEN);
+				log_trace("--formation %s", options.formation);
+				break;
+			}
+
+			case 'g':
+			{
+				int scanResult = sscanf(optarg, "%d", &options.groupId);
+				if (scanResult == 0)
+				{
+					log_fatal("--group argument is not a valid group ID: \"%s\"",
+							  optarg);
+					exit(EXIT_CODE_BAD_ARGS);
+				}
+				log_trace("--group %d", options.groupId);
+				break;
+			}
+
+			case 'V':
+			{
+				/* keeper_cli_print_version prints version and exits. */
+				keeper_cli_print_version(argc, argv);
+				break;
+			}
+
+			case 'v':
+			{
+				++verboseCount;
+				switch (verboseCount)
+				{
+					case 1:
+						log_set_level(LOG_INFO);
+						break;
+
+					case 2:
+						log_set_level(LOG_DEBUG);
+						break;
+
+					default:
+						log_set_level(LOG_TRACE);
+						break;
+				}
+				break;
+			}
+
+			case 'q':
+			{
+				log_set_level(LOG_ERROR);
+				break;
+			}
+
+			case 'h':
+			{
+				commandline_help(stderr);
+				exit(EXIT_CODE_QUIT);
+				break;
+			}
+
+			default:
+			{
+				/* getopt_long already wrote an error message */
+				errors++;
+			}
+		}
+	}
+
+	if (errors > 0)
+	{
+		commandline_help(stderr);
+		exit(EXIT_CODE_BAD_ARGS);
+	}
+
+	if (IS_EMPTY_STRING_BUFFER(options.pgSetup.pgdata))
+	{
+		char *pgdata = getenv("PGDATA");
+
+		if (pgdata == NULL)
+		{
+			log_fatal("Failed to get PGDATA either from the environment "
+					  "or from --pgdata");
+			exit(EXIT_CODE_BAD_ARGS);
+		}
+
+		strlcpy(options.pgSetup.pgdata, pgdata, MAXPGPATH);
+	}
+
+	/*
+	 * pg_setup_init wants a single pg_ctl, and we don't use it here: pretend
+	 * we had a --pgctl option and processed it.
+	 */
+	set_first_pgctl(&(options.pgSetup));
+
+	keeperOptions = options;
+
+	return optind;
+}
+
+
+/*
+ * cli_show_standby_names prints the synchronous_standby_names setting value
+ * for a given group (in a known formation).
+ */
+static void
+cli_show_standby_names(int argc, char **argv)
+{
+	KeeperConfig config = keeperOptions;
+	Monitor monitor = { 0 };
+	char synchronous_standby_names[BUFSIZE] = { 0 };
+
+	if (!monitor_init_from_pgsetup(&monitor, &config.pgSetup))
+	{
+		/* errors have already been logged */
+		exit(EXIT_CODE_BAD_ARGS);
+	}
+
+	if (!monitor_synchronous_standby_names(
+			&monitor,
+			config.formation,
+			config.groupId,
+			synchronous_standby_names,
+			BUFSIZE))
+	{
+		log_fatal("Failed to get the synchronous_standby_names setting value "
+				  " from the monitor, see above for details");
+		exit(EXIT_CODE_MONITOR);
+	}
+
+	(void) fprintf(stdout, "%s\n", synchronous_standby_names);
 }
 
 

--- a/src/bin/pg_autoctl/defaults.h
+++ b/src/bin/pg_autoctl/defaults.h
@@ -32,6 +32,7 @@
 #define REPLICATION_SLOT_NAME_DEFAULT "pgautofailover_standby"
 #define REPLICATION_SLOT_NAME_PATTERN "^pgautofailover_standby_"
 #define REPLICATION_PASSWORD_DEFAULT NULL
+#define REPLICATION_APPLICATION_NAME_PREFIX "pgautofailover_standby_"
 #define FORMATION_DEFAULT "default"
 #define GROUP_ID_DEFAULT 0
 #define POSTGRES_CONNECT_TIMEOUT "5"

--- a/src/bin/pg_autoctl/fsm_transition.c
+++ b/src/bin/pg_autoctl/fsm_transition.c
@@ -682,6 +682,8 @@ fsm_init_standby(Keeper *keeper)
 	ReplicationSource replicationSource = { 0 };
 	int groupId = keeper->state.current_group;
 
+	char applicationName[BUFSIZE] = { 0 };
+
 	/* get the primary node to follow */
 	if (!config->monitorDisabled)
 	{
@@ -707,6 +709,13 @@ fsm_init_standby(Keeper *keeper)
 	replicationSource.slotName = config->replication_slot_name;
 	replicationSource.maximumBackupRate = config->maximum_backup_rate;
 	replicationSource.backupDir = config->backupDirectory;
+
+	/* prepare our application_name */
+	snprintf(applicationName, BUFSIZE,
+			 "%s%d",
+			 REPLICATION_APPLICATION_NAME_PREFIX,
+			 keeper->state.current_node_id);
+	replicationSource.applicationName = applicationName;
 
 	if (!standby_init_database(postgres, &replicationSource))
 	{
@@ -731,6 +740,7 @@ fsm_rewind_or_init(Keeper *keeper)
 	LocalPostgresServer *postgres = &(keeper->postgres);
 	ReplicationSource replicationSource = { 0 };
 	int groupId = keeper->state.current_group;
+	char applicationName[BUFSIZE] = { 0 };
 
 	/* get the primary node to follow */
 	if (!config->monitorDisabled)
@@ -757,6 +767,13 @@ fsm_rewind_or_init(Keeper *keeper)
 	replicationSource.slotName = config->replication_slot_name;
 	replicationSource.maximumBackupRate = config->maximum_backup_rate;
 	replicationSource.backupDir = config->backupDirectory;
+
+	/* prepare our application_name */
+	snprintf(applicationName, BUFSIZE,
+			 "%s%d",
+			 REPLICATION_APPLICATION_NAME_PREFIX,
+			 keeper->state.current_node_id);
+	replicationSource.applicationName = applicationName;
 
 	if (!primary_rewind_to_standby(postgres, &replicationSource))
 	{

--- a/src/bin/pg_autoctl/fsm_transition.c
+++ b/src/bin/pg_autoctl/fsm_transition.c
@@ -765,6 +765,7 @@ fsm_rewind_or_init(Keeper *keeper)
 	replicationSource.userName = PG_AUTOCTL_REPLICA_USERNAME;
 	replicationSource.password = config->replication_password;
 	replicationSource.slotName = config->replication_slot_name;
+	replicationSource.applicationName = config->replication_slot_name;
 	replicationSource.maximumBackupRate = config->maximum_backup_rate;
 	replicationSource.backupDir = config->backupDirectory;
 

--- a/src/bin/pg_autoctl/fsm_transition.c
+++ b/src/bin/pg_autoctl/fsm_transition.c
@@ -669,6 +669,7 @@ fsm_stop_postgres(Keeper *keeper)
 }
 
 
+
 /*
  * fsm_init_standby is used when the primary is now ready to accept a standby,
  * we're the standby.

--- a/src/bin/pg_autoctl/keeper.c
+++ b/src/bin/pg_autoctl/keeper.c
@@ -143,7 +143,7 @@ keeper_should_ensure_current_state_before_transition(Keeper *keeper)
 		return false;
 	}
 
-	if (keeperState->assigned_role == DEMOTED_STATE
+	if (keeperState->assigned_role == DRAINING_STATE
 		|| keeperState->assigned_role == DEMOTE_TIMEOUT_STATE
 		|| keeperState->assigned_role == DEMOTED_STATE)
 	{
@@ -151,7 +151,7 @@ keeper_should_ensure_current_state_before_transition(Keeper *keeper)
 		return false;
 	}
 
-	if (keeperState->current_role == DEMOTED_STATE
+	if (keeperState->current_role == DRAINING_STATE
 		|| keeperState->current_role == DEMOTE_TIMEOUT_STATE
 		|| keeperState->current_role == DEMOTED_STATE)
 	{

--- a/src/bin/pg_autoctl/pgctl.c
+++ b/src/bin/pg_autoctl/pgctl.c
@@ -1017,6 +1017,7 @@ pg_write_recovery_conf(const char *pgdata,
 	join_path_components(recoveryConfPath, pgdata, "recovery.conf");
 
 	log_info("Writing recovery configuration to \"%s\"", recoveryConfPath);
+	log_debug("%s:\n%s", recoveryConfPath, content->data);
 
 	if (!write_file(content->data, content->len, recoveryConfPath))
 	{
@@ -1108,10 +1109,7 @@ prepare_primary_conninfo(char *primaryConnInfo,
 	buffer = createPQExpBuffer();
 
 	/* application_name shows up in pg_stat_replication on the primary */
-	appendPQExpBuffer(buffer,
-					  "application_name=pgautofailover_standby_%d",
-					  primaryNodeId);
-
+	appendPQExpBuffer(buffer, "application_name=%s", applicationName);
 	appendPQExpBuffer(buffer, " host=%s", primaryHost);
 	appendPQExpBuffer(buffer, " port=%d", primaryPort);
 	appendPQExpBuffer(buffer, " user=%s", replicationUsername);

--- a/src/bin/pg_autoctl/pgctl.c
+++ b/src/bin/pg_autoctl/pgctl.c
@@ -1210,7 +1210,7 @@ pg_write_standby_signal(const char *configFilePath,
 	 * false here and let the main loop try again. At least Postgres won't
 	 * start as a cloned single accepting writes.
 	 */
-	if (!pg_include_config(standbyConfigFilePath,
+	if (!pg_include_config(configFilePath,
 						   AUTOCTL_SB_CONF_INCLUDE_LINE,
 						   AUTOCTL_SB_CONF_INCLUDE_REGEX,
 						   AUTOCTL_CONF_INCLUDE_COMMENT))

--- a/src/bin/pg_autoctl/pgctl.c
+++ b/src/bin/pg_autoctl/pgctl.c
@@ -1107,7 +1107,12 @@ prepare_primary_conninfo(char *primaryConnInfo,
 
 	buffer = createPQExpBuffer();
 
-	appendPQExpBuffer(buffer, "host=%s", primaryHost);
+	/* application_name shows up in pg_stat_replication on the primary */
+	appendPQExpBuffer(buffer,
+					  "application_name=pgautofailover_standby_%d",
+					  primaryNodeId);
+
+	appendPQExpBuffer(buffer, " host=%s", primaryHost);
 	appendPQExpBuffer(buffer, " port=%d", primaryPort);
 	appendPQExpBuffer(buffer, " user=%s", replicationUsername);
 

--- a/src/bin/pg_autoctl/pgctl.h
+++ b/src/bin/pg_autoctl/pgctl.h
@@ -37,7 +37,9 @@ bool pg_basebackup(const char *pgdata,
 				   const char *replication_username,
 				   const char *replication_password,
 				   const char *replication_slot_name,
-				   const char *primary_hostname, int primary_port);
+				   const char *primary_hostname,
+				   int primary_port,
+				   const char *application_name);
 bool pg_rewind(const char *pgdata, const char *pg_ctl, const char *primaryHost,
 			   int primaryPort, const char *databaseName,
 			   const char *replicationUsername,

--- a/src/bin/pg_autoctl/pgsql.c
+++ b/src/bin/pg_autoctl/pgsql.c
@@ -807,28 +807,6 @@ pgsql_reload_conf(PGSQL *pgsql)
 
 
 /*
- * pgsql_get_config_file_path gets the value of the config_file setting in
- * Postgres or returns false if a failure occurred. The value is copied to
- * the configFilePath pointer.
- */
-bool
-pgsql_get_config_file_path(PGSQL *pgsql, char *configFilePath, int maxPathLength)
-{
-	char *configValue = NULL;
-
-	if (!pgsql_get_current_setting(pgsql, "config_file", &configValue))
-	{
-		return false;
-	}
-
-	strlcpy(configFilePath, configValue, maxPathLength);
-	free(configValue);
-
-	return true;
-}
-
-
-/*
  * pgsql_get_hba_file_path gets the value of the hba_file setting in
  * Postgres or returns false if a failure occurred. The value is copied to
  * the hbaFilePath pointer.

--- a/src/bin/pg_autoctl/pgsql.c
+++ b/src/bin/pg_autoctl/pgsql.c
@@ -794,6 +794,38 @@ pgsql_alter_system_set(PGSQL *pgsql, GUC setting)
 
 
 /*
+ * pgsql_reset_primary_conninfo issues the following SQL commands:
+ *
+ *   ALTER SYSTEM RESET primary_conninfo;
+ *   ALTER SYSTEM RESET primary_slot_name;
+ *
+ * That's necessary to clean-up the replication settings that pg_basebackup
+ * puts in place in postgresql.auto.conf in Postgres 12. We don't reload the
+ * configuration after the RESET in that case, because Postgres 12 requires a
+ * restart to apply the new setting value anyway.
+ */
+bool
+pgsql_reset_primary_conninfo(PGSQL *pgsql)
+{
+	char *reset_primary_conninfo = "ALTER SYSTEM RESET primary_conninfo";
+	char *reset_primary_slot_name = "ALTER SYSTEM RESET primary_slot_name";
+
+	/* ALTER SYSTEM cannot run inside a transaction block */
+	if (!pgsql_execute(pgsql, reset_primary_conninfo))
+	{
+		return false;
+	}
+
+	if (!pgsql_execute(pgsql, reset_primary_slot_name))
+	{
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
  * pgsql_reload_conf causes open sessions to reload the PostgresSQL configuration
  * files.
  */

--- a/src/bin/pg_autoctl/pgsql.h
+++ b/src/bin/pg_autoctl/pgsql.h
@@ -204,6 +204,7 @@ bool hostname_from_uri(const char *pguri,
 int make_conninfo_field_str(char *destination, const char *key, const char *value);
 int make_conninfo_field_int(char *destination, const char *key, int value);
 bool validate_connection_string(const char *connectionString);
+bool pgsql_reset_primary_conninfo(PGSQL *pgsql);
 
 bool pgsql_get_postgres_metadata(PGSQL *pgsql, const char *slotName,
 								 bool *pg_is_in_recovery,

--- a/src/bin/pg_autoctl/pgsql.h
+++ b/src/bin/pg_autoctl/pgsql.h
@@ -101,6 +101,7 @@ typedef struct ReplicationSource
 	char *password;
 	char *maximumBackupRate;
 	char *backupDir;
+	char *applicationName;
 } ReplicationSource;
 
 

--- a/src/bin/pg_autoctl/pgsql.h
+++ b/src/bin/pg_autoctl/pgsql.h
@@ -193,7 +193,6 @@ bool pgsql_disable_synchronous_replication(PGSQL *pgsql);
 bool pgsql_set_default_transaction_mode_read_only(PGSQL *pgsql);
 bool pgsql_set_default_transaction_mode_read_write(PGSQL *pgsql);
 bool pgsql_checkpoint(PGSQL *pgsql);
-bool pgsql_get_config_file_path(PGSQL *pgsql, char *configFilePath, int maxPathLength);
 bool pgsql_get_hba_file_path(PGSQL *pgsql, char *hbaFilePath, int maxPathLength);
 bool pgsql_create_database(PGSQL *pgsql, const char *dbname, const char *owner);
 bool pgsql_create_extension(PGSQL *pgsql, const char *name);

--- a/src/bin/pg_autoctl/primary_standby.c
+++ b/src/bin/pg_autoctl/primary_standby.c
@@ -352,14 +352,8 @@ postgres_add_default_settings(LocalPostgresServer *postgres)
 
 	log_trace("primary_add_default_postgres_settings");
 
-	/* get the path of the config file from the running database */
-	if (!pgsql_get_config_file_path(pgsql, configFilePath, MAXPGPATH))
-	{
-		log_error("Failed to add default settings to postgres.conf: couldn't get "
-				  "the postgresql.conf path from the local postgres server, see "
-				  "above for details");
-		return false;
-	}
+	/* configFilePath = $PGDATA/postgresql.conf */
+	join_path_components(configFilePath, pgSetup->pgdata, "postgresql.conf");
 
 	/* in case of errors, pgsql_ functions finish the connection */
 	pgsql_finish(pgsql);
@@ -607,13 +601,8 @@ primary_rewind_to_standby(LocalPostgresServer *postgres,
 	log_info("Rewinding PostgreSQL to follow new primary %s:%d",
 			 primaryNode->host, primaryNode->port);
 
-	/* get the path of the config file from the running database */
-	if (!pgsql_get_config_file_path(pgsql, configFilePath, MAXPGPATH))
-	{
-		log_error("Failed to get the postgresql.conf path from the "
-				  "local postgres server, see above for details");
-		return false;
-	}
+	/* configFilePath = $PGDATA/postgresql.conf */
+	join_path_components(configFilePath, pgSetup->pgdata, "postgresql.conf");
 
 	if (!pg_ctl_stop(pgSetup->pg_ctl, pgSetup->pgdata))
 	{

--- a/src/bin/pg_autoctl/primary_standby.c
+++ b/src/bin/pg_autoctl/primary_standby.c
@@ -556,7 +556,8 @@ standby_init_database(LocalPostgresServer *postgres,
 					   replicationSource->password,
 					   replicationSource->slotName,
 					   replicationSource->primaryNode.host,
-					   replicationSource->primaryNode.port))
+					   replicationSource->primaryNode.port,
+					   replicationSource->applicationName))
 	{
 		return false;
 	}

--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -727,7 +727,7 @@ class PGAutoCtl():
         if argv:
             self.command = [self.program] + argv
 
-    def run(self):
+    def run(self, level='-vv'):
         """
         Runs our command in the background, returns immediately.
 
@@ -735,7 +735,7 @@ class PGAutoCtl():
         We could be given a full `pg_autoctl create postgres --run` command.
         """
         if not self.command:
-            self.command = [self.program, 'run', '--pgdata', self.datadir, '-vv']
+            self.command = [self.program, 'run', '--pgdata', self.datadir, level]
 
         self.run_proc = self.vnode.run(self.command)
         print("pg_autoctl run [%d]" % self.run_proc.pid)

--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -229,7 +229,6 @@ class PGNode:
         """
         self.stop_pg_autoctl()
 
-
         try:
             destroy = PGAutoCtl(self.vnode, self.datadir)
             destroy.execute("pg_autoctl do destroy", 'destroy')
@@ -272,6 +271,15 @@ class PGNode:
                             ".local/share/pg_autoctl",
                             pgdata,
                             "pg_autoctl.state")
+
+    def get_postgres_logs(self):
+        ldir = os.path.join(self.datadir, "log")
+        logs = []
+        for logfile in os.listdir(ldir):
+            logs += ["\n\n%s:\n" % logfile]
+            logs += open(os.path.join(ldir, logfile)).readlines()
+
+        return "".join(logs)
 
 
 class DataNode(PGNode):
@@ -358,13 +366,14 @@ class DataNode(PGNode):
                 (self.datadir, target_state, timeout))
 
             events = self.get_events_str()
+            pglogs = self.get_postgres_logs()
 
             if self.pg_autoctl and self.pg_autoctl.run_proc:
                 out, err = self.stop_pg_autoctl()
                 raise Exception("%s failed to reach %s after %d attempts: " \
-                                "\n%s\n%s\n%s" %
+                                "\n%s\n%s\n%s\n%s" %
                                 (self.datadir, target_state, timeout,
-                                 out, err, events))
+                                 out, err, events, pglogs))
             else:
                 raise Exception("%s failed to reach %s after %d attempts:\n%s" %
                                 (self.datadir, target_state, timeout, events))
@@ -524,6 +533,17 @@ SELECT reportedstate
                                    'show', 'synchronous_standby_names')
 
         return out.strip()
+
+    def list_replication_slot_names(self):
+        """
+            Returns a list of the replication slot names on the local Postgres.
+        """
+        query = "select slot_name from pg_replication_slots " \
+            + "where slot_name ~ '^pgautofailover_standby_' " \
+            + " and slot_type = 'physical'"
+
+        result = self.run_sql_query(query)
+        return [row[0] for row in result]
 
 
 class MonitorNode(PGNode):

--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -282,6 +282,16 @@ class PGNode:
             logs += ["\n\n%s:\n" % logfile]
             logs += open(os.path.join(ldir, logfile)).readlines()
 
+        # it's not really logs but we want to see that too
+        for inc in ["recovery.conf",
+                    "postgresql.auto.conf",
+                    "postgresql-auto-failover.conf",
+                    "postgresql-auto-failover-standby.conf"]:
+            conf = os.path.join(self.datadir, inc)
+            if os.path.isfile(conf):
+                logs += ["\n\n%s:\n" % conf]
+                logs += open(conf).readlines()
+
         return "".join(logs)
 
 

--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -274,8 +274,11 @@ class PGNode:
 
     def get_postgres_logs(self):
         ldir = os.path.join(self.datadir, "log")
+        logfiles = os.listdir(ldir)
+        logfiles.sort()
+
         logs = []
-        for logfile in os.listdir(ldir):
+        for logfile in logfiles:
             logs += ["\n\n%s:\n" % logfile]
             logs += open(os.path.join(ldir, logfile)).readlines()
 


### PR DESCRIPTION
Use application_name in our primary_conninfo setting, so that we can use the computed synchronous_standby_names: the names are checked with the application_name value for the replication connections.

In passing, stop using `pgsql_get_config_file_path()` to discover live where `postgresql.conf` is located and just assume it's located in $PGDATA. After all, we fail to create a standby when that's not the case.

Finally, introduce `pg_autoctl show synchronous_standby_names` command.