### PR TITLE
Open files in a safe way

### DIFF
--- a/src/bin/pg_autoctl/debian.c
+++ b/src/bin/pg_autoctl/debian.c
@@ -606,7 +606,7 @@ comment_out_configuration_parameters(const char *srcConfPath,
 		"(data_directory|hba_file|ident_file|include_dir)( *)=";
 
 	/* open a file */
-	fileStream = fopen(srcConfPath, "rb");
+	fileStream = fopen_read_only(srcConfPath);
 	if (fileStream == NULL)
 	{
 		log_error("Failed to open file \"%s\": %m", srcConfPath);

--- a/src/bin/pg_autoctl/defaults.h
+++ b/src/bin/pg_autoctl/defaults.h
@@ -101,14 +101,11 @@
 
 
 /*
- * This opens file write only and creates if it doesn't exist. It does this
- * using exclusive access to the file.
+ * This opens file write only and creates if it doesn't exist.
  */
-#define FOPEN_FLAGS_W O_WRONLY | O_CREAT | O_EXCL
+#define FOPEN_FLAGS_W O_WRONLY | O_CREAT
 /*
- * This opens the file in append mode and creates it if it doesn't exist. It
- * doesn't take exclusive access to the file, since normally multiple processes
- * should be able to append to the same file at the same time.
+ * This opens the file in append mode and creates it if it doesn't exist.
  */
 #define FOPEN_FLAGS_A O_APPEND | O_CREAT
 

--- a/src/bin/pg_autoctl/defaults.h
+++ b/src/bin/pg_autoctl/defaults.h
@@ -100,4 +100,16 @@
 #define EXIT_CODE_INTERNAL_ERROR 12
 
 
+/*
+ * This opens file write only and creates if it doesn't exist. It does this
+ * using exclusive access to the file.
+ */
+#define FOPEN_FLAGS_W O_WRONLY | O_CREAT | O_EXCL
+/*
+ * This opens the file in append mode and creates it if it doesn't exist. It
+ * doesn't take exclusive access to the file, since normally multiple processes
+ * should be able to append to the same file at the same time.
+ */
+#define FOPEN_FLAGS_A O_APPEND | O_CREAT
+
 #endif /* DEFAULTS_H */

--- a/src/bin/pg_autoctl/file_utils.c
+++ b/src/bin/pg_autoctl/file_utils.c
@@ -153,6 +153,21 @@ fopen_with_umask(const char *filePath, const char* modes, int flags, mode_t umas
 
 
 /*
+ * fopen_read_only opens the file as a read only stream.
+ */
+FILE *
+fopen_read_only(const char *filePath)
+{
+	/*
+	 * Explanation of IGNORE-BANNED
+	 * fopen is safe here because we open the file in read only mode. So no
+	 * exclusive access is needed.
+	 */
+	return fopen(filePath, "rb"); /* IGNORE-BANNED */
+}
+
+
+/*
  * write_file writes the given data to the file given by filePath using
  * our logging library to report errors. If succesful, the function returns
  * true.
@@ -232,7 +247,7 @@ read_file(const char *filePath, char **contents, long *fileSize)
 	FILE *fileStream = NULL;
 
 	/* open a file */
-	fileStream = fopen(filePath, "rb");
+	fileStream = fopen_read_only(filePath);
 	if (fileStream == NULL)
 	{
 		log_error("Failed to open file \"%s\": %s", filePath, strerror(errno));

--- a/src/bin/pg_autoctl/file_utils.c
+++ b/src/bin/pg_autoctl/file_utils.c
@@ -176,7 +176,7 @@ bool
 write_file(char *data, long fileSize, const char *filePath)
 {
 
-	FILE *fileStream = fopen_with_umask(filePath, "wb", O_WRONLY | O_CREAT | O_EXCL, 0644);
+	FILE *fileStream = fopen_with_umask(filePath, "wb", FOPEN_FLAGS_W, 0644);
 	if (fileStream == NULL)
 	{
 		/* errors have already been logged */
@@ -208,7 +208,7 @@ write_file(char *data, long fileSize, const char *filePath)
 bool
 append_to_file(char *data, long fileSize, const char *filePath)
 {
-	FILE *fileStream = fopen_with_umask(filePath, "ab", O_APPEND | O_CREAT | O_EXCL, 0644);
+	FILE *fileStream = fopen_with_umask(filePath, "ab", FOPEN_FLAGS_A, 0644);
 	if (fileStream == NULL)
 	{
 		/* errors have already been logged */

--- a/src/bin/pg_autoctl/file_utils.c
+++ b/src/bin/pg_autoctl/file_utils.c
@@ -134,7 +134,7 @@ ensure_empty_dir(const char *dirname, int mode)
 FILE *
 fopen_with_umask(const char *filePath, const char* modes, int flags, mode_t umask)
 {
-	int fileDescriptor = open(filePath, O_WRONLY | O_CREAT, umask);
+	int fileDescriptor = open(filePath, flags, umask);
 	FILE *fileStream = NULL;
 	if (fileDescriptor == -1)
 	{

--- a/src/bin/pg_autoctl/file_utils.c
+++ b/src/bin/pg_autoctl/file_utils.c
@@ -161,7 +161,7 @@ bool
 write_file(char *data, long fileSize, const char *filePath)
 {
 
-	FILE *fileStream = fopen_with_umask(filePath, "wb", O_WRONLY | O_CREAT, 0644);
+	FILE *fileStream = fopen_with_umask(filePath, "wb", O_WRONLY | O_CREAT | O_EXCL, 0644);
 	if (fileStream == NULL)
 	{
 		/* errors have already been logged */
@@ -193,7 +193,7 @@ write_file(char *data, long fileSize, const char *filePath)
 bool
 append_to_file(char *data, long fileSize, const char *filePath)
 {
-	FILE *fileStream = fopen_with_umask(filePath, "ab", O_APPEND | O_CREAT, 0644);
+	FILE *fileStream = fopen_with_umask(filePath, "ab", O_APPEND | O_CREAT | O_EXCL, 0644);
 	if (fileStream == NULL)
 	{
 		/* errors have already been logged */

--- a/src/bin/pg_autoctl/file_utils.h
+++ b/src/bin/pg_autoctl/file_utils.h
@@ -21,6 +21,7 @@ bool file_exists(const char *filename);
 bool directory_exists(const char *path);
 bool ensure_empty_dir(const char *dirname, int mode);
 FILE * fopen_with_umask(const char *filePath, const char* modes, int flags, mode_t umask);
+FILE * fopen_read_only(const char *filePath);
 bool write_file(char *data, long fileSize, const char *filePath);
 bool append_to_file(char *data, long fileSize, const char *filePath);
 bool read_file(const char *filePath, char **contents, long *fileSize);

--- a/src/bin/pg_autoctl/keeper_config.c
+++ b/src/bin/pg_autoctl/keeper_config.c
@@ -415,7 +415,7 @@ keeper_config_write_file(KeeperConfig *config)
 
 	log_trace("keeper_config_write_file \"%s\"", filePath);
 
-	fileStream = fopen_with_umask(filePath, "w", O_WRONLY | O_CREAT, 0644);
+	fileStream = fopen_with_umask(filePath, "w", O_WRONLY | O_CREAT | O_EXCL, 0644);
 	if (fileStream == NULL)
 	{
 		/* errors have already been logged */

--- a/src/bin/pg_autoctl/keeper_config.c
+++ b/src/bin/pg_autoctl/keeper_config.c
@@ -415,7 +415,7 @@ keeper_config_write_file(KeeperConfig *config)
 
 	log_trace("keeper_config_write_file \"%s\"", filePath);
 
-	fileStream = fopen_with_umask(filePath, "w", O_WRONLY | O_CREAT | O_EXCL, 0644);
+	fileStream = fopen_with_umask(filePath, "w", FOPEN_FLAGS_W, 0644);
 	if (fileStream == NULL)
 	{
 		/* errors have already been logged */

--- a/src/bin/pg_autoctl/monitor_config.c
+++ b/src/bin/pg_autoctl/monitor_config.c
@@ -314,7 +314,7 @@ monitor_config_write_file(MonitorConfig *config)
 
 	log_trace("monitor_config_write_file \"%s\"", filePath);
 
-	fileStream = fopen_with_umask(filePath, "w", O_WRONLY | O_CREAT | O_EXCL, 0644);
+	fileStream = fopen_with_umask(filePath, "w", FOPEN_FLAGS_W, 0644);
 	if (fileStream == NULL)
 	{
 		/* errors have already been logged */

--- a/src/bin/pg_autoctl/monitor_config.c
+++ b/src/bin/pg_autoctl/monitor_config.c
@@ -314,7 +314,7 @@ monitor_config_write_file(MonitorConfig *config)
 
 	log_trace("monitor_config_write_file \"%s\"", filePath);
 
-	fileStream = fopen_with_umask(filePath, "w", O_WRONLY | O_CREAT, 0644);
+	fileStream = fopen_with_umask(filePath, "w", O_WRONLY | O_CREAT | O_EXCL, 0644);
 	if (fileStream == NULL)
 	{
 		/* errors have already been logged */

--- a/src/bin/pg_autoctl/pgsetup.c
+++ b/src/bin/pg_autoctl/pgsetup.c
@@ -411,7 +411,7 @@ get_pgpid(PostgresSetup *pgSetup, bool pg_is_not_running_is_ok)
 
 	join_path_components(pidfile, pgSetup->pgdata, "postmaster.pid");
 
-	if ((fp = fopen(pidfile, "r")) == NULL)
+	if ((fp = fopen_read_only(pidfile)) == NULL)
 	{
 		if (!pg_is_not_running_is_ok)
 		{
@@ -482,7 +482,7 @@ read_pg_pidfile(PostgresSetup *pgSetup, bool pg_is_not_running_is_ok)
 
 	join_path_components(pidfile, pgSetup->pgdata, "postmaster.pid");
 
-	if ((fp = fopen(pidfile, "r")) == NULL)
+	if ((fp = fopen_read_only(pidfile)) == NULL)
 	{
 		if (!pg_is_not_running_is_ok)
 		{


### PR DESCRIPTION
And reads are moved to a dedicated function for easy ignoring fopen as a banned
function there.