### PR TITLE
Improve "show uri" command

### DIFF
--- a/src/bin/pg_autoctl/cli_show.c
+++ b/src/bin/pg_autoctl/cli_show.c
@@ -857,7 +857,6 @@ cli_show_uri(int argc, char **argv)
 		}
 	}
 
-
 	if (showUriOptions.monitorOnly)
 	{
 		(void) print_monitor_uri(&monitor, stdout);

--- a/src/bin/pg_autoctl/keeper_config.c
+++ b/src/bin/pg_autoctl/keeper_config.c
@@ -356,6 +356,15 @@ keeper_config_read_file_skip_pgsetup(KeeperConfig *config,
 		}
 	}
 
+	/*
+	 * Required for grandfathering old clusters that don't have sslmode
+	 * explicitely set
+	 */
+	if (IS_EMPTY_STRING_BUFFER(config->pgSetup.ssl.sslModeStr))
+	{
+		strlcpy(config->pgSetup.ssl.sslModeStr, "prefer", SSL_MODE_STRLEN);
+	}
+
 	/* set the ENUM value for sslMode */
 	config->pgSetup.ssl.sslMode =
 		pgsetup_parse_sslmode(config->pgSetup.ssl.sslModeStr);

--- a/src/bin/pg_autoctl/monitor_config.c
+++ b/src/bin/pg_autoctl/monitor_config.c
@@ -292,6 +292,15 @@ monitor_config_read_file(MonitorConfig *config,
 	strlcpy(config->pgSetup.dbname, PG_AUTOCTL_MONITOR_DBNAME, NAMEDATALEN);
 	strlcpy(config->pgSetup.username, PG_AUTOCTL_MONITOR_USERNAME, NAMEDATALEN);
 
+	/*
+	 * Required for grandfathering old clusters that don't have sslmode
+	 * explicitely set
+	 */
+	if (IS_EMPTY_STRING_BUFFER(config->pgSetup.ssl.sslModeStr))
+	{
+		strlcpy(config->pgSetup.ssl.sslModeStr, "prefer", SSL_MODE_STRLEN);
+	}
+
 	/* set the ENUM value for sslMode */
 	config->pgSetup.ssl.sslMode =
 		pgsetup_parse_sslmode(config->pgSetup.ssl.sslModeStr);


### PR DESCRIPTION
This does three things:
1. Make "show uri" output consistent for keeper and monitor
2. Add --monitor flag to get only the monitor uri
3. Fix sslmode in a uri being empty on old clusters

NOTE: Before this change on a keeper `pg_autoctl show uri` would output the
string for the formation that the keeper was a part of. This is not possible
anymore now without passing `--formation the-formation-string`. If it is deemed
useful to have this old behaviour behind a flag, it would be quite easy to add.
Another option is to have it stay the default, but add an `--all` flag that can
be used to show all formation strings on the keeper.

Fixes #238