### PR TITLE
Make CC generate dependency information for Makefile

### DIFF
--- a/src/bin/pg_autoctl/Makefile
+++ b/src/bin/pg_autoctl/Makefile
@@ -3,6 +3,8 @@
 
 PG_AUTOCTL = ./pg_autoctl
 
+DEPDIR = .deps
+
 SRC_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
 INCLUDES  = $(patsubst ${SRC_DIR}%.h,%.h,$(wildcard ${SRC_DIR}*.h))
@@ -47,23 +49,35 @@ LIBS += -lpq
 
 all: $(PG_AUTOCTL) ;
 
+# Based on Postgres Makefile for automatic dependency generation
+# https://github.com/postgres/postgres/blob/1933ae629e7b706c6c23673a381e778819db307d/src/Makefile.global.in#L890-L924
+%.o : %.c
+	@if test ! -d $(DEPDIR); then mkdir -p $(DEPDIR); fi
+	$(CC) $(CFLAGS) -c -MMD -MP -MF$(DEPDIR)/$(*F).Po -o $@ $<
+
+Po_files := $(wildcard $(DEPDIR)/*.Po)
+ifneq (,$(Po_files))
+include $(Po_files)
+endif
+
+
 $(PG_AUTOCTL): $(OBJS) $(INCLUDES)
 	$(CC) $(CFLAGS) $(OBJS) $(LDFLAGS) $(LIBS) -o $@
 
 lib-snprintf.o: $(PG_SNPRINTF)
-	$(CC) $(CFLAGS) -c -o $@ ${SRC_DIR}../lib/pg/snprintf.c
+	$(CC) $(CFLAGS) -c -MMD -MP -MF$(DEPDIR)/$(*F).Po -MT$@ -o $@ ${SRC_DIR}../lib/pg/snprintf.c
 
 lib-strerror.o: $(PG_SNPRINTF)
-	$(CC) $(CFLAGS) -c -o $@ ${SRC_DIR}../lib/pg/strerror.c
+	$(CC) $(CFLAGS) -c -MMD -MP -MF$(DEPDIR)/$(*F).Po -MT$@ -o $@ ${SRC_DIR}../lib/pg/strerror.c
 
 lib-log.o: $(LOG_SRC)
-	$(CC) $(CFLAGS) -c -o $@ ${SRC_DIR}../lib/log/src/log.c
+	$(CC) $(CFLAGS) -c -MMD -MP -MF$(DEPDIR)/$(*F).Po -MT$@ -o $@ ${SRC_DIR}../lib/log/src/log.c
 
 lib-commandline.o: $(COMMANDLINE_SRC)
-	$(CC) $(CFLAGS) -c -o $@ ${SRC_DIR}../lib/subcommands.c/commandline.c
+	$(CC) $(CFLAGS) -c -MMD -MP -MF$(DEPDIR)/$(*F).Po -MT$@ -o $@ ${SRC_DIR}../lib/subcommands.c/commandline.c
 
 lib-parson.o: $(PARSON_SRC)
-	$(CC) $(CFLAGS) -c -o $@ ${SRC_DIR}../lib/parson/parson.c
+	$(CC) $(CFLAGS) -c -MMD -MP -MF$(DEPDIR)/$(*F).Po -MT$@ -o $@ ${SRC_DIR}../lib/parson/parson.c
 
 clean:
 	rm -f $(OBJS) $(PG_AUTOCTL)
@@ -71,5 +85,7 @@ clean:
 install: $(PG_AUTOCTL)
 	install -d $(DESTDIR)$(BINDIR)
 	install -m 0755 $(PG_AUTOCTL) $(DESTDIR)$(BINDIR)
+
+
 
 .PHONY: all monitor clean


### PR DESCRIPTION
This makes sure you don't have to run "make clean" anymore to get a
correct build when you change header files. To get the same support for
the monitor extension, you should compile your postgres with --enable-depend.