### PR TITLE
Improve docs related to SSL options

### DIFF
--- a/docs/security.rst
+++ b/docs/security.rst
@@ -50,7 +50,7 @@ To enable a “trust” security model with pg_auto_failover, use the
 
 When using ``--auth trust`` pg_autoctl adds new HBA rules in the monitor and
 the Postgres nodes to enable connections as seen above.
-  
+
 Authentication with passwords
 -----------------------------
 
@@ -70,7 +70,7 @@ following command::
 
 Now that the monitor is ready with our password set for the ``autoctl_node``
 user, we can use the password in the monitor connection string used when
-creating Postgres nodes. 
+creating Postgres nodes.
 
 On the primary node, we can create the Postgres setup as usual, and then set
 our replication password, that we will use if we are demoted and then
@@ -101,7 +101,7 @@ Postgres documentation in order to maintain your passwords in a separate
 file, not in your main pg_auto_failover configuration file. This also avoids
 using passwords in the environment and in command lines.
 
-__ https://www.postgresql.org/docs/current/libpq-pgpass.html  
+__ https://www.postgresql.org/docs/current/libpq-pgpass.html
 
 Encryption of network communications
 ------------------------------------
@@ -160,20 +160,20 @@ It is still possible to give the certificates to pg_auto_failover and have
 it handle the setup for you, including the creation of and signing of client
 certificates for the ``autoctl_node`` and ``pgautofailover_replication``
 users::
-  
+
   $ pg_autoctl create monitor --ssl-ca-file root.crt   \
                               --ssl-crl-file root.crl  \
                               --server-crt server.crt  \
                               --server-key server.key  \
                               --ssl-mode validate-full \
                               ...
-  
+
   $ pg_autoctl create postgres --ssl-ca-file root.crt   \
                                --server-crt server.crt  \
                                --server-key server.key  \
                                --ssl-mode validate-full \
                                ...
-                              
+
   $ pg_autoctl create postgres --ssl-ca-file root.crt   \
                                --server-crt server.crt  \
                                --server-key server.key  \
@@ -182,8 +182,8 @@ users::
 
 The option ``--ssl-mode`` can be used to force connection strings used by
 ``pg_autoctl`` to contain your prefered ssl mode. It defaults to ``require``
-when SSL is used and to ``allow`` when ``--ssl`` is not used. Here, we set
-``--ssl-mode`` to ``validate-ca`` which requires SSL Certificates
+when using ``--ssl-self-signed`` and to ``allow`` when ``--no-ssl`` is used.
+Here, we set ``--ssl-mode`` to ``validate-ca`` which requires SSL Certificates
 Authentication, covered next.
 
 The default ``--ssl-mode`` when providing your own certificates (signed by
@@ -235,7 +235,7 @@ then have the following entry, to allow ``postgres`` to connect as the
 To enable streaming replication, the ``pg_ident.conf`` file on each Postgres
 node should now allow the ``postgres`` user in the client certificate to
 connect as the ``pgautofailover_replicator`` database user::
-  
+
   # MAPNAME       SYSTEM-USERNAME         PG-USERNAME
 
   # pg_autoctl runs as postgres and connects to the monitor autoctl_node user
@@ -245,7 +245,7 @@ Given that user name map, you can then use the ``cert`` authentication
 method. As with the ``pg_ident.conf`` provisioning, it is best to now
 provision the HBA rules yourself, using the ``--skip-pg-hba`` option::
 
-  $ pg_autoctl create postgres --skip-pg-hba --ssl --ssl-ca-file ...
+  $ pg_autoctl create postgres --skip-pg-hba --ssl-ca-file ...
 
 The HBA rule will use the authentication method ``cert`` with a map option,
 and might then look like the following on the monitor::

--- a/src/bin/pg_autoctl/cli_common.c
+++ b/src/bin/pg_autoctl/cli_common.c
@@ -434,9 +434,10 @@ cli_create_node_getopts(int argc, char **argv,
 	if (sslCommandLineOptions == SSL_CLI_UNKNOWN)
 	{
 		log_fatal("Explicit SSL choice is required: please use either "
-				  "--no-ssl or --ssl-self-signed or provide your certificates "
+				  "--ssl-self-signed or provide your certificates "
 				  "using --ssl-ca-file, --ssl-crl-file, "
-				  "--server-key, and --server-crt");
+				  "--server-key, and --server-crt (or use --no-ssl if you "
+				  "are very sure that you do not want encrypted traffic)");
 		exit(EXIT_CODE_BAD_ARGS);
 	}
 

--- a/src/bin/pg_autoctl/cli_common.h
+++ b/src/bin/pg_autoctl/cli_common.h
@@ -33,11 +33,11 @@ extern bool outputJSON;
 extern int ssl_flag;
 
 #define KEEPER_CLI_SSL_OPTIONS \
-	"  --no-ssl          activate ssl in Postgres configuration\n" \
-	"  --ssl-self-signed activate ssl in Postgres configuration\n" \
+	"  --ssl-self-signed setup network encryption using self signed certificates (does NOT protect against MITM)\n" \
 	"  --ssl-mode        use that sslmode in connection strings\n" \
 	"  --ssl-ca-file     set the Postgres ssl_ca_file to that file path\n" \
 	"  --ssl-crl-file    set the Postgres ssl_crl_file to that file path\n" \
+	"  --no-ssl          don't enable network encryption (NOT recommended, prefer --ssl-self-signed)\n" \
 	"  --server-key      set the Postgres ssl_key_file to that file path\n" \
 	"  --server-cert     set the Postgres ssl_cert_file to that file path\n"
 

--- a/src/bin/pg_autoctl/cli_create_drop_node.c
+++ b/src/bin/pg_autoctl/cli_create_drop_node.c
@@ -590,15 +590,17 @@ cli_create_monitor_getopts(int argc, char **argv)
 	}
 
 	/*
-	 * If we have --ssl, either we have a root ca file and a server.key and a
-	 * server.crt or none of them. Any other combo is a mistake.
+	 * If any --ssl-* option is provided, either we have a root ca file and a
+	 * server.key and a server.crt or none of them. Any other combo is a
+	 * mistake.
 	 */
 	if (sslCommandLineOptions == SSL_CLI_UNKNOWN)
 	{
 		log_fatal("Explicit SSL choice is required: please use either "
-				  "--no-ssl or --ssl-self-signed or provide your certificates "
+				  "--ssl-self-signed or provide your certificates "
 				  "using --ssl-ca-file, --ssl-crl-file, "
-				  "--server-key, and --server-crt");
+				  "--server-key, and --server-crt (or use --no-ssl if you "
+				  "are very sure that you do not want encrypted traffic)");
 		exit(EXIT_CODE_BAD_ARGS);
 	}
 

--- a/src/bin/pg_autoctl/fsm_transition.c
+++ b/src/bin/pg_autoctl/fsm_transition.c
@@ -187,9 +187,9 @@ fsm_init_primary(Keeper *keeper)
 	 * We just created the local Postgres cluster, make sure it has our minimum
 	 * configuration deployed.
 	 *
-	 * When --ssl has been used without SSL certificates being given, now is
-	 * the time to build a self-signed certificate for the server. We place the
-	 * certificate and private key in $PGDATA/server.key and $PGDATA/server.crt
+	 * When --ssl-self-signed has been used, now is the time to build a
+	 * self-signed certificate for the server. We place the certificate and
+	 * private key in $PGDATA/server.key and $PGDATA/server.crt
 	 */
 	if (pgSetup.ssl.createSelfSignedCert
 		&& (!file_exists(pgSetup.ssl.serverKey)

--- a/src/bin/pg_autoctl/keeper_pg_init.c
+++ b/src/bin/pg_autoctl/keeper_pg_init.c
@@ -673,9 +673,9 @@ create_database_and_extension(Keeper *keeper)
 	}
 
 	/*
-	 * When --ssl has been used without SSL certificates being given, now is
-	 * the time to build a self-signed certificate for the server. We place the
-	 * certificate and private key in $PGDATA/server.key and $PGDATA/server.crt
+	 * When --ssl-self-signed has been used, now is the time to build a
+	 * self-signed certificate for the server. We place the certificate and
+	 * private key in $PGDATA/server.key and $PGDATA/server.crt
 	 */
 	if (pgSetup->ssl.createSelfSignedCert)
 	{

--- a/src/bin/pg_autoctl/pgsetup.c
+++ b/src/bin/pg_autoctl/pgsetup.c
@@ -1278,7 +1278,7 @@ pgsetup_validate_ssl_settings(PostgresSetup *pgSetup)
 			log_info("Using default --ssl-mode \"%s\"", ssl->sslModeStr);
 		}
 
-		log_info("Using --ssl without certificates: pg_autoctl will "
+		log_info("Using --ssl-self-signed: pg_autoctl will "
 				 " create self-signed certificates, allowing for "
 				 "encrypted network traffic");
 		log_warn("Self-signed certificates provide protection against "
@@ -1293,6 +1293,12 @@ pgsetup_validate_ssl_settings(PostgresSetup *pgSetup)
 	/* --no-ssl is ok */
 	if (ssl->active == 0)
 	{
+		log_warn("No encryption is used for network traffic! This allows an "
+				 "attacker on the network to read all replication data.");
+		log_warn("Using --ssl-self-signed instead of --no-ssl is recommend to "
+				 "achieve more security with the same ease of deployment.");
+		log_warn("See https://www.postgresql.org/docs/current/libpq-ssl.html "
+				 "for details on how to improve");
 		return true;
 	}
 

--- a/src/bin/pg_autoctl/primary_standby.c
+++ b/src/bin/pg_autoctl/primary_standby.c
@@ -554,9 +554,9 @@ standby_init_database(LocalPostgresServer *postgres,
 	}
 
 	/*
-	 * When --ssl has been used without SSL certificates being given, now is
-	 * the time to build a self-signed certificate for the server. We place the
-	 * certificate and private key in $PGDATA/server.key and $PGDATA/server.crt
+	 * When --ssl-self-signed has been used, now is the time to build a
+	 * self-signed certificate for the server. We place the certificate and
+	 * private key in $PGDATA/server.key and $PGDATA/server.crt
 	 *
 	 * In particular we override the certificates that we might have fetched
 	 * from the primary as part of pg_basebackup: we're not a backup, we're a


### PR DESCRIPTION
Things this does:

1. Remove last mentions to never merged `--ssl` option.
2. Make clear that `--ssl-self-signed` should be prefered over `--no-ssl`, both in error and help messages
3. Add warning when using `--no-ssl`