### PR TITLE
Normalize pgdata in a better place

### DIFF
--- a/src/bin/pg_autoctl/pgsetup.c
+++ b/src/bin/pg_autoctl/pgsetup.c
@@ -132,6 +132,15 @@ pg_setup_init(PostgresSetup *pgSetup,
 			return false;
 		}
 
+		/*
+		 * Normalize PGDATA if the directory exists, otherwise keep the
+		 * relative path.
+		 */
+		if (!normalize_filename(pgSetup->pgdata, pgSetup->pgdata, MAXPGPATH))
+		{
+			return false;
+		}
+
 		pg_controldata(pgSetup, missing_pgdata_is_ok);
 
 		if (pgSetup->control.pg_control_version == 0)

--- a/src/bin/pg_autoctl/primary_standby.c
+++ b/src/bin/pg_autoctl/primary_standby.c
@@ -155,14 +155,6 @@ local_postgres_update(LocalPostgresServer *postgres, bool postgresNotRunningIsOk
 		return false;
 	}
 
-	/*
-	 * Now that we now that pgdata exists, lets normalize the path.
-	 */
-	if (!normalize_filename(pgSetup->pgdata, pgSetup->pgdata, MAXPGPATH))
-	{
-		return false;
-	}
-
 	(void) local_postgres_init(postgres, &newPgSetup);
 
 	return true;


### PR DESCRIPTION
The normalize we had didn't actually work correctly, since it was doing it on
`pgSetup` instead of `newPgSetup`. So the result was basically thrown away.
This moves the normalization to `pg_setup_init`, which seems reasonable because
`normalize_filename` is a no-op when the directory does not exist.