### PR TITLE
Speed up tests a bit

### DIFF
--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -362,16 +362,16 @@ class PGNode:
         Waits until the underlying Postgres process is running.
         """
         wait_until = dt.datetime.now() + dt.timedelta(seconds=timeout)
+        time.sleep(1)
         while wait_until > dt.datetime.now():
+            if self.pg_is_running():
+                time.sleep(1)
+                return True
             time.sleep(1)
 
-            if self.pg_is_running():
-                return True
-
-        else:
-            print("Postgres is still not running in %s after %d seconds" %
-                  (self.datadir, timeout))
-            return False
+        print("Postgres is still not running in %s after %d seconds" %
+              (self.datadir, timeout))
+        return False
 
     def fail(self):
         """
@@ -597,7 +597,7 @@ class DataNode(PGNode):
 
     def wait_until_state(self, target_state,
                          timeout=STATE_CHANGE_TIMEOUT,
-                         sleep_time=1,
+                         sleep_time=0.1,
                          other_node=None):
         """
         Waits until this data node reaches the target state, and then returns

--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -362,12 +362,10 @@ class PGNode:
         Waits until the underlying Postgres process is running.
         """
         wait_until = dt.datetime.now() + dt.timedelta(seconds=timeout)
-        time.sleep(1)
         while wait_until > dt.datetime.now():
-            if self.pg_is_running():
-                time.sleep(1)
-                return True
             time.sleep(1)
+            if self.pg_is_running():
+                return True
 
         print("Postgres is still not running in %s after %d seconds" %
               (self.datadir, timeout))

--- a/tests/test_basic_operation.py
+++ b/tests/test_basic_operation.py
@@ -111,8 +111,8 @@ def test_015_add_new_secondary():
     node3 = cluster.create_datanode("/tmp/basic/node3")
     node3.create()
     node3.run()
-    assert node3.wait_until_state(target_state="secondary")
-    assert node2.wait_until_state(target_state="primary")
+    assert node3.wait_until_state(target_state="secondary", other_node=node2)
+    assert node2.wait_until_state(target_state="primary", other_node=node3)
 
     assert node2.has_needed_replication_slots()
     assert node3.has_needed_replication_slots()

--- a/tests/test_ensure.py
+++ b/tests/test_ensure.py
@@ -56,10 +56,7 @@ def test_004_demoted():
     node2.sleep(30)
     node1.run()
 
-    # we might miss DEMOTE_TIMEOUT -> DEMOTED if we wait for a full second
-    # here
-    assert node1.wait_until_state(
-        target_state="demoted", sleep_time=0.1, other_node=node2)
+    assert node1.wait_until_state(target_state="demoted", other_node=node2)
 
     # ideally we should be able to check that we refrain from starting
     # postgres again before calling the transition function

--- a/tests/test_extension_update.py
+++ b/tests/test_extension_update.py
@@ -2,7 +2,7 @@ import os
 import time
 
 import pgautofailover_utils as pgautofailover
-from nose.tools import *
+from nose.tools import eq_
 
 cluster = None
 
@@ -31,4 +31,4 @@ def test_001_update_extension():
              FROM pg_available_extensions
             WHERE name = 'pgautofailover'
         """)
-    assert results == [('dummy',)]
+    eq_(results, [('dummy',)])


### PR DESCRIPTION
Sleeping with smaller resolution makes sure that when something takes 150ms we
don't wait a full second, but instead only 200ms.