### PR TITLE
Integrate other_node functionality into the cluster

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -51,5 +51,5 @@ def test_004_failover():
     print()
     print("Calling pgautofailover.failover() on the monitor")
     cluster.monitor.failover()
-    assert node2.wait_until_state(target_state="primary", other_node=node1)
-    assert node1.wait_until_state(target_state="secondary", other_node=node2)
+    assert node2.wait_until_state(target_state="primary")
+    assert node1.wait_until_state(target_state="secondary")

--- a/tests/test_basic_operation.py
+++ b/tests/test_basic_operation.py
@@ -111,8 +111,8 @@ def test_015_add_new_secondary():
     node3 = cluster.create_datanode("/tmp/basic/node3")
     node3.create()
     node3.run()
-    assert node3.wait_until_state(target_state="secondary", other_node=node2)
-    assert node2.wait_until_state(target_state="primary", other_node=node3)
+    assert node3.wait_until_state(target_state="secondary")
+    assert node2.wait_until_state(target_state="primary")
 
     assert node2.has_needed_replication_slots()
     assert node3.has_needed_replication_slots()
@@ -131,16 +131,16 @@ def test_016_multiple_manual_failover_verify_replication_slots():
 
     print("Calling pgautofailover.failover() on the monitor")
     monitor.failover()
-    assert node2.wait_until_state(target_state="secondary", other_node=node3)
-    assert node3.wait_until_state(target_state="primary", other_node=node2)
+    assert node2.wait_until_state(target_state="secondary")
+    assert node3.wait_until_state(target_state="primary")
 
     assert node2.has_needed_replication_slots()
     assert node3.has_needed_replication_slots()
 
     print("Calling pgautofailover.failover() on the monitor")
     monitor.failover()
-    assert node2.wait_until_state(target_state="primary", other_node=node3)
-    assert node3.wait_until_state(target_state="secondary", other_node=node2)
+    assert node2.wait_until_state(target_state="primary")
+    assert node3.wait_until_state(target_state="secondary")
 
     assert node2.has_needed_replication_slots()
     assert node3.has_needed_replication_slots()

--- a/tests/test_create_run.py
+++ b/tests/test_create_run.py
@@ -41,14 +41,14 @@ def test_004_read_from_secondary():
 
 def test_005_maintenance():
     node2.enable_maintenance()
-    assert node2.wait_until_state(target_state="maintenance", other_node=node1)
+    assert node2.wait_until_state(target_state="maintenance")
     node2.fail()
     node1.run_sql_query("INSERT INTO t1 VALUES (3)")
     node2.run()
-    node2.disable_maintenance(other_node=node1)
+    node2.disable_maintenance()
     assert node2.wait_until_pg_is_running()
-    assert node2.wait_until_state(target_state="secondary", other_node=node1)
-    assert node1.wait_until_state(target_state="primary", other_node=node2)
+    assert node2.wait_until_state(target_state="secondary")
+    assert node1.wait_until_state(target_state="primary")
 
 def test_006_fail_primary():
     node1.fail()

--- a/tests/test_ensure.py
+++ b/tests/test_ensure.py
@@ -58,7 +58,7 @@ def test_004_demoted():
     # We must not wait for PG to run, since otherwise we might miss the demoted
     # state
 
-    assert node1.wait_until_state(target_state="demoted", other_node=node2)
+    assert node1.wait_until_state(target_state="demoted")
 
     # ideally we should be able to check that we refrain from starting
     # postgres again before calling the transition function

--- a/tests/test_skip_pg_hba.py
+++ b/tests/test_skip_pg_hba.py
@@ -110,5 +110,5 @@ def test_004_failover():
     print()
     print("Calling pgautofailover.failover() on the monitor")
     cluster.monitor.failover()
-    assert node2.wait_until_state(target_state="primary", other_node=node1)
-    assert node1.wait_until_state(target_state="secondary", other_node=node2)
+    assert node2.wait_until_state(target_state="primary")
+    assert node1.wait_until_state(target_state="secondary")

--- a/tests/test_ssl_cert.py
+++ b/tests/test_ssl_cert.py
@@ -311,5 +311,5 @@ def test_004_failover():
     print()
     print("Calling pgautofailover.failover() on the monitor")
     cluster.monitor.failover()
-    assert node2.wait_until_state(target_state="primary", other_node=node1)
-    assert node1.wait_until_state(target_state="secondary", other_node=node2)
+    assert node2.wait_until_state(target_state="primary")
+    assert node1.wait_until_state(target_state="secondary")

--- a/tests/test_ssl_self_signed.py
+++ b/tests/test_ssl_self_signed.py
@@ -77,8 +77,8 @@ def test_003_init_secondary():
     assert node2.config_get("ssl.sslmode") == "require"
 
     node2.run()
-    assert node2.wait_until_state(target_state="secondary", other_node=node1)
-    assert node1.wait_until_state(target_state="primary", other_node=node2)
+    assert node2.wait_until_state(target_state="secondary")
+    assert node1.wait_until_state(target_state="primary")
 
     check_ssl_files(node2)
     check_ssl_ciphers(node2)
@@ -88,5 +88,5 @@ def test_004_failover():
     print()
     print("Calling pgautofailover.failover() on the monitor")
     cluster.monitor.failover()
-    assert node2.wait_until_state(target_state="primary", other_node=node1)
-    assert node1.wait_until_state(target_state="secondary", other_node=node2)
+    assert node2.wait_until_state(target_state="primary")
+    assert node1.wait_until_state(target_state="secondary")


### PR DESCRIPTION
The `other_node` parameter in the tests infects all APIs and is somewhat
fragile, since it only supports one other node, even though there are
potentially more.

This PR removes the `other_node` parameters throughout the testing framework
and instead adds cluster level support for sleeping and calling `communicate`
on a NSPopen object. These new functions make sure to flush the unix pipes of
all postgres nodes in the cluster, this way deadlocks should not happen
anymore.

This was also discussed shortly here:
https://github.com/citusdata/pg_auto_failover/pull/226#discussion_r408009938