### PR TITLE
Return non-zero exit code when command parsing fails

### DIFF
--- a/src/bin/lib/subcommands.c/commandline.h
+++ b/src/bin/lib/subcommands.c/commandline.h
@@ -12,6 +12,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <stdbool.h>
 
 typedef int (*command_getopt)(int argc, char **argv);
 typedef void (*command_run)(int argc, char **argv);
@@ -38,7 +39,7 @@ extern CommandLine *current_command;
 #define make_command(name, desc, usage, help, getopt, run) \
 	{ name, desc, usage, help, getopt, run, NULL, NULL }
 
-void commandline_run(CommandLine *command, int argc, char **argv);
+bool commandline_run(CommandLine *command, int argc, char **argv);
 void commandline_help(FILE *stream);
 void commandline_print_usage(CommandLine *command, FILE *stream);
 void commandline_print_subcommands(CommandLine *command, FILE *stream);

--- a/src/bin/pg_autoctl/main.c
+++ b/src/bin/pg_autoctl/main.c
@@ -79,7 +79,10 @@ main(int argc, char **argv)
 		exit(EXIT_CODE_INTERNAL_ERROR);
 	}
 
-	(void) commandline_run(&command, argc, argv);
+	if (!commandline_run(&command, argc, argv))
+	{
+		exit(EXIT_CODE_BAD_ARGS);
+	}
 
 	return 0;
 }


### PR DESCRIPTION
This would have saved some time debugging a failing test.
And it's also more UNIX compliant in general.