### PR TITLE
Refrain from setting pgSetup.pg_ctl when we don't need it.

### DIFF
--- a/src/bin/pg_autoctl/cli_formation.c
+++ b/src/bin/pg_autoctl/cli_formation.c
@@ -163,12 +163,6 @@ keeper_cli_formation_getopts(int argc, char **argv)
 		strlcpy(options.pgSetup.pgdata, pgdata, MAXPGPATH);
 	}
 
-	/*
-	 * pg_setup_init wants a single pg_ctl, and we don't use it here: pretend
-	 * we had a --pgctl option and processed it.
-	 */
-	set_first_pgctl(&(options.pgSetup));
-
 	/* publish our option parsing in the global variable */
 	formationOptions = options;
 
@@ -331,12 +325,6 @@ keeper_cli_formation_create_getopts(int argc, char **argv)
 				  DEFAULT_DATABASE_NAME);
 		strlcpy(options.dbname, DEFAULT_DATABASE_NAME, NAMEDATALEN);
 	}
-
-	/*
-	 * pg_setup_init wants a single pg_ctl, and we don't use it here: pretend
-	 * we had a --pgctl option and processed it.
-	 */
-	set_first_pgctl(&(options.pgSetup));
 
 	/* publish our option parsing in the global variable */
 	formationOptions = options;

--- a/src/bin/pg_autoctl/cli_perform.c
+++ b/src/bin/pg_autoctl/cli_perform.c
@@ -185,12 +185,6 @@ cli_perform_failover_getopts(int argc, char **argv)
 		strlcpy(options.pgSetup.pgdata, pgdata, MAXPGPATH);
 	}
 
-	/*
-	 * pg_setup_init wants a single pg_ctl, and we don't use it here: pretend
-	 * we had a --pgctl option and processed it.
-	 */
-	set_first_pgctl(&(options.pgSetup));
-
 	keeperOptions = options;
 
 	return optind;

--- a/src/bin/pg_autoctl/cli_show.c
+++ b/src/bin/pg_autoctl/cli_show.c
@@ -268,12 +268,6 @@ cli_show_state_getopts(int argc, char **argv)
 		strlcpy(options.pgSetup.pgdata, pgdata, MAXPGPATH);
 	}
 
-	/*
-	 * pg_setup_init wants a single pg_ctl, and we don't use it here: pretend
-	 * we had a --pgctl option and processed it.
-	 */
-	set_first_pgctl(&(options.pgSetup));
-
 	keeperOptions = options;
 
 	return optind;


### PR DESCRIPTION
To be able to set the first pg_ctl found in the PATH we require that there's
at least one pg_ctl entry there, and it's not always the case. Most of
pg_autoctl commands won't need to call pg_ctl and other bin tools anyway.