### PR TITLE
Always error out on warnings indicating obvious mistakes

### DIFF
--- a/src/bin/pg_autoctl/Makefile
+++ b/src/bin/pg_autoctl/Makefile
@@ -34,6 +34,10 @@ DEFAULT_CFLAGS += -I $(shell $(PG_CONFIG) --pkgincludedir)/internal
 DEFAULT_CFLAGS += -I $(shell $(PG_CONFIG) --cflags)
 DEFAULT_CFLAGS += -Wformat
 DEFAULT_CFLAGS += -Wall
+DEFAULT_CFLAGS += -Werror=implicit-int
+DEFAULT_CFLAGS += -Werror=implicit-function-declaration
+DEFAULT_CFLAGS += -Werror=return-type
+
 # Needed for OSX
 DEFAULT_CFLAGS += -Wno-missing-braces
 DEFAULT_CFLAGS += $(COMMON_LIBS)


### PR DESCRIPTION
Implicit function declarations and wrong return types cause confusing errors
during development and are never behave like you want.