### PR TITLE
Allow setting custom CFLAGS in the monitor

### DIFF
--- a/src/bin/pg_autoctl/Makefile
+++ b/src/bin/pg_autoctl/Makefile
@@ -33,7 +33,7 @@ DEFAULT_CFLAGS = -std=c99 -D_GNU_SOURCE -g
 DEFAULT_CFLAGS += -I $(shell $(PG_CONFIG) --includedir)
 DEFAULT_CFLAGS += -I $(shell $(PG_CONFIG) --includedir-server)
 DEFAULT_CFLAGS += -I $(shell $(PG_CONFIG) --pkgincludedir)/internal
-DEFAULT_CFLAGS += -I $(shell $(PG_CONFIG) --cflags)
+DEFAULT_CFLAGS += $(shell $(PG_CONFIG) --cflags)
 DEFAULT_CFLAGS += -Wformat
 DEFAULT_CFLAGS += -Wall
 DEFAULT_CFLAGS += -Werror=implicit-int

--- a/src/monitor/Makefile
+++ b/src/monitor/Makefile
@@ -23,7 +23,7 @@ USE_PGXS = 1
 .PHONY: cleanup-before-install
 
 DEFAULT_CFLAGS = -std=c99 -D_GNU_SOURCE -g
-DEFAULT_CFLAGS += -I $(shell $(PG_CONFIG) --cflags)
+DEFAULT_CFLAGS += $(shell $(PG_CONFIG) --cflags)
 override CFLAGS := $(DEFAULT_CFLAGS) $(CFLAGS)
 
 include $(PGXS)

--- a/src/monitor/Makefile
+++ b/src/monitor/Makefile
@@ -22,6 +22,10 @@ USE_PGXS = 1
 
 .PHONY: cleanup-before-install
 
+DEFAULT_CFLAGS = -std=c99 -D_GNU_SOURCE -g
+DEFAULT_CFLAGS += -I $(shell $(PG_CONFIG) --cflags)
+override CFLAGS := $(DEFAULT_CFLAGS) $(CFLAGS)
+
 include $(PGXS)
 
 cleanup-before-install:


### PR DESCRIPTION
We already had this for pg_auto_ctl, but not for the monitor extension. This
caused packaging to not include the expected CFLAGS, most importantly `-g` so
no debug info was created.