### PR TITLE
Avoid requiring a restart of Postgres during our initialization steps.

### DIFF
--- a/src/bin/pg_autoctl/keeper_pg_init.c
+++ b/src/bin/pg_autoctl/keeper_pg_init.c
@@ -754,14 +754,12 @@ create_database_and_extension(Keeper *keeper)
 		}
 
 		/*
-		 * Install the citus extension in that database, skipping if the
-		 * extension has already been installed.
-		 */
-		log_info("CREATE EXTENSION %s;", CITUS_EXTENSION_NAME);
-
-		/*
-		 * Connect to pgsql as the system user to create extension: Same
-		 * user as initdb with superuser privileges.
+		 * Connect to pgsql as the system user to create extension: Same user
+		 * as initdb with superuser privileges.
+		 *
+		 * Calling keeper_update_state will re-init our sqlClient to now
+		 * connect per the configuration settings, cleaning-up the local
+		 * changes we made before.
 		 */
 		if (!keeper_update_pg_state(keeper))
 		{
@@ -769,6 +767,12 @@ create_database_and_extension(Keeper *keeper)
 					  "PostgreSQL instance, see above for details.");
 			return false;
 		}
+
+		/*
+		 * Install the citus extension in that database, skipping if the
+		 * extension has already been installed.
+		 */
+		log_info("CREATE EXTENSION %s;", CITUS_EXTENSION_NAME);
 
 		if (!pgsql_create_extension(&(postgres->sqlClient), CITUS_EXTENSION_NAME))
 		{

--- a/tests/test_ssl_self_signed.py
+++ b/tests/test_ssl_self_signed.py
@@ -29,7 +29,8 @@ def teardown_module():
 
 
 def check_ssl_files(node):
-    for setting, f in [("ssl_key_file", "server.key"), ("ssl_cert_file", "server.crt")]:
+    for setting, f in [("ssl_key_file", "server.key"),
+                       ("ssl_cert_file", "server.crt")]:
         file_path = os.path.join(node.datadir, f)
         assert os.path.isfile(file_path)
         eq_(node.pg_config_get(setting), file_path)


### PR DESCRIPTION
If we create the postgresql.conf before starting Postgres, we can include
the citus extension in the shared_preload_libraries and be done with that
step without having to later pg_ctl restart.