### PR TITLE
Don't create pgautofailover_monitor user anymore

### DIFF
--- a/src/bin/pg_autoctl/cli_do_misc.c
+++ b/src/bin/pg_autoctl/cli_do_misc.c
@@ -145,59 +145,6 @@ keeper_cli_add_default_settings(int argc, char **argv)
 
 
 /*
- * keeper_create_monitor_user implements the CLI to add a user for the
- * pg_auto_failover monitor.
- */
-void
-keeper_cli_create_monitor_user(int argc, char **argv)
-{
-	KeeperConfig config = keeperOptions;
-	LocalPostgresServer postgres = { 0 };
-	bool missingPgdataOk = false;
-	bool postgresNotRunningOk = false;
-	int urlLength = 0;
-	char monitorHostname[_POSIX_HOST_NAME_MAX];
-	int monitorPort = 0;
-
-	/*
-	 * Monitor does not use a password, we expect it to login and immediately
-	 * disconnect.
-	 */
-	char *password = NULL;
-
-	keeper_config_init(&config, missingPgdataOk, postgresNotRunningOk);
-	local_postgres_init(&postgres, &(config.pgSetup));
-
-	urlLength = strlcpy(config.monitor_pguri, argv[0], MAXCONNINFO);
-	if (urlLength >= MAXCONNINFO)
-	{
-		log_fatal("Monitor URL \"%s\" given in command line is %d characters, "
-				  "the maximum supported by pg_autoctl is %d",
-				  argv[0], urlLength, MAXCONNINFO - 1);
-		exit(EXIT_CODE_BAD_ARGS);
-	}
-
-	if (!hostname_from_uri(config.monitor_pguri,
-						   monitorHostname, _POSIX_HOST_NAME_MAX,
-						   &monitorPort))
-	{
-		log_fatal("Failed to determine monitor hostname");
-		exit(EXIT_CODE_BAD_ARGS);
-	}
-
-	if (!primary_create_user_with_hba(&postgres,
-									  PG_AUTOCTL_HEALTH_USERNAME, password,
-									  monitorHostname,
-									  pg_setup_get_auth_method(&(config.pgSetup))))
-	{
-		log_fatal("Failed to create the database user that the pg_auto_failover "
-				  " monitor uses for health checks, see above for details");
-		exit(EXIT_CODE_PGSQL);
-	}
-}
-
-
-/*
  * keeper_create_replication_user implements the CLI to add a user for the
  * secondary.
  */

--- a/src/bin/pg_autoctl/cli_do_root.c
+++ b/src/bin/pg_autoctl/cli_do_root.c
@@ -30,14 +30,6 @@
 #include "primary_standby.h"
 
 
-CommandLine do_primary_adduser_monitor =
-	make_command("monitor",
-				 "add a local user for queries from the monitor",
-				 "",
-				 KEEPER_CLI_WORKER_SETUP_OPTIONS,
-				 keeper_cli_keeper_setup_getopts,
-				 keeper_cli_create_monitor_user);
-
 CommandLine do_primary_adduser_replica =
 	make_command("replica",
 				 "add a local user with replication privileges",
@@ -47,7 +39,6 @@ CommandLine do_primary_adduser_replica =
 				 keeper_cli_create_replication_user);
 
 CommandLine *do_primary_adduser_subcommands[] = {
-	&do_primary_adduser_monitor,
 	&do_primary_adduser_replica,
 	NULL
 };

--- a/src/bin/pg_autoctl/cli_do_root.h
+++ b/src/bin/pg_autoctl/cli_do_root.h
@@ -25,7 +25,6 @@ extern CommandLine do_show_commands;
 /* src/bin/pg_autoctl/cli_do_root.c */
 extern CommandLine do_primary_adduser;
 extern CommandLine *do_primary_adduser_subcommands[];
-extern CommandLine do_primary_adduser_monitor;
 extern CommandLine do_primary_adduser_replica;
 
 extern CommandLine do_primary_syncrep_;
@@ -68,7 +67,6 @@ void keeper_cli_enable_synchronous_replication(int argc, char **argv);
 void keeper_cli_disable_synchronous_replication(int argc, char **argv);
 void keeper_cli_discover_pg_setup(int argc, char **argv);
 void keeper_cli_add_default_settings(int argc, char **argv);
-void keeper_cli_create_monitor_user(int argc, char **argv);
 void keeper_cli_create_replication_user(int argc, char **argv);
 void keeper_cli_add_standby_to_hba(int argc, char **argv);
 void keeper_cli_init_standby(int argc, char **argv);

--- a/src/bin/pg_autoctl/fsm_transition.c
+++ b/src/bin/pg_autoctl/fsm_transition.c
@@ -218,8 +218,6 @@ fsm_init_primary(Keeper *keeper)
 	{
 		char monitorHostname[_POSIX_HOST_NAME_MAX];
 		int monitorPort = 0;
-		char *password = NULL;
-		char *authMethod = NULL;
 
 		if (!hostname_from_uri(config->monitor_pguri,
 							   monitorHostname, _POSIX_HOST_NAME_MAX,
@@ -228,23 +226,6 @@ fsm_init_primary(Keeper *keeper)
 			/* developer error, this should never happen */
 			log_fatal("BUG: monitor_pguri should be validated before calling "
 					  "fsm_init_primary");
-			return false;
-		}
-
-		authMethod = pg_setup_get_auth_method(&(config->pgSetup));
-
-		/*
-		 * We need to add the monitor host:port in the HBA settings for the
-		 * node to enable the health checks.
-		 */
-		if (!primary_create_user_with_hba(postgres,
-										  PG_AUTOCTL_HEALTH_USERNAME, password,
-										  monitorHostname, authMethod))
-		{
-			log_error(
-				"Failed to initialise postgres as primary because "
-				"creating the database user that the pg_auto_failover monitor "
-				"uses for health checks failed, see above for details");
 			return false;
 		}
 	}

--- a/src/bin/pg_autoctl/primary_standby.c
+++ b/src/bin/pg_autoctl/primary_standby.c
@@ -463,61 +463,6 @@ postgres_add_default_settings(LocalPostgresServer *postgres)
 
 
 /*
- * primary_create_user_with_hba creates a user and updates pg_hba.conf
- * to allow the user to connect from the given hostname.
- */
-bool
-primary_create_user_with_hba(LocalPostgresServer *postgres, char *userName,
-							 char *password, char *hostname, char *authMethod)
-{
-	PGSQL *pgsql = &(postgres->sqlClient);
-	bool login = true;
-	bool superuser = false;
-	bool replication = false;
-	char hbaFilePath[MAXPGPATH];
-
-	log_trace("primary_create_user_with_hba");
-
-	if (!pgsql_create_user(pgsql, userName, password,
-						   login, superuser, replication))
-	{
-		log_error("Failed to create user \"%s\" on local postgres server",
-				  userName);
-		return false;
-	}
-
-	if (!pgsql_get_hba_file_path(pgsql, hbaFilePath, MAXPGPATH))
-	{
-		log_error("Failed to set the pg_hba rule for user \"%s\": couldn't get "
-				  "hba_file from local postgres server", userName);
-		return false;
-	}
-
-	if (!pghba_ensure_host_rule_exists(hbaFilePath,
-									   postgres->postgresSetup.ssl.active,
-									   HBA_DATABASE_ALL,
-									   NULL,
-									   userName,
-									   hostname,
-									   authMethod))
-	{
-		log_error("Failed to set the pg_hba rule for user \"%s\"", userName);
-		return false;
-	}
-
-	if (!pgsql_reload_conf(pgsql))
-	{
-		log_error("Failed to reload pg_hba settings after updating pg_hba.conf");
-		return false;
-	}
-
-	pgsql_finish(pgsql);
-
-	return true;
-}
-
-
-/*
  * primary_create_replication_user creates a user that allows the secondary
  * to connect for replication.
  */

--- a/src/bin/pg_autoctl/primary_standby.h
+++ b/src/bin/pg_autoctl/primary_standby.h
@@ -58,8 +58,6 @@ bool postgres_replication_slot_maintain(LocalPostgresServer *postgres,
 bool primary_enable_synchronous_replication(LocalPostgresServer *postgres);
 bool primary_disable_synchronous_replication(LocalPostgresServer *postgres);
 bool postgres_add_default_settings(LocalPostgresServer *postgres);
-bool primary_create_user_with_hba(LocalPostgresServer *postgres, char *userName,
-								  char *password, char *hostname, char *authMethod);
 bool primary_create_replication_user(LocalPostgresServer *postgres,
 									 char *replicationUser,
 									 char *replicationPassword);

--- a/src/monitor/health_check_worker.c
+++ b/src/monitor/health_check_worker.c
@@ -45,8 +45,16 @@
 #include "utils/memutils.h"
 #include "tcop/utility.h"
 
+/*
+ * The healthcheck only checks if it gets a response back from postgres. So
+ * both user and password are actually useless, because we do not need to
+ * authenticate. They are provided though to override any settings set through
+ * PGPASSWORD environment variable or .pgpass file. This way it does not matter
+ * that TLS is not necessarily used, because no secret information is sent.
+ */
 #define CONN_INFO_TEMPLATE \
 	"host=%s port=%u user=pgautofailover_monitor dbname=postgres " \
+	"password=pgautofailover_monitor" \
 	"connect_timeout=%u"
 #define MAX_CONN_INFO_SIZE 1024
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -24,7 +24,6 @@ def test_001_init_primary():
     node1 = cluster.create_datanode("/tmp/auth/node1", authMethod="md5")
     node1.create()
 
-    node1.set_user_password("pgautofailover_monitor", "monitor_password")
     node1.set_user_password("pgautofailover_replicator", "streaming_password")
     node1.config_set("replication.password", "streaming_password")
 


### PR DESCRIPTION
We don't actually need this user or its HBA rules, since authentication
does not need to succeed for the healtcheck to work. The healthcheck only
checks if the port is open on the specified host and it speaks the
postgres protocol.