### PR TITLE
Fix problems with empty sslmode in show uri command

### DIFF
--- a/src/bin/pg_autoctl/cli_show.c
+++ b/src/bin/pg_autoctl/cli_show.c
@@ -816,6 +816,12 @@ cli_show_formation_uri(int argc, char **argv)
 				exit(EXIT_CODE_BAD_CONFIG);
 			}
 
+			/*
+			 * Use the pgSetup values from the monitor. This makes sure the ssl
+			 * options are correct.
+			 */
+			kconfig.pgSetup = mconfig.pgSetup;
+
 			(void) print_monitor_and_formation_uri(&kconfig, &monitor, stdout);
 			break;
 		}

--- a/src/bin/pg_autoctl/keeper_config.c
+++ b/src/bin/pg_autoctl/keeper_config.c
@@ -371,8 +371,8 @@ keeper_config_read_file_skip_pgsetup(KeeperConfig *config,
 
 
 /*
- * keeper_config_read_file_skip_pgsetup overrides values in given KeeperConfig
- * with whatever values are read from given configuration filename.
+ * keeper_config_pgsetup_init overrides values in given KeeperConfig with
+ * whatever values are read from given configuration filename.
  */
 bool
 keeper_config_pgsetup_init(KeeperConfig *config,

--- a/src/bin/pg_autoctl/pgsetup.c
+++ b/src/bin/pg_autoctl/pgsetup.c
@@ -1339,6 +1339,15 @@ pgsetup_validate_ssl_settings(PostgresSetup *pgSetup)
 				 "achieve more security with the same ease of deployment.");
 		log_warn("See https://www.postgresql.org/docs/current/libpq-ssl.html "
 				 "for details on how to improve");
+
+		/* Install a default value for --ssl-mode */
+		if (ssl->sslMode == SSL_MODE_UNKNOWN)
+		{
+			ssl->sslMode = SSL_MODE_PREFER;
+			strlcpy(ssl->sslModeStr,
+					pgsetup_sslmode_to_string(ssl->sslMode), SSL_MODE_STRLEN);
+			log_info("Using default --ssl-mode \"%s\"", ssl->sslModeStr);
+		}
 		return true;
 	}
 


### PR DESCRIPTION
There were two issues:
1. When using `--formation ...` on the monitor it would not pass the loaded
   sslmode, because the wrong pgSetup was used.
2. When initialized with `--no-ssl` an empty `sslModeStr` would be stored.

Fixes #239 