### PR TITLE
Cleanup, fix, refactor pgsetup Postgres pidfile utilities.

### DIFF
--- a/src/bin/pg_autoctl/cli_common.h
+++ b/src/bin/pg_autoctl/cli_common.h
@@ -129,16 +129,34 @@ extern CommandLine show_standby_names_command;
 /* cli_systemd.c */
 extern CommandLine systemd_cat_service_file_command;
 
+/*
+ * Handling SSL options on the command line and their inter-compatibility is a
+ * little complex.
+ */
+typedef enum
+{
+	SSL_CLI_UNKNOWN = 0,
+	SSL_CLI_NO_SSL,
+	SSL_CLI_SELF_SIGNED,
+	SSL_CLI_USER_PROVIDED
+} SSLCommandLineOptions;
 
 void keeper_cli_help(int argc, char **argv);
 int cli_print_version_getopts(int argc, char **argv);
 void keeper_cli_print_version(int argc, char **argv);
 void cli_pprint_json(JSON_Value *js);
 
+int cli_common_keeper_getopts(int argc, char **argv,
+							  struct option *long_options,
+							  const char *optstring,
+							  KeeperConfig *options,
+							  SSLCommandLineOptions *sslCommandLineOptions);
+
 int cli_create_node_getopts(int argc, char **argv,
 							struct option *long_options,
 							const char *optstring,
 							KeeperConfig *options);
+
 int cli_getopt_pgdata(int argc, char **argv);
 void prepare_keeper_options(KeeperConfig *options);
 
@@ -152,18 +170,6 @@ bool cli_create_config(Keeper *keeper, KeeperConfig *config);
 void cli_create_pg(Keeper *keeper);
 bool check_or_discover_nodename(KeeperConfig *config);
 void keeper_cli_destroy_node(int argc, char **argv);
-
-/*
- * Handling SSL options on the command line and their inter-compatibility is a
- * little complex.
- */
-typedef enum
-{
-	SSL_CLI_UNKNOWN = 0,
-	SSL_CLI_NO_SSL,
-	SSL_CLI_SELF_SIGNED,
-	SSL_CLI_USER_PROVIDED
-} SSLCommandLineOptions;
 
 bool cli_getopt_ssl_flags(int ssl_flag, char *optarg, PostgresSetup *pgSetup);
 bool cli_getopt_accept_ssl_options(SSLCommandLineOptions newSSLOption,

--- a/src/bin/pg_autoctl/cli_config.c
+++ b/src/bin/pg_autoctl/cli_config.c
@@ -248,7 +248,7 @@ cli_config_check_pgsetup(PostgresSetup *pgSetup)
 	}
 
 	log_info("Postgres setup for PGDATA \"%s\" is ok, "
-			 "running with PID %d and port %ld",
+			 "running with PID %d and port %d",
 			 pgSetup->pgdata, pgSetup->pidFile.port, pgSetup->pidFile.pid);
 }
 

--- a/src/bin/pg_autoctl/cli_do_misc.c
+++ b/src/bin/pg_autoctl/cli_do_misc.c
@@ -253,7 +253,7 @@ keeper_cli_pgsetup_is_ready(int argc, char **argv)
 		exit(EXIT_CODE_PGCTL);
 	}
 
-	log_debug("Initialized pgSetup, now calling pg_setup_wait_until_is_ready()");
+	log_debug("Initialized pgSetup, now calling pg_setup_is_ready()");
 
 	pgIsReady = pg_setup_is_ready(&pgSetup, pgIsNotRunningIsOk);
 
@@ -310,7 +310,7 @@ keeper_cli_pgsetup_startup_logs(int argc, char **argv)
 		exit(EXIT_CODE_PGCTL);
 	}
 
-	log_debug("Initialized pgSetup, now calling pg_setup_wait_until_is_ready()");
+	log_debug("Initialized pgSetup, now calling pg_log_startup()");
 
 	if (!pg_log_startup(pgSetup.pgdata, LOG_INFO))
 	{

--- a/src/bin/pg_autoctl/cli_do_misc.c
+++ b/src/bin/pg_autoctl/cli_do_misc.c
@@ -215,11 +215,11 @@ keeper_cli_add_standby_to_hba(int argc, char **argv)
 
 
 /*
- * keeper_cli_discover_pg_setup implements the CLI to discover a PostgreSQL
+ * keeper_cli_pgsetup_discover implements the CLI to discover a PostgreSQL
  * setup thanks to PGDATA and other environment variables.
  */
 void
-keeper_cli_discover_pg_setup(int argc, char **argv)
+keeper_cli_pgsetup_discover(int argc, char **argv)
 {
 	PostgresSetup pgSetup = { 0 };
 
@@ -237,6 +237,91 @@ keeper_cli_discover_pg_setup(int argc, char **argv)
 }
 
 
+/*
+ * keeper_cli_pgsetup_is_ready returns success when the local PostgreSQL setup
+ * belongs to a server that is "ready".
+ */
+void
+keeper_cli_pgsetup_is_ready(int argc, char **argv)
+{
+	PostgresSetup pgSetup = { 0 };
+	bool pgIsReady = false;
+	bool pgIsNotRunningIsOk = false;
+
+	if (!pg_setup_init(&pgSetup, &keeperOptions.pgSetup, true, true))
+	{
+		exit(EXIT_CODE_PGCTL);
+	}
+
+	log_debug("Initialized pgSetup, now calling pg_setup_wait_until_is_ready()");
+
+	pgIsReady = pg_setup_is_ready(&pgSetup, pgIsNotRunningIsOk);
+
+	log_info("Postgres status is: \"%s\"", pmStatusToString(pgSetup.pm_status));
+
+	if (pgIsReady)
+	{
+		exit(EXIT_CODE_QUIT);
+	}
+	exit(EXIT_CODE_PGSQL);
+}
+
+
+/*
+ * keeper_cli_discover_pg_setup implements the CLI to discover a PostgreSQL
+ * setup thanks to PGDATA and other environment variables.
+ */
+void
+keeper_cli_pgsetup_wait_until_ready(int argc, char **argv)
+{
+	int timeout = 30;
+	PostgresSetup pgSetup = { 0 };
+	bool pgIsReady = false;
+
+	if (!pg_setup_init(&pgSetup, &keeperOptions.pgSetup, true, true))
+	{
+		exit(EXIT_CODE_PGCTL);
+	}
+
+	log_debug("Initialized pgSetup, now calling pg_setup_wait_until_is_ready()");
+
+	pgIsReady = pg_setup_wait_until_is_ready(&pgSetup, timeout, LOG_INFO);
+
+	log_info("Postgres status is: \"%s\"", pmStatusToString(pgSetup.pm_status));
+
+	if (pgIsReady)
+	{
+		exit(EXIT_CODE_QUIT);
+	}
+	exit(EXIT_CODE_PGSQL);
+}
+
+
+/*
+ * keeper_cli_pgsetup_startup_logs logs the Postgre startup logs.
+ */
+void
+keeper_cli_pgsetup_startup_logs(int argc, char **argv)
+{
+	PostgresSetup pgSetup = { 0 };
+
+	if (!pg_setup_init(&pgSetup, &keeperOptions.pgSetup, true, true))
+	{
+		exit(EXIT_CODE_PGCTL);
+	}
+
+	log_debug("Initialized pgSetup, now calling pg_setup_wait_until_is_ready()");
+
+	if (!pg_log_startup(pgSetup.pgdata, LOG_INFO))
+	{
+		exit(EXIT_CODE_PGCTL);
+	}
+}
+
+
+/*
+ * keeper_cli_init_standby initializes a standby
+ */
 void
 keeper_cli_init_standby(int argc, char **argv)
 {

--- a/src/bin/pg_autoctl/cli_do_root.h
+++ b/src/bin/pg_autoctl/cli_do_root.h
@@ -65,7 +65,12 @@ void keeper_cli_create_replication_slot(int argc, char **argv);
 void keeper_cli_drop_replication_slot(int argc, char **argv);
 void keeper_cli_enable_synchronous_replication(int argc, char **argv);
 void keeper_cli_disable_synchronous_replication(int argc, char **argv);
-void keeper_cli_discover_pg_setup(int argc, char **argv);
+
+void keeper_cli_pgsetup_discover(int argc, char **argv);
+void keeper_cli_pgsetup_is_ready(int argc, char **argv);
+void keeper_cli_pgsetup_wait_until_ready(int argc, char **argv);
+void keeper_cli_pgsetup_startup_logs(int argc, char **argv);
+
 void keeper_cli_add_default_settings(int argc, char **argv);
 void keeper_cli_create_replication_user(int argc, char **argv);
 void keeper_cli_add_standby_to_hba(int argc, char **argv);

--- a/src/bin/pg_autoctl/file_utils.h
+++ b/src/bin/pg_autoctl/file_utils.h
@@ -17,6 +17,13 @@
 #include <fcntl.h>
 
 
+#if defined(__APPLE__)
+#define ST_MTIME_S(st) ((int64_t) st.st_mtimespec.tv_sec)
+#else
+#define ST_MTIME_S(st) ((int64_t) st.st_mtime)
+#endif
+
+
 bool file_exists(const char *filename);
 bool directory_exists(const char *path);
 bool ensure_empty_dir(const char *dirname, int mode);

--- a/src/bin/pg_autoctl/keeper.c
+++ b/src/bin/pg_autoctl/keeper.c
@@ -702,7 +702,7 @@ keeper_ensure_postgres_is_running(Keeper *keeper, bool updateRetries)
 	}
 	else if (ensure_local_postgres_is_running(postgres))
 	{
-		log_warn("PostgreSQL was not running, restarted with pid %ld",
+		log_warn("PostgreSQL was not running, restarted with pid %d",
 				 pgSetup->pidFile.pid);
 		return true;
 	}

--- a/src/bin/pg_autoctl/pgctl.c
+++ b/src/bin/pg_autoctl/pgctl.c
@@ -8,6 +8,7 @@
  *
  */
 
+#include <dirent.h>
 #include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
@@ -36,8 +37,6 @@
 
 #define AUTOCTL_CONF_INCLUDE_LINE "include '" AUTOCTL_DEFAULTS_CONF_FILENAME "'"
 #define AUTOCTL_SB_CONF_INCLUDE_LINE "include '" AUTOCTL_STANDBY_CONF_FILENAME "'"
-
-#define PROGRAM_NOT_RUNNING 3
 
 
 static bool pg_include_config(const char *configFilePath,
@@ -921,6 +920,156 @@ pg_ctl_start(const char *pg_ctl,
 
 
 /*
+ * pg_log_startup logs the PGDATA/startup.log file contents so that our users
+ * have enough information about why Postgres failed to start when that
+ * happens.
+ */
+bool
+pg_log_startup(const char *pgdata, int logLevel)
+{
+	char pgLogDirPath[MAXPGPATH] = { 0 };
+
+	char pgStartupPath[MAXPGPATH] = { 0 };
+	char *fileContents;
+	long fileSize;
+
+	/* logLevel to use when introducing which file path logs come from */
+	int pathLogLevel = logLevel <= LOG_DEBUG ? LOG_DEBUG : LOG_WARN;
+
+	/* prepare startup.log file in PGDATA */
+	join_path_components(pgStartupPath, pgdata, "startup.log");
+
+	if (read_file(pgStartupPath, &fileContents, &fileSize) && fileSize > 0)
+	{
+		char *lines[BUFSIZE];
+		int lineCount = splitLines(fileContents, lines, BUFSIZE);
+		int lineNumber = 0;
+
+		log_level(pathLogLevel, "Postgres logs from \"%s\":", pgStartupPath);
+
+		for (lineNumber = 0; lineNumber < lineCount; lineNumber++)
+		{
+			log_level(logLevel, "%s", lines[lineNumber]);
+		}
+	}
+
+	/*
+	 * Add in the most recent Postgres log file if it's been created after the
+	 * startup.log file, it might contain very useful information, such as a
+	 * FATAL line(s).
+	 *
+	 * Given that we setup Postgres to use the logging_collector, we expect
+	 * there to be a single Postgres log file in the "log" directory that was
+	 * created later than the "startup.log" file, and we expect the file to be
+	 * rather short.
+	 *
+	 * Also we setup log_directory to be "log" so that's where we are looking
+	 * into.
+	 */
+
+	/* prepare PGDATA/log directory path */
+	join_path_components(pgLogDirPath, pgdata, "log");
+
+	if (directory_exists(pgLogDirPath))
+	{
+		struct stat pgStartupStat;
+		int64_t pgStartupMtime = 0;
+
+		DIR *logDir = NULL;
+		struct dirent *logFileDirEntry = NULL;
+
+		/* get the time of last modification of the startup.log file */
+		if (lstat(pgStartupPath, &pgStartupStat) != 0)
+		{
+			log_error("Failed to get file information for \"%s\": %m",
+					  pgStartupPath);
+			return false;
+		}
+		pgStartupMtime = ST_MTIME_S(pgStartupStat);
+
+		/* open and scan through the Postgres log directory */
+		logDir = opendir(pgLogDirPath);
+
+		if (logDir == NULL)
+		{
+			log_error("Failed to open Postgres log directory \"%s\": %m",
+					  pgLogDirPath);
+			return false;
+		}
+
+		while ((logFileDirEntry = readdir(logDir)) != NULL)
+		{
+			char pgLogFilePath[MAXPGPATH] = { 0 };
+			struct stat pgLogFileStat;
+			int64_t pgLogFileMtime = 0;
+
+			/* our logFiles are regular files, skip . and .. and others */
+			if (logFileDirEntry->d_type != DT_REG)
+			{
+				continue;
+			}
+
+			/* build the absolute file path for the logfile */
+			join_path_components(pgLogFilePath,
+								 pgLogDirPath,
+								 logFileDirEntry->d_name);
+
+			/* get the file information for the current logFile */
+			if (lstat(pgLogFilePath, &pgLogFileStat) != 0)
+			{
+				log_error("Failed to get file information for \"%s\": %m",
+						  pgLogFilePath);
+				return false;
+			}
+			pgLogFileMtime = ST_MTIME_S(pgLogFileStat);
+
+			/*
+			 * Compare modification times and only add to our logs the content
+			 * from the Postgres log file that was created after the
+			 * startup.log file.
+			 */
+			if (pgLogFileMtime >= pgStartupMtime)
+			{
+				char *fileContents;
+				long fileSize;
+
+				log_level(pathLogLevel,
+						  "Postgres logs from \"%s\":", pgLogFilePath);
+
+				if (read_file(pgLogFilePath, &fileContents, &fileSize) &&
+					fileSize > 0)
+				{
+					char *lines[BUFSIZE];
+					int lineCount = splitLines(fileContents, lines, BUFSIZE);
+					int lineNumber = 0;
+
+					for (lineNumber = 0; lineNumber < lineCount; lineNumber++)
+					{
+						if (strstr(lines[lineNumber], "FATAL") != NULL)
+						{
+							log_fatal("%s", lines[lineNumber]);
+						}
+						else if (strstr(lines[lineNumber], "ERROR") != NULL)
+						{
+							log_error("%s", lines[lineNumber]);
+						}
+						else
+						{
+							log_level(logLevel, "%s", lines[lineNumber]);
+						}
+					}
+				}
+			}
+		}
+
+		closedir(logDir);
+	}
+
+	return true;
+}
+
+
+/*
  * pg_ctl_stop tries to stop a PostgreSQL server by running a "pg_ctl stop"
  * command. If the server was stopped successfully, or if the server is not
  * running at all, it returns true.
@@ -975,7 +1124,7 @@ pg_ctl_stop(const char *pg_ctl, const char *pgdata)
 	 */
 
 	status = pg_ctl_status(pg_ctl, pgdata, log_output);
-	if (status == PROGRAM_NOT_RUNNING)
+	if (status == PG_CTL_STATUS_NOT_RUNNING)
 	{
 		log_info("pg_ctl stop failed, but PostgreSQL is not running anyway");
 		free_program(&program);

--- a/src/bin/pg_autoctl/pgctl.h
+++ b/src/bin/pg_autoctl/pgctl.h
@@ -26,6 +26,8 @@
 #define AUTOCTL_DEFAULTS_CONF_FILENAME "postgresql-auto-failover.conf"
 #define AUTOCTL_STANDBY_CONF_FILENAME "postgresql-auto-failover-standby.conf"
 
+#define PG_CTL_STATUS_NOT_RUNNING 3
+
 bool pg_controldata(PostgresSetup *pgSetup, bool missing_ok);
 int config_find_pg_ctl(PostgresSetup *pgSetup);
 char * pg_ctl_version(const char *pg_ctl_path);
@@ -43,6 +45,7 @@ bool pg_rewind(const char *pgdata,
 bool pg_ctl_initdb(const char *pg_ctl, const char *pgdata);
 bool pg_ctl_start(const char *pg_ctl,
 				  const char *pgdata, int pgport, char *listen_addresses);
+bool pg_log_startup(const char *pgdata, int logLevel);
 bool pg_ctl_stop(const char *pg_ctl, const char *pgdata);
 int pg_ctl_status(const char *pg_ctl, const char *pgdata, bool log_output);
 bool pg_ctl_restart(const char *pg_ctl, const char *pgdata);

--- a/src/bin/pg_autoctl/pgsetup.c
+++ b/src/bin/pg_autoctl/pgsetup.c
@@ -574,6 +574,7 @@ read_pg_pidfile(PostgresSetup *pgSetup, bool pgIsNotRunningIsOk, int maxRetries)
 				return false;
 			}
 
+			/* a standalone backend pid is negative, we signal the actual pid */
 			pgSetup->pidFile.pid = abs(pid);
 
 			if (kill(pgSetup->pidFile.pid, 0) != 0)

--- a/src/bin/pg_autoctl/pgsetup.h
+++ b/src/bin/pg_autoctl/pgsetup.h
@@ -39,7 +39,7 @@ typedef struct pg_control_data
  */
 typedef struct pg_pidfile
 {
-	long pid;
+	pid_t pid;
 	unsigned short port;
 } PostgresPIDFile;
 
@@ -162,7 +162,9 @@ bool pg_setup_init(PostgresSetup *pgSetup,
 				   bool missing_pgdata_is_ok,
 				   bool pg_is_not_running_is_ok);
 
-bool read_pg_pidfile(PostgresSetup *pgSetup, bool pg_is_not_running_is_ok);
+bool read_pg_pidfile(PostgresSetup *pgSetup,
+					 bool pgIsNotRunningIsOk,
+					 int maxRetries);
 
 void fprintf_pg_setup(FILE *stream, PostgresSetup *pgSetup);
 bool pg_setup_as_json(PostgresSetup *pgSetup, JSON_Value *js);
@@ -173,6 +175,12 @@ bool pg_setup_pgdata_exists(PostgresSetup *pgSetup);
 bool pg_setup_is_running(PostgresSetup *pgSetup);
 bool pg_setup_is_primary(PostgresSetup *pgSetup);
 bool pg_setup_is_ready(PostgresSetup *pgSetup, bool pg_is_not_running_is_ok);
+bool pg_setup_wait_until_is_ready(PostgresSetup *pgSetup,
+								  int timeout, int logLevel);
+bool pg_setup_wait_until_is_stopped(PostgresSetup *pgSetup,
+									int timeout, int logLevel);
+char * pmStatusToString(PostmasterStatus pm_status);
+
 char * pg_setup_get_username(PostgresSetup *pgSetup);
 
 #define SKIP_HBA(authMethod) \

--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -389,47 +389,23 @@ class PGNode:
         """
         Returns true when Postgres is running. We use pg_ctl status.
         """
-        status_command = [shutil.which('pg_ctl'), '-D', self.datadir, 'status']
-        with self.vnode.run(status_command) as status_proc:
-            out, err = self.cluster.communicate(status_proc, timeout)
-            if status_proc.returncode == 0:
-                # pg_ctl status is happy to report 0 (Postgres is running) even
-                # when it's still "starting" and thus not ready for queries.
-                #
-                # because our tests need to be able to send queries to Postgres,
-                # the "starting" status is not good enough for us, we're only
-                # happy with "ready".
-                pidfile = os.path.join(self.datadir, 'postmaster.pid')
-                try:
-                    with open(pidfile, "r") as p:
-                        pidlines = p.readlines()
-                        if len(pidlines) > 7:
-                            pg_status = pidlines[7]
-                            return pg_status.startswith("ready")
-                except FileNotFoundError:
-                    # It's possible that the pidfile or pgdata does not exist yet.
-                    # Obviously postgres is not running in that case
-                    return False
-            elif status_proc.returncode > 0:
-                # ignore `pg_ctl status` output, silently try again till timeout
-                return False
-            elif status_proc.returncode is None:
-                print("pg_ctl status timed out after %ds" % timeout)
-                return False
+        command = PGAutoCtl(self)
+
+        try:
+            command.execute("pgsetup ready", 'do', 'pgsetup', 'ready', '-vvv')
+        except Exception as e:
+            # pg_autoctl uses EXIT_CODE_PGSQL when Postgres is not ready
+            return False
+        return True
 
     def wait_until_pg_is_running(self, timeout=STATE_CHANGE_TIMEOUT):
         """
         Waits until the underlying Postgres process is running.
         """
-        wait_until = dt.datetime.now() + dt.timedelta(seconds=timeout)
-        while wait_until > dt.datetime.now():
-            if self.pg_is_running():
-                return True
-            time.sleep(POLLING_INTERVAL)
-
-        print("Postgres is still not running in %s after %d seconds" %
-              (self.datadir, timeout))
-        return False
+        command = PGAutoCtl(self)
+        out, err, ret = command.execute("pgsetup ready",
+                                        'do', 'pgsetup', 'wait', '-vvv')
+        return ret == 0
 
     def fail(self):
         """
@@ -542,8 +518,8 @@ class PGNode:
         Set a configuration parameter to given value
         """
         command = PGAutoCtl(self)
-        out, err = command.execute("config get %s" % setting,
-                                   'config', 'get', setting)
+        out, err, ret = command.execute("config get %s" % setting,
+                                        'config', 'get', setting)
         return out[:-1]
 
     def show_uri(self, json=False):
@@ -552,9 +528,9 @@ class PGNode:
         """
         command = PGAutoCtl(self)
         if json:
-            out, err = command.execute("show uri", 'show', 'uri', '--json')
+            out, err, ret = command.execute("show uri", 'show', 'uri', '--json')
         else:
-            out, err = command.execute("show uri", 'show', 'uri')
+            out, err, ret = command.execute("show uri", 'show', 'uri')
         return out
 
     def logs(self):
@@ -933,8 +909,8 @@ SELECT reportedstate
             Gets candidate priority via pg_autoctl
         """
         command = PGAutoCtl(self)
-        out, err = command.execute("get canditate priority",
-                                   'get', 'node', 'candidate-priority')
+        out, err, ret = command.execute("get canditate priority",
+                                        'get', 'node', 'candidate-priority')
         return int(out)
 
     def set_replication_quorum(self, replicationQuorum):
@@ -956,8 +932,8 @@ SELECT reportedstate
             Gets replication quorum via pg_autoctl
         """
         command = PGAutoCtl(self)
-        out, err = command.execute("get replication quorum",
-                                   'get', 'node', 'replication-quorum')
+        out, err, ret = command.execute("get replication quorum",
+                                        'get', 'node', 'replication-quorum')
 
         value = out.strip()
 
@@ -987,8 +963,9 @@ SELECT reportedstate
             Gets number sync standbys  via pg_autoctl
         """
         command = PGAutoCtl(self)
-        out, err = command.execute("get number sync standbys",
-                                   'get', 'formation', 'number-sync-standbys')
+        out, err, ret = command.execute("get number sync standbys",
+                                        'get', 'formation',
+                                        'number-sync-standbys')
 
         return int(out)
 
@@ -997,8 +974,8 @@ SELECT reportedstate
             Gets number sync standbys  via pg_autoctl
         """
         command = PGAutoCtl(self)
-        out, err = command.execute("get synchronous_standby_names",
-                                   'show', 'synchronous_standby_names')
+        out, err, ret = command.execute("get synchronous_standby_names",
+                                        'show', 'synchronous_standby_names')
 
         return out.strip()
 
@@ -1212,7 +1189,7 @@ class MonitorNode(PGNode):
         print("pg_autoctl show state --pgdata %s" % self.datadir)
 
         command = PGAutoCtl(self)
-        out, err = command.execute("show state", 'show', 'state')
+        out, err, ret = command.execute("show state", 'show', 'state')
         print("%s" % out)
 
     def get_other_nodes(self, host, port):
@@ -1282,7 +1259,7 @@ class PGAutoCtl():
                                 (name,
                                  " ".join(self.command),
                                  out, err))
-            return out, err
+            return out, err, proc.returncode
 
     def stop(self):
         """

--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -584,15 +584,15 @@ class PGNode:
             ssl_args += ['--no-ssl']
 
         command = PGAutoCtl(self, argv=ssl_args)
-        out, err = command.execute("enable ssl")
+        out, err, ret = command.execute("enable ssl")
 
     def get_monitor_uri(self):
         """
         pg_autoctl show uri --monitor
         """
         command = PGAutoCtl(self)
-        out, err = command.execute("show uri --monitor",
-                                   'show', 'uri', '--monitor')
+        out, err, ret = command.execute("show uri --monitor",
+                                        'show', 'uri', '--monitor')
         return out
 
     def get_formation_uri(self, formationName='default'):
@@ -600,8 +600,9 @@ class PGNode:
         pg_autoctl show uri --formation {formationName}
         """
         command = PGAutoCtl(self)
-        out, err = command.execute("show uri --formation",
-                                   'show', 'uri', '--formation', formationName)
+        out, err, ret = command.execute("show uri --formation",
+                                        'show', 'uri',
+                                        '--formation', formationName)
         return out
 
     def check_conn_string_ssl(self, conn_string, sslmode):


### PR DESCRIPTION
Also make our functions exported in the PG_AUTOCTL_DEBUG facilities, to make
it easy to test and fix them. Since they're published there now, also use
them in our test suite rather than re-implementing a special-purpose version
of them in Python.