### PR TITLE
Fix/systemd setup

### DIFF
--- a/src/bin/pg_autoctl/cli_systemd.c
+++ b/src/bin/pg_autoctl/cli_systemd.c
@@ -171,6 +171,7 @@ cli_systemd_cat_service_file(int argc, char **argv)
 	log_info("pg_autoctl -q show systemd --pgdata \"%s\" | sudo tee %s",
 			 config.pgSetup.pgdata, config.pathnames.systemd);
 	log_info("sudo systemctl daemon-reload");
+	log_info("sudo systemctl enable pgautofailover");
 	log_info("sudo systemctl start pgautofailover");
 
 	if (!systemd_config_write(stdout, &config))

--- a/src/bin/pg_autoctl/systemd_config.c
+++ b/src/bin/pg_autoctl/systemd_config.c
@@ -104,8 +104,10 @@ systemd_config_init(SystemdServiceConfig *config, const char *pgdata)
 	sformat(config->EnvironmentPGDATA, BUFSIZE,
 			"'PGDATA=%s'", config->pgSetup.pgdata);
 
-	strlcpy(config->User, config->pgSetup.username, NAMEDATALEN);
+	/* adjust the user to the current system user */
+	strlcpy(config->User, user, NAMEDATALEN);
 
+	/* adjust the program to the current full path of argv[0] */
 	sformat(config->ExecStart, BUFSIZE, "%s run", pg_autoctl_program);
 
 	if (!ini_validate_options(systemdOptions))


### PR DESCRIPTION
  - username should be the current USER on the system rather than default hard coded value
  - update the instructions to setup systemd with `daemon-reload`, `enable`, `start`