### PR TITLE
Add .editorconfig so indentation is done right across editors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,28 @@
+# top-most EditorConfig file
+root = true
+
+# rules for all files
+# we use tabs with indent size 4
+[*]
+indent_style = tab
+indent_size = 4
+tab_width = 4
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+
+# Don't change test output files, pngs or test data files
+[*.{out,png,data}]
+insert_final_newline = unset
+trim_trailing_whitespace = unset
+
+[*.{sql,sh,py}]
+indent_style = space
+indent_size = 4
+tab_width = 4
+
+[*.yml]
+indent_style = space
+indent_size = 2
+tab_width = 2


### PR DESCRIPTION
Github respects this file and basically all editors have support for it. Either
through plugin or out of the box.  https://editorconfig.org/