### PR TITLE
Implement pg_autoctl drop monitor and drop node --nodename --nodeport.

### DIFF
--- a/docs/ref/reference.rst
+++ b/docs/ref/reference.rst
@@ -45,6 +45,7 @@ keeper::
       formation    Create a new formation on the pg_auto_failover monitor
 
     pg_autoctl drop
+      monitor    Drop the pg_auto_failover monitor
       node       Drop a node from the pg_auto_failover monitor
       formation  Drop a formation on the pg_auto_failover monitor
 
@@ -539,16 +540,24 @@ Removing a node from the pg_auto_failover monitor
 To clean-up an installation and remove a PostgreSQL instance from pg_auto_failover
 keeper and monitor, use the following command::
 
-  $ pg_autoctl drop node --help
-  pg_autoctl drop node: Drop a node from the pg_auto_failover monitor
-  usage: pg_autoctl drop node  [ --pgdata --destroy ]
-
-    --pgdata      path to data directory
-    --destroy     also destroy Postgres database
+    $ pg_autoctl drop node --help
+    pg_autoctl drop node: Drop a node from the pg_auto_failover monitor
+    usage: pg_autoctl drop node [ --pgdata --destroy --nodename --nodeport ]
+    
+      --pgdata      path to data directory
+      --destroy     also destroy Postgres database
+      --nodename    nodename to remove from the monitor
+      --nodeport    Postgres port of the node to remove
 
 The ``pg_autoctl drop node`` connects to the monitor and removes the
 nodename from it, then removes the local pg_auto_failover keeper state file. The
 configuration file is not removed.
+
+It is possible to run the ``pg_autoctl drop node`` command either from the
+node itself and then the ``--destroy`` option is available to wipe out
+everything, including configuration files and PGDATA; or to run the command
+from the monitor and then use the ``--nodename`` and ``--nodeport`` options
+to target a (presumably dead) node to remove from the monitor registration.
 
 .. _pg_autoctl_maintenance:
 

--- a/src/bin/pg_autoctl/cli_common.c
+++ b/src/bin/pg_autoctl/cli_common.c
@@ -10,6 +10,7 @@
 #include <errno.h>
 #include <inttypes.h>
 #include <getopt.h>
+#include <signal.h>
 
 #include "commandline.h"
 
@@ -32,6 +33,10 @@ bool allowRemovingPgdata = false;
 bool createAndRun = false;
 bool outputJSON = false;
 int ssl_flag = 0;
+
+static void stop_postgres_and_remove_pgdata_and_config(
+	ConfigFilePaths *pathnames,
+	PostgresSetup *pgSetup);
 
 /*
  * cli_create_node_getopts parses the CLI options for the pg_autoctl create
@@ -1015,4 +1020,156 @@ cli_pprint_json(JSON_Value *js)
 	/* free intermediate memory */
 	json_free_serialized_string(serialized_string);
 	json_value_free(js);
+}
+
+
+/*
+ * cli_drop_local_node drops the local Postgres node.
+ */
+void
+cli_drop_local_node(KeeperConfig *config, bool dropAndDestroy)
+{
+	Keeper keeper = { 0 };
+
+	/*
+	 * Now also stop the pg_autoctl process.
+	 */
+	if (file_exists(config->pathnames.pid))
+	{
+		pid_t pid = 0;
+
+		if (read_pidfile(config->pathnames.pid, &pid))
+		{
+			log_info("An instance of this keeper is running with PID %d, "
+					 "stopping it.", pid);
+
+			if (kill(pid, SIGQUIT) != 0)
+			{
+				log_error("Failed to send SIGQUIT to the keeper's pid %d: %s",
+						  pid, strerror(errno));
+				exit(EXIT_CODE_INTERNAL_ERROR);
+			}
+		}
+	}
+
+	/* only keeper_remove when we still have a state file around */
+	if (file_exists(config->pathnames.state))
+	{
+		bool ignoreMonitorErrors = true;
+
+		/* keeper_remove uses log_info() to explain what's happening */
+		if (!keeper_remove(&keeper, config, ignoreMonitorErrors))
+		{
+			log_fatal("Failed to remove local node from the pg_auto_failover "
+					  "monitor, see above for details");
+
+			exit(EXIT_CODE_BAD_STATE);
+		}
+
+		log_info("Removed pg_autoctl node at \"%s\" from the monitor and "
+				 "removed the state file \"%s\"",
+				 config->pgSetup.pgdata,
+				 config->pathnames.state);
+	}
+	else
+	{
+		log_warn("Skipping node removal from the monitor: "
+				 "state file \"%s\" does not exist",
+				 config->pathnames.state);
+	}
+
+	/*
+	 * Either --destroy the whole Postgres cluster and configuraiton, or leave
+	 * enough behind us that it's possible to re-join a formation later.
+	 */
+	if (dropAndDestroy)
+	{
+		(void)
+			stop_postgres_and_remove_pgdata_and_config(
+				&config->pathnames,
+				&config->pgSetup);
+	}
+	else
+	{
+		/*
+		 * We need to stop Postgres now, otherwise we won't be able to drop the
+		 * replication slot on the other node, because it's still active.
+		 */
+		log_info("Stopping PostgreSQL at \"%s\"", config->pgSetup.pgdata);
+
+		if (!pg_ctl_stop(config->pgSetup.pg_ctl, config->pgSetup.pgdata))
+		{
+			log_error("Failed to stop PostgreSQL at \"%s\"",
+					  config->pgSetup.pgdata);
+			exit(EXIT_CODE_PGCTL);
+		}
+
+		/*
+		 * Now give the whole picture to the user, who might have missed our
+		 * --destroy option and might want to use it now to start again with a
+		 * fresh environment.
+		 */
+		log_warn("Configuration file \"%s\" has been preserved",
+			 config->pathnames.config);
+
+		if (directory_exists(config->pgSetup.pgdata))
+		{
+			log_warn("Postgres Data Directory \"%s\" has been preserved",
+					 config->pgSetup.pgdata);
+		}
+
+		log_info("drop node keeps your data and setup safe, you can still run "
+				 "Postgres or re-join the pg_auto_failover cluster later");
+		log_info("HINT: to completely remove your local Postgres instance and "
+				 "setup, consider `pg_autoctl drop node --destroy`");
+	}
+
+	keeper_config_destroy(config);
+}
+
+
+/*
+ * stop_postgres_and_remove_pgdata_and_config stops PostgreSQL and then removes
+ * PGDATA, and then config and state files.
+ */
+static void
+stop_postgres_and_remove_pgdata_and_config(ConfigFilePaths *pathnames,
+										   PostgresSetup *pgSetup)
+{
+	log_info("Stopping PostgreSQL at \"%s\"", pgSetup->pgdata);
+
+	if (!pg_ctl_stop(pgSetup->pg_ctl, pgSetup->pgdata))
+	{
+		log_error("Failed to stop PostgreSQL at \"%s\"", pgSetup->pgdata);
+		log_fatal("Skipping removal of directory \"%s\"", pgSetup->pgdata);
+		exit(EXIT_CODE_PGCTL);
+	}
+
+	/*
+	 * Only try to rm -rf PGDATA if we managed to stop PostgreSQL.
+	 */
+	if (directory_exists(pgSetup->pgdata))
+	{
+		log_info("Removing \"%s\"", pgSetup->pgdata);
+
+		if (!rmtree(pgSetup->pgdata, true))
+		{
+			log_error("Failed to remove directory \"%s\": %s",
+					  pgSetup->pgdata, strerror(errno));
+			exit(EXIT_CODE_INTERNAL_ERROR);
+		}
+	}
+	else
+	{
+		log_warn("Skipping removal of \"%s\": directory does not exists",
+				 pgSetup->pgdata);
+	}
+
+	log_info("Removing \"%s\"", pathnames->config);
+
+	if (!unlink_file(pathnames->config))
+	{
+		/* errors have already been logged. */
+		exit(EXIT_CODE_BAD_CONFIG);
+	}
 }

--- a/src/bin/pg_autoctl/cli_common.h
+++ b/src/bin/pg_autoctl/cli_common.h
@@ -89,6 +89,7 @@ extern CommandLine config_commands;
 extern CommandLine create_monitor_command;
 extern CommandLine create_postgres_command;
 extern CommandLine drop_node_command;
+extern CommandLine drop_monitor_command;
 extern CommandLine destroy_command;
 
 /* cli_enable_disable.c */
@@ -162,5 +163,6 @@ typedef enum
 bool cli_getopt_ssl_flags(int ssl_flag, char *optarg, PostgresSetup *pgSetup);
 bool cli_getopt_accept_ssl_options(SSLCommandLineOptions newSSLOption,
 								   SSLCommandLineOptions currentSSLOptions);
+void cli_drop_local_node(KeeperConfig *config, bool dropAndDestroy);
 
 #endif  /* CLI_COMMON_H */

--- a/src/bin/pg_autoctl/cli_create_drop_node.c
+++ b/src/bin/pg_autoctl/cli_create_drop_node.c
@@ -107,11 +107,11 @@ CommandLine drop_monitor_command =
 CommandLine drop_node_command =
 	make_command("node",
 				 "Drop a node from the pg_auto_failover monitor",
-				 "[ --pgdata --destroy --nodename --nodeport ]",
+				 "[ --pgdata --destroy --nodename --pgport ]",
 				 "  --pgdata      path to data directory\n"
 				 "  --destroy     also destroy Postgres database\n"
 				 "  --nodename    nodename to remove from the monitor\n"
-				 "  --nodeport    Postgres port of the node to remove",
+				 "  --pgport      Postgres port of the node to remove",
 				 cli_drop_node_getopts,
 				 cli_drop_node);
 
@@ -935,14 +935,14 @@ cli_drop_node(int argc, char **argv)
 		case PG_AUTOCTL_ROLE_MONITOR:
 		{
 			/*
-			 * Now check --nodename and --nodeport and remove the entry on the
+			 * Now check --nodename and --pgport and remove the entry on the
 			 * monitor.
 			 */
 			if (IS_EMPTY_STRING_BUFFER(config.nodename)
 				|| config.pgSetup.pgport == 0)
 			{
 				log_fatal("To remove a node from the monitor, both the "
-						  "--nodename and --nodeport options are required");
+						  "--nodename and --pgport options are required");
 				exit(EXIT_CODE_BAD_ARGS);
 			}
 
@@ -1069,7 +1069,7 @@ cli_drop_monitor(int argc, char **argv)
 
 /*
  * cli_drop_node_from_monitor calls pgautofailover.remove_node() on the
- * monitor for the given --nodename and --nodeport.
+ * monitor for the given --nodename and --pgport.
  */
 static void
 cli_drop_node_from_monitor(KeeperConfig *config, const char *nodename, int port)

--- a/src/bin/pg_autoctl/cli_create_drop_node.c
+++ b/src/bin/pg_autoctl/cli_create_drop_node.c
@@ -777,7 +777,7 @@ cli_drop_node_getopts(int argc, char **argv)
 		{ "pgdata", required_argument, NULL, 'D' },
 		{ "destroy", no_argument, NULL, 'd' },
 		{ "nodename", required_argument, NULL, 'n' },
-		{ "nodeport", required_argument, NULL, 'p' },
+		{ "pgport", required_argument, NULL, 'p' },
 		{ "version", no_argument, NULL, 'V' },
 		{ "verbose", no_argument, NULL, 'v' },
 		{ "quiet", no_argument, NULL, 'q' },
@@ -880,7 +880,7 @@ cli_drop_node_getopts(int argc, char **argv)
 		&& (!IS_EMPTY_STRING_BUFFER(options.nodename)
 			|| options.pgSetup.pgport != 0))
 	{
-		log_error("Please use either --nodename and --nodeport or ---destroy");
+		log_error("Please use either --nodename and --pgport or ---destroy");
 		log_info("Destroying a node is not supported from a distance");
 		exit(EXIT_CODE_BAD_ARGS);
 	}
@@ -1033,9 +1033,7 @@ cli_drop_monitor(int argc, char **argv)
 			}
 
 			/* expose the pgSetup in the given KeeperConfig */
-			memcpy(&(config.pgSetup),
-				   &(mconfig.pgSetup),
-				   sizeof(PostgresSetup));
+			config.pgSetup = mconfig.pgSetup;
 
 			/* somehow at this point we've lost our pathnames */
 			if (!keeper_config_set_pathnames_from_pgdata(

--- a/src/bin/pg_autoctl/cli_create_drop_node.c
+++ b/src/bin/pg_autoctl/cli_create_drop_node.c
@@ -47,14 +47,15 @@ static void cli_create_monitor(int argc, char **argv);
 
 static int cli_drop_node_getopts(int argc, char **argv);
 static void cli_drop_node(int argc, char **argv);
+static void cli_drop_monitor(int argc, char **argv);
+
+static void cli_drop_node_from_monitor(KeeperConfig *config,
+									   const char *nodename,
+									   int port);
 
 static bool discover_nodename(char *nodename, int size,
 							  const char *monitorHostname, int monitorPort);
 static void check_nodename(const char *nodename);
-
-static void stop_postgres_and_remove_pgdata_and_config(
-	ConfigFilePaths *pathnames,
-	PostgresSetup *pgSetup);
 
 CommandLine create_monitor_command =
 	make_command(
@@ -94,12 +95,23 @@ CommandLine create_postgres_command =
 		cli_create_postgres_getopts,
 		cli_create_postgres);
 
+CommandLine drop_monitor_command =
+	make_command("monitor",
+				 "Drop the pg_auto_failover monitor",
+				 "[ --pgdata --destroy ]",
+				 "  --pgdata      path to data directory\n"
+				 "  --destroy     also destroy Postgres database\n",
+				 cli_drop_node_getopts,
+				 cli_drop_monitor);
+
 CommandLine drop_node_command =
 	make_command("node",
 				 "Drop a node from the pg_auto_failover monitor",
-				 "[ --pgdata --destroy ]",
-				 "  --pgdata      path to data directory\n" \
-				 "  --destroy     also destroy Postgres database",
+				 "[ --pgdata --destroy --nodename --nodeport ]",
+				 "  --pgdata      path to data directory\n"
+				 "  --destroy     also destroy Postgres database\n"
+				 "  --nodename    nodename to remove from the monitor\n"
+				 "  --nodeport    Postgres port of the node to remove",
 				 cli_drop_node_getopts,
 				 cli_drop_node);
 
@@ -764,6 +776,8 @@ cli_drop_node_getopts(int argc, char **argv)
 	static struct option long_options[] = {
 		{ "pgdata", required_argument, NULL, 'D' },
 		{ "destroy", no_argument, NULL, 'd' },
+		{ "nodename", required_argument, NULL, 'n' },
+		{ "nodeport", required_argument, NULL, 'p' },
 		{ "version", no_argument, NULL, 'V' },
 		{ "verbose", no_argument, NULL, 'v' },
 		{ "quiet", no_argument, NULL, 'q' },
@@ -773,7 +787,7 @@ cli_drop_node_getopts(int argc, char **argv)
 
 	optind = 0;
 
-	while ((c = getopt_long(argc, argv, "D:dVvqh",
+	while ((c = getopt_long(argc, argv, "D:dn:p:Vvqh",
 							long_options, &option_index)) != -1)
 	{
 		switch (c)
@@ -789,6 +803,26 @@ cli_drop_node_getopts(int argc, char **argv)
 			{
 				dropAndDestroy = true;
 				log_trace("--destroy");
+				break;
+			}
+
+			case 'n':
+			{
+				strlcpy(options.nodename, optarg, _POSIX_HOST_NAME_MAX);
+				log_trace("--nodename %s", options.nodename);
+				break;
+			}
+
+			case 'p':
+			{
+				int scanResult = sscanf(optarg, "%d", &(options.pgSetup.pgport));
+				if (scanResult == 0)
+				{
+					log_fatal("--pgport argument is a valid port number: \"%s\"",
+							  optarg);
+					exit(EXIT_CODE_BAD_ARGS);
+				}
+				log_trace("--pgport %d", options.pgSetup.pgport);
 				break;
 			}
 
@@ -842,6 +876,15 @@ cli_drop_node_getopts(int argc, char **argv)
 		}
 	}
 
+	if (dropAndDestroy
+		&& (!IS_EMPTY_STRING_BUFFER(options.nodename)
+			|| options.pgSetup.pgport != 0))
+	{
+		log_error("Please use either --nodename and --nodeport or ---destroy");
+		log_info("Destroying a node is not supported from a distance");
+		exit(EXIT_CODE_BAD_ARGS);
+	}
+
 	if (errors > 0)
 	{
 		commandline_help(stderr);
@@ -865,179 +908,202 @@ cli_drop_node_getopts(int argc, char **argv)
 static void
 cli_drop_node(int argc, char **argv)
 {
-	Keeper keeper = { 0 };
 	KeeperConfig config = keeperOptions;
 
 	bool missingPgdataIsOk = true;
 	bool pgIsNotRunningIsOk = true;
 	bool monitorDisabledIsOk = false;
 
-	if (file_exists(config.pathnames.config))
+	/*
+	 * The configuration file is the last bit we remove, so we don't have to
+	 * implement "continue from previous failed attempt" when the configuration
+	 * file does not exists.
+	 */
+	if (!file_exists(config.pathnames.config))
 	{
-		/*
-		 * We are going to need to use the right pg_ctl binary to control the
-		 * Postgres cluster: pg_ctl stop.
-		 */
-		switch (ProbeConfigurationFileRole(config.pathnames.config))
+		log_error("Failed to find expected configuration file \"%s\"",
+				  config.pathnames.config);
+		exit(EXIT_CODE_BAD_CONFIG);
+	}
+
+	/*
+	 * We are going to need to use the right pg_ctl binary to control the
+	 * Postgres cluster: pg_ctl stop.
+	 */
+	switch (ProbeConfigurationFileRole(config.pathnames.config))
+	{
+		case PG_AUTOCTL_ROLE_MONITOR:
 		{
-			case PG_AUTOCTL_ROLE_MONITOR:
+			/*
+			 * Now check --nodename and --nodeport and remove the entry on the
+			 * monitor.
+			 */
+			if (IS_EMPTY_STRING_BUFFER(config.nodename)
+				|| config.pgSetup.pgport == 0)
 			{
-				MonitorConfig mconfig = { 0 };
-
-				if (!monitor_config_init_from_pgsetup(&mconfig,
-													  &(config.pgSetup),
-													  missingPgdataIsOk,
-													  pgIsNotRunningIsOk))
-				{
-					/* errors have already been logged */
-					exit(EXIT_CODE_BAD_CONFIG);
-				}
-
-				/* expose the pgSetup in the given KeeperConfig */
-				memcpy(&(config.pgSetup),
-					   &(mconfig.pgSetup),
-					   sizeof(PostgresSetup));
-
-				/* somehow at this point we've lost our pathnames */
-				if (!keeper_config_set_pathnames_from_pgdata(
-						&(config.pathnames),
-						config.pgSetup.pgdata))
-				{
-					/* errors have already been logged */
-					exit(EXIT_CODE_BAD_ARGS);
-				}
-
-				break;
+				log_fatal("To remove a node from the monitor, both the "
+						  "--nodename and --nodeport options are required");
+				exit(EXIT_CODE_BAD_ARGS);
 			}
 
-			case PG_AUTOCTL_ROLE_KEEPER:
+			/* pg_autoctl drop node on the monitor drops another node */
+			(void) cli_drop_node_from_monitor(&config,
+											  config.nodename,
+											  config.pgSetup.pgport);
+			return;
+		}
+
+		case PG_AUTOCTL_ROLE_KEEPER:
+		{
+			if (!IS_EMPTY_STRING_BUFFER(config.nodename)
+				|| config.pgSetup.pgport != 0)
 			{
-				/* just read the keeper file in given KeeperConfig */
-				if (!keeper_config_read_file(&config,
-											 missingPgdataIsOk,
-											 pgIsNotRunningIsOk,
-											 monitorDisabledIsOk))
-				{
-					exit(EXIT_CODE_BAD_CONFIG);
-				}
-				break;
+				log_fatal("Only dropping the local node is supported");
+				log_info("To drop another node, please use this command "
+						 "from the monitor itself.");
+				exit(EXIT_CODE_BAD_ARGS);
 			}
 
-			default:
+			/* just read the keeper file in given KeeperConfig */
+			if (!keeper_config_read_file(&config,
+										 missingPgdataIsOk,
+										 pgIsNotRunningIsOk,
+										 monitorDisabledIsOk))
 			{
-				log_fatal("Unrecognized configuration file \"%s\"",
-						  config.pathnames.config);
 				exit(EXIT_CODE_BAD_CONFIG);
 			}
+
+			/* drop the node and maybe destroy its PGDATA entirely. */
+			(void) cli_drop_local_node(&config, dropAndDestroy);
+
+			return;
 		}
 
-		log_trace("Found pg_ctl at \"%s\" in config file \"%s\"",
-				  config.pgSetup.pg_ctl,
+		default:
+		{
+			log_fatal("Unrecognized configuration file \"%s\"",
+					  config.pathnames.config);
+			exit(EXIT_CODE_BAD_CONFIG);
+		}
+	}
+}
+
+
+/*
+ * cli_drop_monitor removes the local monitor node.
+ */
+static void
+cli_drop_monitor(int argc, char **argv)
+{
+	KeeperConfig config = keeperOptions;
+
+	bool missingPgdataIsOk = true;
+	bool pgIsNotRunningIsOk = true;
+	bool monitorDisabledIsOk = false;
+
+	/*
+	 * The configuration file is the last bit we remove, so we don't have to
+	 * implement "continue from previous failed attempt" when the configuration
+	 * file does not exists.
+	 */
+	if (!file_exists(config.pathnames.config))
+	{
+		log_error("Failed to find expected configuration file \"%s\"",
 				  config.pathnames.config);
-	}
-	else
-	{
-		/* all we really need now is pg_ctl */
-		set_first_pgctl(&(config.pgSetup));
-		log_info("Configuration file \"%s\" does not exists, using %s",
-				 config.pathnames.config,
-				 config.pgSetup.pg_ctl);
+		exit(EXIT_CODE_BAD_CONFIG);
 	}
 
 	/*
-	 * Now also stop the pg_autoctl process.
+	 * We are going to need to use the right pg_ctl binary to control the
+	 * Postgres cluster: pg_ctl stop.
 	 */
-	if (file_exists(config.pathnames.pid))
+	switch (ProbeConfigurationFileRole(config.pathnames.config))
 	{
-		pid_t pid = 0;
-
-		if (read_pidfile(config.pathnames.pid, &pid))
+		case PG_AUTOCTL_ROLE_MONITOR:
 		{
-			log_info("An instance of this keeper is running with PID %d, "
-					 "stopping it.", pid);
+			MonitorConfig mconfig = { 0 };
 
-			if (kill(pid, SIGQUIT) != 0)
+			if (!monitor_config_init_from_pgsetup(&mconfig,
+												  &(config.pgSetup),
+												  missingPgdataIsOk,
+												  pgIsNotRunningIsOk))
 			{
-				log_error("Failed to send SIGQUIT to the keeper's pid %d: %s",
-						  pid, strerror(errno));
-				exit(EXIT_CODE_INTERNAL_ERROR);
+				/* errors have already been logged */
+				exit(EXIT_CODE_BAD_CONFIG);
 			}
+
+			/* expose the pgSetup in the given KeeperConfig */
+			memcpy(&(config.pgSetup),
+				   &(mconfig.pgSetup),
+				   sizeof(PostgresSetup));
+
+			/* somehow at this point we've lost our pathnames */
+			if (!keeper_config_set_pathnames_from_pgdata(
+					&(config.pathnames),
+					config.pgSetup.pgdata))
+			{
+				/* errors have already been logged */
+				exit(EXIT_CODE_BAD_ARGS);
+			}
+
+			/* drop the node and maybe destroy its PGDATA entirely. */
+			(void) cli_drop_local_node(&config, dropAndDestroy);
+			return;
 		}
-	}
 
-	/* only keeper_remove when we still have a state file around */
-	if (file_exists(config.pathnames.state))
-	{
-		bool ignoreMonitorErrors = true;
-
-		/* keeper_remove uses log_info() to explain what's happening */
-		if (!keeper_remove(&keeper, &config, ignoreMonitorErrors))
+		case PG_AUTOCTL_ROLE_KEEPER:
 		{
-			log_fatal("Failed to remove local node from the pg_auto_failover "
-					  "monitor, see above for details");
+			log_fatal("Local node is not a monitor");
+			exit(EXIT_CODE_BAD_CONFIG);
 
-			exit(EXIT_CODE_BAD_STATE);
+			break;
 		}
 
-		log_info("Removed pg_autoctl node at \"%s\" from the monitor and "
-				 "removed the state file \"%s\"",
-				 config.pgSetup.pgdata,
-				 config.pathnames.state);
-	}
-	else
-	{
-		log_warn("Skipping node removal from the monitor: "
-				 "state file \"%s\" does not exist",
-				 config.pathnames.state);
-	}
-
-	/*
-	 * Either --destroy the whole Postgres cluster and configuraiton, or leave
-	 * enough behind us that it's possible to re-join a formation later.
-	 */
-	if (dropAndDestroy)
-	{
-		(void)
-			stop_postgres_and_remove_pgdata_and_config(
-				&config.pathnames,
-				&config.pgSetup);
-	}
-	else
-	{
-		/*
-		 * We need to stop Postgres now, otherwise we won't be able to drop the
-		 * replication slot on the other node, because it's still active.
-		 */
-		log_info("Stopping PostgreSQL at \"%s\"", config.pgSetup.pgdata);
-
-		if (!pg_ctl_stop(config.pgSetup.pg_ctl, config.pgSetup.pgdata))
+		default:
 		{
-			log_error("Failed to stop PostgreSQL at \"%s\"",
-					  config.pgSetup.pgdata);
-			exit(EXIT_CODE_PGCTL);
+			log_fatal("Unrecognized configuration file \"%s\"",
+					  config.pathnames.config);
+			exit(EXIT_CODE_BAD_CONFIG);
 		}
+	}
+}
 
-		/*
-		 * Now give the whole picture to the user, who might have missed our
-		 * --destroy option and might want to use it now to start again with a
-		 * fresh environment.
-		 */
-		log_warn("Configuration file \"%s\" has been preserved",
-			 config.pathnames.config);
 
-		if (directory_exists(config.pgSetup.pgdata))
-		{
-			log_warn("Postgres Data Directory \"%s\" has been preserved",
-					 config.pgSetup.pgdata);
-		}
+/*
+ * cli_drop_node_from_monitor calls pgautofailover.remove_node() on the
+ * monitor for the given --nodename and --nodeport.
+ */
+static void
+cli_drop_node_from_monitor(KeeperConfig *config, const char *nodename, int port)
+{
+	Monitor monitor = { 0 };
+	MonitorConfig mconfig = { 0 };
+	char connInfo[MAXCONNINFO] = { 0 };
 
-		log_info("drop node keeps your data and setup safe, you can still run "
-				 "Postgres or re-join the pg_auto_failover cluster later");
-		log_info("HINT: to completely remove your local Postgres instance and "
-				 "setup, consider `pg_autoctl drop node --destroy`");
+	bool missingPgdataIsOk = true;
+	bool pgIsNotRunningIsOk = true;
+
+	if (!monitor_config_init_from_pgsetup(&mconfig,
+										  &(config->pgSetup),
+										  missingPgdataIsOk,
+										  pgIsNotRunningIsOk))
+	{
+		/* errors have already been logged */
+		exit(EXIT_CODE_BAD_CONFIG);
 	}
 
-	keeper_config_destroy(&config);
+	/* expose the pgSetup in the given KeeperConfig */
+	memcpy(&(config->pgSetup), &(mconfig.pgSetup), sizeof(PostgresSetup));
+
+	/* prepare to connect to the monitor, locally */
+	pg_setup_get_local_connection_string(&(mconfig.pgSetup), connInfo);
+	monitor_init(&monitor, connInfo);
+
+	if (!monitor_remove(&monitor, (char *) nodename, port))
+	{
+		/* errors have already been logged */
+		exit(EXIT_CODE_MONITOR);
+	}
 }
 
 
@@ -1228,52 +1294,5 @@ check_nodename(const char *nodename)
 					 "interfaces, automated pg_hba.conf setup might fail.",
 					 nodename);
 		}
-	}
-}
-
-
-/*
- * stop_postgres_and_remove_pgdata_and_config stops PostgreSQL and then removes
- * PGDATA, and then config and state files.
- */
-static void
-stop_postgres_and_remove_pgdata_and_config(ConfigFilePaths *pathnames,
-										   PostgresSetup *pgSetup)
-{
-	log_info("Stopping PostgreSQL at \"%s\"", pgSetup->pgdata);
-
-	if (!pg_ctl_stop(pgSetup->pg_ctl, pgSetup->pgdata))
-	{
-		log_error("Failed to stop PostgreSQL at \"%s\"", pgSetup->pgdata);
-		log_fatal("Skipping removal of directory \"%s\"", pgSetup->pgdata);
-		exit(EXIT_CODE_PGCTL);
-	}
-
-	/*
-	 * Only try to rm -rf PGDATA if we managed to stop PostgreSQL.
-	 */
-	if (directory_exists(pgSetup->pgdata))
-	{
-		log_info("Removing \"%s\"", pgSetup->pgdata);
-
-		if (!rmtree(pgSetup->pgdata, true))
-		{
-			log_error("Failed to remove directory \"%s\": %s",
-					  pgSetup->pgdata, strerror(errno));
-			exit(EXIT_CODE_INTERNAL_ERROR);
-		}
-	}
-	else
-	{
-		log_warn("Skipping removal of \"%s\": directory does not exists",
-				 pgSetup->pgdata);
-	}
-
-	log_info("Removing \"%s\"", pathnames->config);
-
-	if (!unlink_file(pathnames->config))
-	{
-		/* errors have already been logged. */
-		exit(EXIT_CODE_BAD_CONFIG);
 	}
 }

--- a/src/bin/pg_autoctl/cli_root.c
+++ b/src/bin/pg_autoctl/cli_root.c
@@ -48,6 +48,7 @@ CommandLine show_commands =
 					 NULL, show_subcommands);
 
 CommandLine *drop_subcommands[] = {
+	&drop_monitor_command,
 	&drop_node_command,
 	&drop_formation_command,
 	NULL


### PR DESCRIPTION
This allows removing a node from the monitor when it's been declared dead
already.