### PR TITLE
Make sure old pgautofailover files are removed before install

### DIFF
--- a/src/monitor/Makefile
+++ b/src/monitor/Makefile
@@ -20,7 +20,14 @@ PG_CONFIG ?= pg_config
 PGXS = $(shell $(PG_CONFIG) --pgxs)
 USE_PGXS = 1
 
+.PHONY: cleanup-before-install
+
 include $(PGXS)
+
+cleanup-before-install:
+	rm -f $(DESTDIR)$(datadir)/$(datamoduledir)/pgautofailover*
+
+install: cleanup-before-install
 
 $(EXTENSION)--$(EXTVERSION).sql: $(EXTENSION).sql
 	cat $^ > $@


### PR DESCRIPTION
We do the same in the citus repo. This makes sure that in dev environments (or
building from source normally) old sql migration files are not accidentally
left behind.