### PR TITLE
Implement a service supervisor for Postgres.

### DIFF
--- a/src/bin/lib/log/src/log.c
+++ b/src/bin/lib/log/src/log.c
@@ -25,6 +25,7 @@
 #include <stdarg.h>
 #include <string.h>
 #include <time.h>
+#include <unistd.h>
 
 #include "snprintf.h"
 
@@ -82,6 +83,10 @@ void log_set_level(int level) {
   L.level = level;
 }
 
+int log_get_level(void) {
+	return L.level;
+}
+
 
 void log_set_quiet(int enable) {
   L.quiet = enable ? 1 : 0;
@@ -123,7 +128,10 @@ void log_log(int level, const char *file, int line, const char *fmt, ...)
 
 	if (L.useColors)
 	{
-		pg_fprintf(stderr, "%s %s%-5s\x1b[0m ", buf, level_colors[level],
+		pg_fprintf(stderr, "%s %d %s%-5s\x1b[0m ",
+				   buf,
+				   getpid(),
+				   level_colors[level],
 				   level_names[level]);
 
 		if (showLineNumber)
@@ -133,7 +141,7 @@ void log_log(int level, const char *file, int line, const char *fmt, ...)
 	}
 	else
 	{
-		pg_fprintf(stderr, "%s %-5s ", buf, level_names[level]);
+		pg_fprintf(stderr, "%s %d %-5s ", buf, getpid(), level_names[level]);
 
 		if (showLineNumber)
 		{
@@ -152,7 +160,8 @@ void log_log(int level, const char *file, int line, const char *fmt, ...)
     va_list args;
     char buf[32];
     buf[strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", lt)] = '\0';
-    pg_fprintf(L.fp, "%s %-5s %s:%d: ", buf, level_names[level], file, line);
+    pg_fprintf(L.fp, "%s %d %-5s %s:%d: ",
+			   buf, getpid(), level_names[level], file, line);
     va_start(args, fmt);
     pg_vfprintf(L.fp, fmt, args);
     va_end(args);

--- a/src/bin/lib/log/src/log.h
+++ b/src/bin/lib/log/src/log.h
@@ -30,6 +30,7 @@ void log_set_udata(void *udata);
 void log_set_lock(log_LockFn fn);
 void log_set_fp(FILE *fp);
 void log_set_level(int level);
+int log_get_level(void);
 void log_set_quiet(int enable);
 void log_use_colors(int enable);
 

--- a/src/bin/lib/subcommands.c/runprogram.h
+++ b/src/bin/lib/subcommands.c/runprogram.h
@@ -6,9 +6,6 @@
  *
  */
 
-#ifdef RUN_PROGRAM_IMPLEMENTATION
-#undef RUN_PROGRAM_IMPLEMENTATION
-
 #include <fcntl.h>
 #include <stdarg.h>
 #include <stdbool.h>
@@ -41,19 +38,29 @@ typedef struct
 	int error;                  /* save errno when something's gone wrong */
 	int returnCode;
 
+	bool capture;               /* do we capture output, or redirect it? */
+
+	int stdOutFd;               /* redirect stdout to file descriptor */
+	int stdErrFd;               /* redirect stderr to file descriptor */
+
 	char *stdOut;
 	char *stdErr;
 } Program;
 
 Program run_program(const char *program, ...);
 Program initialize_program(char **args, bool setsid);
+void execute_subprogram(Program *prog);
 void execute_program(Program *prog);
 void free_program(Program *prog);
 int snprintf_program_command_line(Program *prog, char *buffer, int size);
+
+#ifdef RUN_PROGRAM_IMPLEMENTATION
+#undef RUN_PROGRAM_IMPLEMENTATION
+
 static void read_from_pipes(Program *prog,
 							pid_t childPid, int *outpipe, int *errpipe);
 static size_t read_into_buf(int filedes, PQExpBuffer buffer);
-
+static void waitprogram(Program *prog, pid_t childPid);
 
 /*
  * Run a program using fork() and exec(), get the stdOut and stdErr output from
@@ -72,6 +79,9 @@ run_program(const char *program, ...)
 	prog.returnCode = -1;
 	prog.error = 0;
 	prog.setsid = false;
+	prog.capture = true;
+	prog.stdOutFd = -1;
+	prog.stdErrFd = -1;
 	prog.stdOut = NULL;
 	prog.stdErr = NULL;
 
@@ -99,7 +109,7 @@ run_program(const char *program, ...)
 	va_end(args);
 	prog.args[nb_args] = NULL;
 
-	execute_program(&prog);
+	execute_subprogram(&prog);
 
 	return prog;
 }
@@ -119,6 +129,12 @@ initialize_program(char **args, bool setsid)
 	prog.returnCode = -1;
 	prog.error = 0;
 	prog.setsid = setsid;
+
+	/* this could be changed by the caller before calling execute_program */
+	prog.capture = true;
+	prog.stdOutFd = -1;
+	prog.stdErrFd = -1;
+
 	prog.stdOut = NULL;
 	prog.stdErr = NULL;
 
@@ -144,10 +160,10 @@ initialize_program(char **args, bool setsid)
 /*
  * Run given program with its args, by doing the fork()/exec() dance, and also
  * capture the subprocess output by installing pipes. We accimulate the output
- * into an SDS data structure (Simple Dynamic Strings library).
+ * into a PQExpBuffer when prog->capture is true.
  */
 void
-execute_program(Program *prog)
+execute_subprogram(Program *prog)
 {
 	pid_t pid;
 	int outpipe[2] = { 0, 0 };
@@ -157,19 +173,22 @@ execute_program(Program *prog)
 	fflush(stdout);
 	fflush(stderr);
 
-	/* create the pipe now */
-	if (pipe(outpipe) < 0)
+	/* create the output capture pipes now */
+	if (prog->capture)
 	{
-		prog->returnCode = -1;
-		prog->error = errno;
-		return;
-	}
+		if (pipe(outpipe) < 0)
+		{
+			prog->returnCode = -1;
+			prog->error = errno;
+			return;
+		}
 
-	if (pipe(errpipe) < 0)
-	{
-		prog->returnCode = -1;
-		prog->error = errno;
-		return;
+		if (pipe(errpipe) < 0)
+		{
+			prog->returnCode = -1;
+			prog->error = errno;
+			return;
+		}
 	}
 
 	pid = fork();
@@ -196,14 +215,27 @@ execute_program(Program *prog)
 			int stdIn = open(DEV_NULL, O_RDONLY);
 
 			dup2(stdIn, STDIN_FILENO);
-			dup2(outpipe[1], STDOUT_FILENO);
-			dup2(errpipe[1], STDERR_FILENO);
-
 			close(stdIn);
-			close(outpipe[0]);
-			close(outpipe[1]);
-			close(errpipe[0]);
-			close(errpipe[1]);
+
+			/*
+			 * Prepare either for capture the output in pipes, or redirect to
+			 * the given open file descriptors.
+			 */
+			if (prog->capture)
+			{
+				dup2(outpipe[1], STDOUT_FILENO);
+				dup2(errpipe[1], STDERR_FILENO);
+
+				close(outpipe[0]);
+				close(outpipe[1]);
+				close(errpipe[0]);
+				close(errpipe[1]);
+			}
+			else
+			{
+				dup2(prog->stdOutFd, STDOUT_FILENO);
+				dup2(prog->stdErrFd, STDERR_FILENO);
+			}
 
 			/*
 			 * When asked to do so, before creating the child process, we call
@@ -236,10 +268,76 @@ execute_program(Program *prog)
 		default:
 		{
 			/* fork succeeded, in parent */
-			read_from_pipes(prog, pid, outpipe, errpipe);
+			if (prog->capture)
+			{
+				read_from_pipes(prog, pid, outpipe, errpipe);
+			}
+			else
+			{
+				(void) waitprogram(prog, pid);
+			}
 			return;
 		}
 	}
+}
+
+
+/*
+ * Run given program with its args, by using exec().
+ */
+void
+execute_program(Program *prog)
+{
+	/*
+	 * We redirect /dev/null into stdIn rather than closing stdin, because
+	 * apparently closing it may cause undefined behavior if any read was to
+	 * happen.
+	 */
+	int stdIn = open(DEV_NULL, O_RDONLY);
+
+	if (prog->capture)
+	{
+		fprintf(stderr, "BUG: can't execute_program and capture the output");
+		return;
+	}
+
+	/* Flush stdio channels just before fork, to avoid double-output problems */
+	fflush(stdout);
+	fflush(stderr);
+
+	dup2(stdIn, STDIN_FILENO);
+	close(stdIn);
+
+	dup2(prog->stdOutFd, STDOUT_FILENO);
+	dup2(prog->stdErrFd, STDERR_FILENO);
+
+	/*
+	 * When asked to do so, before creating the child process, we call
+	 * setsid() to create our own session group and detach from the
+	 * terminal. That's useful when starting a service in the
+	 * background.
+	 */
+	if (prog->setsid)
+	{
+		if (setsid() == -1)
+		{
+			prog->returnCode = -1;
+			prog->error = errno;
+			return;
+		}
+	}
+
+	if (execv(prog->program, prog->args) == -1)
+	{
+		prog->returnCode = -1;
+		prog->error = errno;
+
+		fprintf(stdout, "%s\n", strerror(errno));
+		fprintf(stderr, "%s\n", strerror(errno));
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+
+	/* now the parent should waitpid() and may use waitprogram() */
 }
 
 
@@ -276,7 +374,6 @@ static void
 read_from_pipes(Program *prog, pid_t childPid, int *outpipe, int *errpipe)
 {
 	bool doneReading = false;
-	int status;
 	int countFdsReadyToRead, nfds; /* see man select(3) */
 	fd_set readFileDescriptorSet;
 	ssize_t bytes_out = BUFSIZE, bytes_err = BUFSIZE;
@@ -388,9 +485,19 @@ read_from_pipes(Program *prog, pid_t childPid, int *outpipe, int *errpipe)
 	destroyPQExpBuffer(outbuf);
 	destroyPQExpBuffer(errbuf);
 
-	/*
-	 * Now, wait until the child process is done.
-	 */
+	/* now, wait until the child process is done. */
+	(void) waitprogram(prog, childPid);
+}
+
+
+/*
+ * Wait until our Program is done.
+ */
+static void
+waitprogram(Program *prog, pid_t childPid)
+{
+	int status;
+
 	do {
 		if (waitpid(childPid, &status, WUNTRACED) == -1)
 		{

--- a/src/bin/pg_autoctl/README.md
+++ b/src/bin/pg_autoctl/README.md
@@ -1,0 +1,180 @@
+# pg_autoctl
+
+This directory contains the code the `pg_autoctl` utility, which implements
+the facilities needed to operate and run a pg_auto_failover installation.
+Such an installation is made of both a monitor and a keeper, and
+`pg_autoctl` allows to operate in those two modes.
+
+The `pg_autoctl` binary exposes a full command line with sub-commands. Most
+of the commands exposed to the user are compatible with running in the
+context of a monitor node or a keeper node.
+
+## Code Structure
+
+The code is organized in the following way:
+
+  - files with a name that starts with `cli_` implement the command line
+    facilities, their role is to understand the user's command and then call
+    into the implementation code.
+
+  - files with a name that starts with `cli_do_` implement the DEBUG command
+    line facilities, that are meant to expose all the `pg_autoctl`
+    facilities in a way that make them easy to invoke from the command line,
+    for better testability of the software, and shorter interaction loops
+    for developers.
+
+  - files with a name that contains `utils`, such as `env_utils.c`,
+    `file_utils.c`, or `string_utils.c` implement abstractions and
+    facilities used in many places in the rest of the code. Files
+    `parsing.[ch]` complete this list and could have been named
+    `parsing_utils` really.
+
+  - files with a name that contains `config` are related to handling of the
+    configuration files for either a monitor or a keeper instance, and this
+    is detailed later in this file.
+
+  - files with a names that start with `ini_` implement our higher level
+    facilities to handle configuration written in the INI format.
+
+  - files with a names that starts with `pg` implement abstrations used to
+    handle a Postgres service:
+
+	  - the `pgsql` module contains code to query the local Postgres
+        instance by using SQL queries, including the connection and result
+        parsing code.
+
+	  - the `monitor` module contains code to query the monitor Postgres
+        instance by using its SQL API, made with stored procedures, written
+        as a C extension to Postgres.
+
+	  - the `pgctl` module contains code to run Postgres commands such as
+        `pg_controldata`, `pg_basebackup`, or `pg_ctl`.
+
+	  - the `pgsetup` module contains code that discovers the current status
+        of a Postgres PGDATA directory, including whether the Postgres
+        service is currently running, on which port, etc.
+
+  - files with a name starting with `service` implement either process
+    control or a subprocess in the `pg_autoctl` process tree, and the
+    `supervisor.[ch]` files implement the main restart strategy to control
+    our process tree, see later for more details.
+
+  - the `primary_standby` file implements facilities to control Postgres
+    streaming replication primary and standby nodes and is mainly used from
+    the `fsm_transition.c` operations.
+
+  - files with a name that contains `fsm` and `state` implement the
+    “client-side” Finite State Machine that controls and implement
+    pg_auto_failover.
+
+There are more files needed to implement `pg_autoctl` and the remaining
+files have specific charters:
+
+  - the `main.c` file contains the `main(argc, argv)` function and
+    initializes our program.
+
+  - the `loop.c` file implements the keeper service.
+
+  - the `keeper_pg_init` module implements the `pg_autoctl create postgres`
+    command, which initialises a Postgres node for pg_auto_failover.
+
+  - the `monitor_pg_init` module implements the `pg_autoctl create monitor`
+    command, which initialises a monitor node for pg_auto_failover.
+
+  - the `debian` module contains code that recognize if we're given a debian
+    style cluster, such as created with `pg_createcluster`, and tools to
+    move the configuration files back in PGDATA and allow `pg_autoctl` to
+    own that cluster again.
+
+  - the `signals` module implements our signal masks and how we react to
+    receiving a SIGHUP or a SIGTERM signal, etc.
+
+  - the `systemd_config` module uses our INI file abstractions to create a
+    systemd unit configuration file that can be deployed and registered to
+    make `pg_autoctl` a systemd unit service.
+
+## Command Line and Configuration
+
+The `pg_autoctl` tool provides a complex set of commands and sub-commands,
+and handles user-given configuration. The configuration is handled in the
+INI format and can be all managed through the `pg_autoctl config` commands:
+
+```
+Available commands:
+  pg_autoctl config
+    check  Check pg_autoctl configuration
+    get    Get the value of a given pg_autoctl configuration variable
+    set    Set the value of a given pg_autoctl configuration variable
+```
+
+The modules in `keeper_config` and `monitor_config` define macros allowing
+to sync values read from the command line option parsing and the INI file
+together.
+
+All the read and edit operations for the configuration of `pg_autoctl` may
+be done through the `pg_autoctl get|set` function, rather than having to
+open the configuration file.
+
+## Software Architecture
+
+As the `pg_autoctl` tool unifies the management of two different process
+with two different modes of operation, the internal structure of the
+software reflects that.
+
+  - the monitor parts of the code are designed around the monitor data
+    structures:
+
+	  Monitor
+	  MonitorConfig
+	  LocalPostgresServer
+	  PostgresSetup
+
+  - the keeper parts of the code are designed around the keeper data
+    structures:
+
+	  Keeper
+	  KeeperConfig
+	  KeeperStateData
+	  LocalPostgresServer
+	  PostgresSetup
+
+We already see that we have common modules that are needed in both the
+keeper and the monitor, that both have to manage a local Postgres instance.
+
+## Process Supervision and Process Tree
+
+The `pg_autoctl` owns the Postgres service as a sub-process. A typical
+process tree for the monitor looks like the following:
+
+```
+-+= 84202 dim ./src/bin/pg_autoctl/pg_autoctl run
+ |-+- 84205 dim pg_autoctl: start/stop postgres
+ | \-+- 84212 dim /Applications/Postgres.app/Contents/Versions/12/bin/postgres -D /private/tmp/plop/m -p 4000 -h *
+ |   |--= 84213 dim postgres: logger
+ |   |--= 84215 dim postgres: checkpointer
+ |   |--= 84216 dim postgres: background writer
+ |   |--= 84217 dim postgres: walwriter
+ |   |--= 84218 dim postgres: autovacuum launcher
+ |   |--= 84219 dim postgres: stats collector
+ |   |--= 84220 dim postgres: pg_auto_failover monitor
+ |   |--= 84221 dim postgres: logical replication launcher
+ |   |--= 84222 dim postgres: pg_auto_failover monitor worker
+ |   |--= 84223 dim postgres: pg_auto_failover monitor worker
+ |   |--= 84228 dim postgres: dim template1 [local] idle
+ |   \--= 84229 dim postgres: autoctl_node pg_auto_failover [local] idle
+ \--- 84206 dim pg_autoctl: monitor listener
+```
+
+The main process start by `pg_autoctl` is a supervisor process. Its job is
+to loop around `waitpid()` and notice when sub-processes are finished. When
+the termination of them is not expected, the supervisor then restarts them.
+
+Given this process structure, the lifetime of the Postgres service is tied
+to that of the `pg_autoctl` service. Yet, we might want to restart the
+`pg_autoctl` code (to install a bugfix, for instance) and avoid restarting
+Postgres.
+
+To that end, the supervisor process starts its services by using `fork()`
+and then `exec("/path/to/pg_autoctl")`. This allows to later easily stop and
+restart that sub-process and load the new binary from disk, then loaded also
+the bug fixes that possibly come with the new version.

--- a/src/bin/pg_autoctl/cli_common.h
+++ b/src/bin/pg_autoctl/cli_common.h
@@ -176,6 +176,10 @@ bool cli_getopt_accept_ssl_options(SSLCommandLineOptions newSSLOption,
 								   SSLCommandLineOptions currentSSLOptions);
 void cli_drop_local_node(KeeperConfig *config, bool dropAndDestroy);
 
+char * logLevelToString(int logLevel);
+
+bool cli_common_pgsetup_init(ConfigFilePaths *pathnames, PostgresSetup *pgSetup);
+
 bool cli_pg_autoctl_reload(const char *pidfile);
 
 #endif  /* CLI_COMMON_H */

--- a/src/bin/pg_autoctl/cli_do_monitor.c
+++ b/src/bin/pg_autoctl/cli_do_monitor.c
@@ -400,7 +400,7 @@ cli_do_monitor_register_node(int argc, char **argv)
 		exit(EXIT_CODE_BAD_CONFIG);
 	}
 
-	if (!keeper_register_and_init(&keeper, &config, initialState))
+	if (!keeper_register_and_init(&keeper, initialState))
 	{
 		exit(EXIT_CODE_BAD_STATE);
 	}

--- a/src/bin/pg_autoctl/cli_do_root.c
+++ b/src/bin/pg_autoctl/cli_do_root.c
@@ -210,7 +210,7 @@ CommandLine do_pgsetup_startup_logs =
 				 keeper_cli_keeper_setup_getopts,
 				 keeper_cli_pgsetup_startup_logs);
 
-CommandLine *do_pg[] = {
+CommandLine *do_pgsetup[] = {
 	&do_pgsetup_discover,
 	&do_pgsetup_is_ready,
 	&do_pgsetup_wait_until_ready,
@@ -218,10 +218,10 @@ CommandLine *do_pg[] = {
 	NULL
 };
 
-CommandLine do_pg_commands =
+CommandLine do_pgsetup_commands =
 	make_command_set("pgsetup",
 					 "Manage a local Postgres setup", NULL, NULL,
-					 NULL, do_pg);
+					 NULL, do_pgsetup);
 
 CommandLine *do_subcommands[] = {
 	&do_monitor_commands,
@@ -229,7 +229,9 @@ CommandLine *do_subcommands[] = {
 	&do_primary_,
 	&do_standby_,
 	&do_show_commands,
-	&do_pg_commands,
+	&do_pgsetup_commands,
+	&do_service_postgres_ctl_commands,
+	&do_service_commands,
 	NULL
 };
 

--- a/src/bin/pg_autoctl/cli_do_root.h
+++ b/src/bin/pg_autoctl/cli_do_root.h
@@ -19,6 +19,10 @@ extern CommandLine do_fsm_commands;
 /* src/bin/pg_autoctl/cli_do_monitor.c */
 extern CommandLine do_monitor_commands;
 
+/* src/bin/pg_autoctl/cli_do_service.c */
+extern CommandLine do_service_commands;
+extern CommandLine do_service_postgres_ctl_commands;
+
 /* src/bin/pg_autoctl/cli_do_show.c */
 extern CommandLine do_show_commands;
 

--- a/src/bin/pg_autoctl/cli_do_service.c
+++ b/src/bin/pg_autoctl/cli_do_service.c
@@ -36,7 +36,7 @@ static void cli_do_service_postgresctl_off(int argc, char **argv);
 
 CommandLine service_pgcontroler =
 	make_command("pgcontroler",
-				 "pg_autoctl service that start/stop postgres when needed",
+				 "pg_autoctl supervised postgres controler",
 				 CLI_PGDATA_USAGE,
 				 CLI_PGDATA_OPTION,
 				 cli_getopt_pgdata,
@@ -44,7 +44,7 @@ CommandLine service_pgcontroler =
 
 CommandLine service_postgres =
 	make_command("postgres",
-				 "pg_autoctl service that start/stop postgres when needed",
+				 "pg_autoctl service that start/stop postgres when asked",
 				 CLI_PGDATA_USAGE,
 				 CLI_PGDATA_OPTION,
 				 cli_getopt_pgdata,

--- a/src/bin/pg_autoctl/cli_do_service.c
+++ b/src/bin/pg_autoctl/cli_do_service.c
@@ -31,7 +31,7 @@
 
 static void cli_do_service_getpid(int argc, char **argv);
 static void cli_do_service_postgres(int argc, char **argv);
-static void cli_do_service_pgcontroler(int argc, char **argv);
+static void cli_do_service_pgcontroller(int argc, char **argv);
 static void cli_do_service_postgresctl_on(int argc, char **argv);
 static void cli_do_service_postgresctl_off(int argc, char **argv);
 
@@ -45,13 +45,13 @@ CommandLine service_getpid =
 				 cli_getopt_pgdata,
 				 cli_do_service_getpid);
 
-CommandLine service_pgcontroler =
-	make_command("pgcontroler",
-				 "pg_autoctl supervised postgres controler",
+CommandLine service_pgcontroller =
+	make_command("pgcontroller",
+				 "pg_autoctl supervised postgres controller",
 				 CLI_PGDATA_USAGE,
 				 CLI_PGDATA_OPTION,
 				 cli_getopt_pgdata,
-				 cli_do_service_pgcontroler);
+				 cli_do_service_pgcontroller);
 
 CommandLine service_postgres =
 	make_command("postgres",
@@ -63,7 +63,7 @@ CommandLine service_postgres =
 
 CommandLine service_restart_postgres =
 	make_command("postgres",
-				 "Restart the pg_autoctl postgres controler service",
+				 "Restart the pg_autoctl postgres controller service",
 				 CLI_PGDATA_USAGE,
 				 CLI_PGDATA_OPTION,
 				 cli_getopt_pgdata,
@@ -82,7 +82,7 @@ CommandLine do_service_restart_commands =
 static CommandLine *service[] = {
 	&do_service_restart_commands,
 	&service_getpid,
-	&service_pgcontroler,
+	&service_pgcontroller,
 	&service_postgres,
 	NULL
 };
@@ -218,16 +218,16 @@ cli_do_service_restart_postgres(int argc, char **argv)
 
 
 /*
- * cli_do_pgcontroler starts the process controler service within a supervision
+ * cli_do_pgcontroller starts the process controller service within a supervision
  * tree. It is used for debug purposes only. When using this entry point we
  * have a supervisor process that is responsible for only one service:
  *
- *  pg_autoctl do service pgcontroler
+ *  pg_autoctl do service pgcontroller
  *   - pg_autoctl do service postgres
  *     - postgres
  */
 static void
-cli_do_service_pgcontroler(int argc, char **argv)
+cli_do_service_pgcontroller(int argc, char **argv)
 {
 	ConfigFilePaths pathnames = { 0 };
 	LocalPostgresServer postgres = { 0 };
@@ -296,7 +296,7 @@ cli_do_service_postgres(int argc, char **argv)
 
 
 /*
- * cli_do_service_postgresctl_on asks the pg_autoctl Postgres controler service
+ * cli_do_service_postgresctl_on asks the pg_autoctl Postgres controller service
  * to ensure that Postgres is running.
  */
 static void
@@ -338,7 +338,7 @@ cli_do_service_postgresctl_on(int argc, char **argv)
 
 
 /*
- * cli_do_service_postgresctl_on asks the pg_autoctl Postgres controler service
+ * cli_do_service_postgresctl_on asks the pg_autoctl Postgres controller service
  * to ensure that Postgres is stopped.
  */
 static void

--- a/src/bin/pg_autoctl/cli_do_service.c
+++ b/src/bin/pg_autoctl/cli_do_service.c
@@ -35,6 +35,8 @@ static void cli_do_service_pgcontroler(int argc, char **argv);
 static void cli_do_service_postgresctl_on(int argc, char **argv);
 static void cli_do_service_postgresctl_off(int argc, char **argv);
 
+static void cli_do_service_restart_postgres(int argc, char **argv);
+
 CommandLine service_getpid =
 	make_command("getpid",
 				 "get PID of a pg_autoctl running service",
@@ -59,7 +61,26 @@ CommandLine service_postgres =
 				 cli_getopt_pgdata,
 				 cli_do_service_postgres);
 
+CommandLine service_restart_postgres =
+	make_command("postgres",
+				 "Restart the pg_autoctl postgres controler service",
+				 CLI_PGDATA_USAGE,
+				 CLI_PGDATA_OPTION,
+				 cli_getopt_pgdata,
+				 cli_do_service_restart_postgres);
+
+static CommandLine *service_restart[] = {
+	&service_restart_postgres,
+	NULL
+};
+
+CommandLine do_service_restart_commands =
+	make_command_set("restart",
+					 "Restart pg_autoctl sub-processes (services)", NULL, NULL,
+					 NULL, service_restart);
+
 static CommandLine *service[] = {
+	&do_service_restart_commands,
 	&service_getpid,
 	&service_pgcontroler,
 	&service_postgres,
@@ -131,6 +152,66 @@ cli_do_service_getpid(int argc, char **argv)
 		log_fatal("Failed to find pid for service name \"%s\"", serviceName);
 		exit(EXIT_CODE_INTERNAL_ERROR);
 	}
+
+	fformat(stdout, "%d\n", pid);
+}
+
+
+/*
+ * cli_do_service_restart_postgres sends the TERM signal to the postgres
+ * service, which is known to have the restart policy RP_PERMANENT (that's
+ * hard-coded). As a consequence the supervisor will restart the service.
+ */
+static void
+cli_do_service_restart_postgres(int argc, char **argv)
+{
+	ConfigFilePaths pathnames = { 0 };
+	LocalPostgresServer postgres = { 0 };
+	const char *serviceName = "postgres";
+
+	pid_t pid = -1;
+	pid_t newPid = -1;
+
+	if (!cli_common_pgsetup_init(&pathnames, &(postgres.postgresSetup)))
+	{
+		/* errors have already been logged */
+		exit(EXIT_CODE_BAD_CONFIG);
+	}
+
+	if (!supervisor_find_service_pid(pathnames.pid, serviceName, &pid))
+	{
+		log_fatal("Failed to find pid for service name \"%s\"", serviceName);
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+
+	log_info("Sending the TERM signal to service \"%s\" with pid %d",
+			 serviceName, pid);
+
+	if (kill(pid, SIGTERM) != 0)
+	{
+		log_error("Failed to send SIGHUP to the pg_autoctl pid %d: %m", pid);
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+
+	/* loop until we have a new pid */
+	do {
+		if (!supervisor_find_service_pid(pathnames.pid, serviceName, &newPid))
+		{
+			log_fatal("Failed to find pid for service name \"%s\"", serviceName);
+			exit(EXIT_CODE_INTERNAL_ERROR);
+		}
+
+		if (newPid == pid)
+		{
+			log_trace("pidfile \"%s\" still contains pid %d for service \"%s\"",
+					  pathnames.pid, newPid, serviceName);
+		}
+
+		pg_usleep(100 * 1000);  /* retry in 100 ms */
+	} while (newPid == pid);
+
+	log_info("Service \"%s\" has been restarted with pid %d",
+			 serviceName, newPid);
 
 	fformat(stdout, "%d\n", pid);
 }

--- a/src/bin/pg_autoctl/cli_do_service.c
+++ b/src/bin/pg_autoctl/cli_do_service.c
@@ -115,15 +115,15 @@ cli_do_service_postgresctl_on(int argc, char **argv)
 {
 	ConfigFilePaths pathnames = { 0 };
 	LocalPostgresServer postgres = { 0 };
-	PostgresSetup pgSetup = { 0 };
+	PostgresSetup *pgSetup = &(postgres.postgresSetup);
 
-	if (!cli_common_pgsetup_init(&pathnames, &pgSetup))
+	if (!cli_common_pgsetup_init(&pathnames, pgSetup))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_BAD_CONFIG);
 	}
 
-	(void) local_postgres_init(&postgres, &pgSetup);
+	(void) local_postgres_init(&postgres, pgSetup);
 
 	if (!ensure_postgres_service_is_running(&postgres))
 	{
@@ -131,13 +131,13 @@ cli_do_service_postgresctl_on(int argc, char **argv)
 	}
 
 	log_info("Postgres is serving PGDATA \"%s\" on port %d with pid %d",
-			 pgSetup.pgdata, pgSetup.pgport, pgSetup.pidFile.pid);
+			 pgSetup->pgdata, pgSetup->pgport, pgSetup->pidFile.pid);
 
 	if (outputJSON)
 	{
 		JSON_Value *js = json_value_init_object();
 
-		if (!pg_setup_as_json(&pgSetup, js))
+		if (!pg_setup_as_json(pgSetup, js))
 		{
 			/* can't happen */
 			exit(EXIT_CODE_INTERNAL_ERROR);
@@ -157,20 +157,20 @@ cli_do_service_postgresctl_off(int argc, char **argv)
 {
 	ConfigFilePaths pathnames = { 0 };
 	LocalPostgresServer postgres = { 0 };
-	PostgresSetup pgSetup = { 0 };
+	PostgresSetup *pgSetup = &(postgres.postgresSetup);
 
-	if (!cli_common_pgsetup_init(&pathnames, &pgSetup))
+	if (!cli_common_pgsetup_init(&pathnames, pgSetup))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_BAD_CONFIG);
 	}
 
-	(void) local_postgres_init(&postgres, &pgSetup);
+	(void) local_postgres_init(&postgres, pgSetup);
 
 	if (!ensure_postgres_service_is_stopped(&postgres))
 	{
 		exit(EXIT_CODE_PGCTL);
 	}
 
-	log_info("Postgres has been stopped for PGDATA \"%s\"", pgSetup.pgdata);
+	log_info("Postgres has been stopped for PGDATA \"%s\"", pgSetup->pgdata);
 }

--- a/src/bin/pg_autoctl/cli_do_service.c
+++ b/src/bin/pg_autoctl/cli_do_service.c
@@ -1,0 +1,176 @@
+/*
+ * src/bin/pg_autoctl/cli_do_service.c
+ *     Implementation of a CLI for controlling the pg_autoctl service.
+ *
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the PostgreSQL License.
+ *
+ */
+
+#include <errno.h>
+#include <inttypes.h>
+#include <getopt.h>
+#include <signal.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "postgres_fe.h"
+
+#include "cli_common.h"
+#include "commandline.h"
+#include "defaults.h"
+#include "keeper_config.h"
+#include "keeper.h"
+#include "monitor.h"
+#include "monitor_config.h"
+#include "service.h"
+#include "service_postgres_ctl.h"
+#include "signals.h"
+
+static void cli_do_service_postgres(int argc, char **argv);
+static void cli_do_service_postgresctl_on(int argc, char **argv);
+static void cli_do_service_postgresctl_off(int argc, char **argv);
+
+CommandLine service_postgres =
+	make_command("postgres",
+				 "pg_autoctl service that start/stop postgres when needed",
+				 CLI_PGDATA_USAGE,
+				 CLI_PGDATA_OPTION,
+				 cli_getopt_pgdata,
+				 cli_do_service_postgres);
+
+static CommandLine *service[] = {
+	&service_postgres,
+	NULL
+};
+
+CommandLine do_service_commands =
+	make_command_set("service",
+					 "Run pg_autoctl sub-processes (services)", NULL, NULL,
+					 NULL, service);
+
+
+CommandLine service_postgres_ctl_on =
+	make_command("on",
+				 "Signal pg_autoctl postgres service to ensure Postgres is running",
+				 CLI_PGDATA_USAGE,
+				 CLI_PGDATA_OPTION,
+				 cli_getopt_pgdata,
+				 cli_do_service_postgresctl_on);
+
+
+CommandLine service_postgres_ctl_off =
+	make_command("off",
+				 "Signal pg_autoctl postgres service to ensure Postgres is stopped",
+				 CLI_PGDATA_USAGE,
+				 CLI_PGDATA_OPTION,
+				 cli_getopt_pgdata,
+				 cli_do_service_postgresctl_off);
+
+static CommandLine *pgctl[] = {
+	&service_postgres_ctl_on,
+	&service_postgres_ctl_off,
+	NULL
+};
+
+CommandLine do_service_postgres_ctl_commands =
+	make_command_set("pgctl",
+					 "Signal the pg_autoctl postgres service", NULL, NULL,
+					 NULL, pgctl);
+
+
+/*
+ * cli_do_service_postgres starts the process service.
+ */
+static void
+cli_do_service_postgres(int argc, char **argv)
+{
+	ConfigFilePaths pathnames = { 0 };
+	LocalPostgresServer postgres = { 0 };
+
+	bool exitOnQuit = true;
+
+	/* Establish a handler for signals. */
+	(void) set_signal_handlers(exitOnQuit);
+
+	if (!cli_common_pgsetup_init(&pathnames, &(postgres.postgresSetup)))
+	{
+		/* errors have already been logged */
+		exit(EXIT_CODE_BAD_CONFIG);
+	}
+
+	/* display a user-friendly process name */
+	(void) set_ps_title("pg_autoctl: start/stop postgres");
+
+	(void) service_postgres_ctl_loop(&postgres);
+}
+
+
+/*
+ * cli_do_service_postgresctl_on asks the pg_autoctl Postgres controler service
+ * to ensure that Postgres is running.
+ */
+static void
+cli_do_service_postgresctl_on(int argc, char **argv)
+{
+	ConfigFilePaths pathnames = { 0 };
+	LocalPostgresServer postgres = { 0 };
+	PostgresSetup pgSetup = { 0 };
+
+	if (!cli_common_pgsetup_init(&pathnames, &pgSetup))
+	{
+		/* errors have already been logged */
+		exit(EXIT_CODE_BAD_CONFIG);
+	}
+
+	(void) local_postgres_init(&postgres, &pgSetup);
+
+	if (!ensure_postgres_service_is_running(&postgres))
+	{
+		exit(EXIT_CODE_PGCTL);
+	}
+
+	log_info("Postgres is serving PGDATA \"%s\" on port %d with pid %d",
+			 pgSetup.pgdata, pgSetup.pgport, pgSetup.pidFile.pid);
+
+	if (outputJSON)
+	{
+		JSON_Value *js = json_value_init_object();
+
+		if (!pg_setup_as_json(&pgSetup, js))
+		{
+			/* can't happen */
+			exit(EXIT_CODE_INTERNAL_ERROR);
+		}
+
+		(void) cli_pprint_json(js);
+	}
+}
+
+
+/*
+ * cli_do_service_postgresctl_on asks the pg_autoctl Postgres controler service
+ * to ensure that Postgres is stopped.
+ */
+static void
+cli_do_service_postgresctl_off(int argc, char **argv)
+{
+	ConfigFilePaths pathnames = { 0 };
+	LocalPostgresServer postgres = { 0 };
+	PostgresSetup pgSetup = { 0 };
+
+	if (!cli_common_pgsetup_init(&pathnames, &pgSetup))
+	{
+		/* errors have already been logged */
+		exit(EXIT_CODE_BAD_CONFIG);
+	}
+
+	(void) local_postgres_init(&postgres, &pgSetup);
+
+	if (!ensure_postgres_service_is_stopped(&postgres))
+	{
+		exit(EXIT_CODE_PGCTL);
+	}
+
+	log_info("Postgres has been stopped for PGDATA \"%s\"", pgSetup.pgdata);
+}

--- a/src/bin/pg_autoctl/cli_do_service.c
+++ b/src/bin/pg_autoctl/cli_do_service.c
@@ -218,9 +218,9 @@ cli_do_service_restart_postgres(int argc, char **argv)
 
 
 /*
- * cli_do_pgcontroler starts the process controller service within a
- * supervision tree. It is used for debug purposes only. When using this entry
- * point we have a supervisor process that is responsible for only one service:
+ * cli_do_pgcontroler starts the process controler service within a supervision
+ * tree. It is used for debug purposes only. When using this entry point we
+ * have a supervisor process that is responsible for only one service:
  *
  *  pg_autoctl do service pgcontroler
  *   - pg_autoctl do service postgres

--- a/src/bin/pg_autoctl/cli_root.h
+++ b/src/bin/pg_autoctl/cli_root.h
@@ -17,6 +17,10 @@ extern char pg_autoctl_argv0[];
 extern char pg_autoctl_program[];
 extern int logLevel;
 
+extern char *ps_buffer;
+extern size_t ps_buffer_size;
+extern size_t last_status_len;
+
 extern CommandLine help;
 extern CommandLine version;
 

--- a/src/bin/pg_autoctl/cli_show.c
+++ b/src/bin/pg_autoctl/cli_show.c
@@ -1268,13 +1268,13 @@ cli_show_file(int argc, char **argv)
 			if (showFileOptions.showFileContents)
 			{
 				Keeper keeper = { 0 };
-				KeeperStateInit initState = { 0 };
 
 				keeper.config = config;
 
-				if (keeper_init_state_read(&keeper, &initState))
+				if (keeper_init_state_read(&(keeper.initState),
+										   config.pathnames.init))
 				{
-					(void) print_keeper_init_state(&initState, stdout);
+					(void) print_keeper_init_state(&(keeper.initState), stdout);
 				}
 				else
 				{

--- a/src/bin/pg_autoctl/config.c
+++ b/src/bin/pg_autoctl/config.c
@@ -198,7 +198,7 @@ SetStateFilePath(ConfigFilePaths *pathnames, const char *pgdata)
 		if (!build_xdg_path(pathnames->init,
 							XDG_DATA,
 							pgdata,
-							KEEPER_INIT_FILENAME))
+							KEEPER_INIT_STATE_FILENAME))
 		{
 			log_error("Failed to build pg_autoctl init state file pathname, "
 					  "see above.");

--- a/src/bin/pg_autoctl/defaults.h
+++ b/src/bin/pg_autoctl/defaults.h
@@ -99,7 +99,8 @@
 #define KEEPER_CONFIGURATION_FILENAME "pg_autoctl.cfg"
 #define KEEPER_STATE_FILENAME "pg_autoctl.state"
 #define KEEPER_PID_FILENAME "pg_autoctl.pid"
-#define KEEPER_INIT_FILENAME "pg_autoctl.init"
+#define KEEPER_INIT_STATE_FILENAME "pg_autoctl.init"
+#define KEEPER_POSTGRES_STATE_FILENAME "pg_autoctl.pg"
 
 #define KEEPER_SYSTEMD_SERVICE "pgautofailover"
 #define KEEPER_SYSTEMD_FILENAME "pgautofailover.service"
@@ -133,6 +134,7 @@
 #define EXIT_CODE_MONITOR 6
 #define EXIT_CODE_COORDINATOR 7
 #define EXIT_CODE_KEEPER 8
+#define EXIT_CODE_RELOAD 9
 #define EXIT_CODE_INTERNAL_ERROR 12
 
 

--- a/src/bin/pg_autoctl/file_utils.h
+++ b/src/bin/pg_autoctl/file_utils.h
@@ -47,6 +47,9 @@ bool unlink_file(const char *filename);
 bool set_program_absolute_path(char *program, int size);
 bool normalize_filename(const char *filename, char *dst, int size);
 
+void init_ps_buffer(int argc, char **argv);
+void set_ps_title(const char *title);
+
 int fformat(FILE *stream, const char *fmt, ...)
 __attribute__((format(printf, 2, 3)));
 

--- a/src/bin/pg_autoctl/keeper.c
+++ b/src/bin/pg_autoctl/keeper.c
@@ -1086,6 +1086,7 @@ bool
 keeper_init_fsm(Keeper *keeper)
 {
 	KeeperConfig *config = &(keeper->config);
+	PostgresSetup *pgSetup = &(config->pgSetup);
 
 	/* fake the initial state provided at monitor registration time */
 	MonitorAssignedState assignedState = {
@@ -1136,7 +1137,9 @@ keeper_init_fsm(Keeper *keeper)
 	 * case of `pg_autoctl create` being interrupted, we may resume operations
 	 * and accept to work on already running PostgreSQL primary instances.
 	 */
-	if (!keeper_init_state_write(keeper))
+	if (!keeper_init_state_create(&(keeper->initState),
+								  pgSetup,
+								  config->pathnames.init))
 	{
 		/* errors have already been logged */
 		return false;
@@ -1152,9 +1155,11 @@ keeper_init_fsm(Keeper *keeper)
  * the assigned goal from the Monitor.
  */
 bool
-keeper_register_and_init(Keeper *keeper,
-						 KeeperConfig *config, NodeState initialState)
+keeper_register_and_init(Keeper *keeper, NodeState initialState)
 {
+	KeeperConfig *config = &(keeper->config);
+	PostgresSetup *pgSetup = &(config->pgSetup);
+	KeeperStateInit *initState = &(keeper->initState);
 	Monitor *monitor = &(keeper->monitor);
 	MonitorAssignedState assignedState = { 0 };
 
@@ -1230,7 +1235,9 @@ keeper_register_and_init(Keeper *keeper,
 	 * case of `pg_autoctl create` being interrupted, we may resume operations
 	 * and accept to work on already running PostgreSQL primary instances.
 	 */
-	if (!keeper_init_state_write(keeper))
+	if (!keeper_init_state_create(initState,
+								  pgSetup,
+								  keeper->config.pathnames.init))
 	{
 		/* errors have already been logged */
 		return false;
@@ -1307,166 +1314,6 @@ keeper_remove(Keeper *keeper, KeeperConfig *config, bool ignore_monitor_errors)
 	}
 
 	return errors == 0;
-}
-
-
-/*
- * keeper_init_state_write create our pg_autoctl.init file.
- *
- * This file is created when entering keeper init and deleted only when the
- * init has been successful. This allows the code to take smarter decisions and
- * decipher in between a previous init having failed halfway through or
- * initializing from scratch in conditions not supported (pre-existing and
- * running cluster, etc).
- */
-bool
-keeper_init_state_write(Keeper *keeper)
-{
-	int fd;
-	char buffer[PG_AUTOCTL_KEEPER_STATE_FILE_SIZE];
-	KeeperStateInit initState = { 0 };
-
-	if (!keeper_init_state_discover(keeper, &initState))
-	{
-		/* errors have already been logged */
-		return false;
-	}
-
-	log_info("Writing keeper init state file at \"%s\"",
-			 keeper->config.pathnames.init);
-	log_debug("keeper_init_state_write: version = %d",
-			  initState.pg_autoctl_state_version);
-	log_debug("keeper_init_state_write: pgInitState = %s",
-			  PreInitPostgreInstanceStateToString(initState.pgInitState));
-
-	memset(buffer, 0, PG_AUTOCTL_KEEPER_STATE_FILE_SIZE);
-
-	/*
-	 * Explanation of IGNORE-BANNED:
-	 * memcpy is safe to use here.
-	 * we have a static assert that sizeof(KeeperStateInit) is always
-	 * less than the buffer length PG_AUTOCTL_KEEPER_STATE_FILE_SIZE.
-	 * also KeeperStateData is a plain struct that does not contain
-	 * any pointers in it. Necessary comment about not using pointers
-	 * is added to the struct definition.
-	 */
-	memcpy(buffer, &initState, sizeof(KeeperStateInit)); /* IGNORE-BANNED */
-
-	fd = open(keeper->config.pathnames.init,
-			  O_RDWR | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR);
-	if (fd < 0)
-	{
-		log_fatal("Failed to create keeper init state file \"%s\": %m",
-				  keeper->config.pathnames.init);
-		return false;
-	}
-
-	errno = 0;
-	if (write(fd, buffer, PG_AUTOCTL_KEEPER_STATE_FILE_SIZE) !=
-		PG_AUTOCTL_KEEPER_STATE_FILE_SIZE)
-	{
-		/* if write didn't set errno, assume problem is no disk space */
-		if (errno == 0)
-		{
-			errno = ENOSPC;
-		}
-		log_fatal("Failed to write keeper state file \"%s\": %m",
-				  keeper->config.pathnames.init);
-		return false;
-	}
-
-	if (fsync(fd) != 0)
-	{
-		log_fatal("fsync error: %m");
-		return false;
-	}
-
-	close(fd);
-
-	return true;
-}
-
-
-/*
- * keeper_init_state_discover discovers the current KeeperStateInit from the
- * command line options, by checking everything we can about the possibly
- * existing Postgres instance.
- */
-bool
-keeper_init_state_discover(Keeper *keeper, KeeperStateInit *initState)
-{
-	PostgresSetup pgSetup = { 0 };
-	bool missingPgdataIsOk = true;
-	bool pgIsNotRunningIsOk = true;
-
-	initState->pg_autoctl_state_version = PG_AUTOCTL_STATE_VERSION;
-
-	if (!pg_setup_init(&pgSetup, &(keeper->config.pgSetup),
-					   missingPgdataIsOk, pgIsNotRunningIsOk))
-	{
-		log_fatal("Failed to initialise the keeper init state, "
-				  "see above for details");
-		return false;
-	}
-
-	if (pg_setup_is_running(&pgSetup) && pg_setup_is_primary(&pgSetup))
-	{
-		initState->pgInitState = PRE_INIT_STATE_PRIMARY;
-	}
-	else if (pg_setup_is_running(&pgSetup))
-	{
-		initState->pgInitState = PRE_INIT_STATE_RUNNING;
-	}
-	else if (pg_setup_pgdata_exists(&pgSetup))
-	{
-		initState->pgInitState = PRE_INIT_STATE_EXISTS;
-	}
-	else
-	{
-		initState->pgInitState = PRE_INIT_STATE_EMPTY;
-	}
-
-	return true;
-}
-
-
-/*
- * keeper_init_state_read reads the information kept in the keeper init file.
- */
-bool
-keeper_init_state_read(Keeper *keeper, KeeperStateInit *initState)
-{
-	char *filename = keeper->config.pathnames.init;
-	char *content = NULL;
-	long fileSize;
-	int pg_autoctl_state_version = 0;
-
-	log_debug("Reading current init state from \"%s\"", filename);
-
-	if (!read_file(filename, &content, &fileSize))
-	{
-		log_error("Failed to read Keeper state from file \"%s\"", filename);
-		return false;
-	}
-
-	pg_autoctl_state_version =
-		((KeeperStateInit *) content)->pg_autoctl_state_version;
-
-	if (fileSize >= sizeof(KeeperStateData) &&
-		pg_autoctl_state_version == PG_AUTOCTL_STATE_VERSION)
-	{
-		*initState = *(KeeperStateInit *) content;
-		free(content);
-		return true;
-	}
-
-	free(content);
-
-	/* Looks like it's a mess. */
-	log_error("Keeper init state file \"%s\" exists but "
-			  "is broken or wrong version",
-			  filename);
-	return false;
 }
 
 

--- a/src/bin/pg_autoctl/keeper.h
+++ b/src/bin/pg_autoctl/keeper.h
@@ -30,13 +30,15 @@ typedef struct Keeper
 	 * information. This is necessary in some transitions.
 	 */
 	NodeAddressArray otherNodes;
+
+	/* Only useful during the initialization of the Keeper */
+	KeeperStateInit initState;
 } Keeper;
 
 
 bool keeper_init(Keeper *keeper, KeeperConfig *config);
 bool keeper_init_fsm(Keeper *keeper);
-bool keeper_register_and_init(Keeper *keeper, KeeperConfig *config,
-							  NodeState initialState);
+bool keeper_register_and_init(Keeper *keeper, NodeState initialState);
 bool keeper_load_state(Keeper *keeper);
 bool keeper_store_state(Keeper *keeper);
 bool keeper_update_state(Keeper *keeper, int node_id, int group_id, NodeState state,
@@ -55,11 +57,7 @@ bool ReportPgIsRunning(Keeper *keeper);
 bool keeper_remove(Keeper *keeper, KeeperConfig *config,
 				   bool ignore_monitor_errors);
 bool keeper_check_monitor_extension_version(Keeper *keeper);
-
-bool keeper_init_state_write(Keeper *keeper);
-bool keeper_init_state_read(Keeper *keeper, KeeperStateInit *initState);
 bool keeper_state_as_json(Keeper *keeper, char *json, int size);
-bool keeper_init_state_discover(Keeper *keeper, KeeperStateInit *initState);
 
 /* loop.c */
 bool keeper_node_active_loop(Keeper *keeper, pid_t start_pid);

--- a/src/bin/pg_autoctl/main.c
+++ b/src/bin/pg_autoctl/main.c
@@ -20,6 +20,10 @@
 char pg_autoctl_argv0[MAXPGPATH];
 char pg_autoctl_program[MAXPGPATH];
 
+char *ps_buffer;                /* will point to argv area */
+size_t ps_buffer_size;          /* space determined at run time */
+size_t last_status_len;         /* use to minimize length of clobber */
+
 /*
  * Main entry point for the binary.
  */
@@ -27,6 +31,9 @@ int
 main(int argc, char **argv)
 {
 	CommandLine command = root;
+
+	/* allows changing process title in ps/top/ptree etc */
+	(void) init_ps_buffer(argc, argv);
 
 	/*
 	 * When PG_AUTOCTL_DEBUG is set in the environment, provide the user

--- a/src/bin/pg_autoctl/pgctl.c
+++ b/src/bin/pg_autoctl/pgctl.c
@@ -984,9 +984,9 @@ pg_ctl_start(const char *pg_ctl,
 
 /*
  * pg_ctl_postgres runs the "postgres" command-line in the current process,
- * with the same options as we would use in pg_ctl_start. pg_ctl_postmaster
- * does not fork a Postgres process in the background, we keep the control over
- * the postmaster process. Think exec() rather then fork().
+ * with the same options as we would use in pg_ctl_start. pg_ctl_postgres does
+ * not fork a Postgres process in the background, we keep the control over the
+ * postmaster process. Think exec() rather then fork().
  *
  * This function will take over the current standard output and standard error
  * file descriptor, closing them and then giving control to them to Postgres

--- a/src/bin/pg_autoctl/pgctl.c
+++ b/src/bin/pg_autoctl/pgctl.c
@@ -807,7 +807,9 @@ pg_ctl_initdb(const char *pg_ctl, const char *pgdata)
 	program = run_program(pg_ctl, "initdb",
 						  "--silent",
 						  "--pgdata", pgdata,
-						  "-o", "'--auth=trust'", /* avoid warning message */
+
+	                      /* avoid warning message */
+						  "--option", "'--auth=trust'",
 						  NULL);
 	log_info("%s initdb -s -D %s", pg_ctl, pgdata);
 

--- a/src/bin/pg_autoctl/pgctl.c
+++ b/src/bin/pg_autoctl/pgctl.c
@@ -27,6 +27,7 @@
 #include "pgctl.h"
 #include "pgsql.h"
 #include "pgsetup.h"
+#include "signals.h"
 #include "string_utils.h"
 
 #define RUN_PROGRAM_IMPLEMENTATION
@@ -37,7 +38,6 @@
 
 #define AUTOCTL_CONF_INCLUDE_LINE "include '" AUTOCTL_DEFAULTS_CONF_FILENAME "'"
 #define AUTOCTL_SB_CONF_INCLUDE_LINE "include '" AUTOCTL_STANDBY_CONF_FILENAME "'"
-
 
 static bool pg_include_config(const char *configFilePath,
 							  const char *configIncludeLine,
@@ -105,7 +105,8 @@ pg_ctl_version(const char *pg_ctl_path)
 bool
 pg_controldata(PostgresSetup *pgSetup, bool missing_ok)
 {
-	char pg_controldata_path[MAXPGPATH];
+	char globalControlPath[MAXPGPATH] = { 0 };
+	char pg_controldata_path[MAXPGPATH] = { 0 };
 	Program prog;
 
 	if (pgSetup->pgdata[0] == '\0' || pgSetup->pg_ctl[0] == '\0')
@@ -114,6 +115,20 @@ pg_controldata(PostgresSetup *pgSetup, bool missing_ok)
 		return false;
 	}
 
+	/* globalControlFilePath = $PGDATA/global/pg_control */
+	join_path_components(globalControlPath, pgSetup->pgdata, "global/pg_control");
+
+	/*
+	 * Refrain from doing too many pg_controldata checks, only proceed when the
+	 * PGDATA/global/pg_control file exists on-disk: that's the first check
+	 * that pg_controldata does anyway.
+	 */
+	if (!file_exists(globalControlPath))
+	{
+		return false;
+	}
+
+	/* now find the pg_controldata binary */
 	path_in_same_directory(pgSetup->pg_ctl, "pg_controldata", pg_controldata_path);
 	log_debug("%s %s", pg_controldata_path, pgSetup->pgdata);
 
@@ -186,7 +201,7 @@ config_find_pg_ctl(PostgresSetup *pgSetup)
 			return 0;
 		}
 
-		log_info("Found pg_ctl for PostgreSQL %s at %s", version, program);
+		log_debug("Found pg_ctl for PostgreSQL %s at %s", version, program);
 
 		strlcpy(pgSetup->pg_ctl, program, MAXPGPATH);
 		strlcpy(pgSetup->pg_version, version, PG_VERSION_STRING_MAX);
@@ -261,6 +276,37 @@ pg_add_auto_failover_default_settings(PostgresSetup *pgSetup,
 	return pg_include_config(configFilePath,
 							 AUTOCTL_CONF_INCLUDE_LINE,
 							 AUTOCTL_CONF_INCLUDE_COMMENT);
+}
+
+
+/*
+ * pg_auto_failover_default_settings_file_exists returns true when our expected
+ * postgresql-auto-failover.conf file exists in PGDATA.
+ */
+bool
+pg_auto_failover_default_settings_file_exists(PostgresSetup *pgSetup)
+{
+	char pgAutoFailoverDefaultsConfigPath[MAXPGPATH] = { 0 };
+	char *contents = NULL;
+	long size = 0L;
+
+	join_path_components(pgAutoFailoverDefaultsConfigPath,
+						 pgSetup->pgdata,
+						 AUTOCTL_DEFAULTS_CONF_FILENAME);
+
+
+	/* make sure the file exists and is not empty (race conditions) */
+	if (!file_exists(pgAutoFailoverDefaultsConfigPath))
+	{
+		return false;
+	}
+
+	if (!read_file(pgAutoFailoverDefaultsConfigPath, &contents, &size))
+	{
+		return false;
+	}
+
+	return contents > 0;
 }
 
 
@@ -752,19 +798,36 @@ log_program_output(Program prog, int outLogLevel, int errorLogLevel)
 bool
 pg_ctl_initdb(const char *pg_ctl, const char *pgdata)
 {
-	Program program = run_program(pg_ctl, "initdb", "-s", "-D", pgdata, NULL);
-	int returnCode = program.returnCode;
+	Program program;
+	bool success = false;
 
+	/* initdb takes time, so log about the operation BEFORE doing it */
 	log_info("Initialising a PostgreSQL cluster at \"%s\"", pgdata);
-	log_debug("%s initdb -s -D %s [%d]", pg_ctl, pgdata, returnCode);
 
-	if (returnCode != 0)
+	program = run_program(pg_ctl, "initdb",
+						  "--silent",
+						  "--pgdata", pgdata,
+						  "-o", "'--auth=trust'", /* avoid warning message */
+						  NULL);
+	log_info("%s initdb -s -D %s", pg_ctl, pgdata);
+
+	success = program.returnCode == 0;
+
+	if (program.returnCode != 0)
 	{
 		(void) log_program_output(program, LOG_INFO, LOG_ERROR);
+		log_fatal("Failed to initialize Postgres cluster at \"%s\", "
+				  "see above for details",
+				  pgdata);
+	}
+	else
+	{
+		/* we might still have important information to read there */
+		(void) log_program_output(program, LOG_INFO, LOG_WARN);
 	}
 	free_program(&program);
 
-	return returnCode == 0;
+	return success;
 }
 
 
@@ -847,7 +910,7 @@ pg_ctl_start(const char *pg_ctl,
 		log_info("%s", command);
 	}
 
-	(void) execute_program(&program);
+	(void) execute_subprogram(&program);
 
 	if (program.returnCode != 0)
 	{
@@ -916,6 +979,97 @@ pg_ctl_start(const char *pg_ctl,
 	free_program(&program);
 
 	return success;
+}
+
+
+/*
+ * pg_ctl_postmaster runs the "postmaster" command-line in the current process,
+ * with the same options as we would use in pg_ctl_start. pg_ctl_postmaster
+ * does not fork a Postgres process in the background, we keep the control over
+ * the postmaster process. Think exec() rather then fork().
+ */
+bool
+pg_ctl_postgres(const char *pg_ctl, const char *pgdata, int pgport,
+				char *listen_addresses)
+{
+	Program program;
+	char postgres[MAXPGPATH];
+	char logfile[MAXPGPATH];
+	int logFileDescriptor = -1;
+
+	char *args[12];
+	int argsIndex = 0;
+
+	char env_pg_regress_sock_dir[MAXPGPATH];
+
+	char command[BUFSIZE];
+	int commandSize = 0;
+
+	/* call postgres directly */
+	path_in_same_directory(pg_ctl, "postgres", postgres);
+
+	/* prepare startup.log file in PGDATA */
+	join_path_components(logfile, pgdata, "startup.log");
+
+	args[argsIndex++] = (char *) postgres;
+	args[argsIndex++] = "-D";
+	args[argsIndex++] = (char *) pgdata;
+	args[argsIndex++] = "-p";
+	args[argsIndex++] = (char *) intToString(pgport).strValue;
+
+	if (!IS_EMPTY_STRING_BUFFER(listen_addresses))
+	{
+		args[argsIndex++] = "-h";
+		args[argsIndex++] = (char *) listen_addresses;
+	}
+
+	if (env_exists("PG_REGRESS_SOCK_DIR"))
+	{
+		if (!get_env_copy("PG_REGRESS_SOCK_DIR", env_pg_regress_sock_dir,
+						  MAXPGPATH))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+
+		/* pg_ctl --options can be specified multiple times */
+		args[argsIndex++] = "-k";
+		args[argsIndex++] = (char *) env_pg_regress_sock_dir;
+	}
+
+	args[argsIndex] = NULL;
+
+	/* we do not want to call setsid() when running this program. */
+	program = initialize_program(args, false);
+
+	/* we want to redirect the output to logfile */
+	logFileDescriptor = open(logfile, FOPEN_FLAGS_W, 0644);
+
+	if (logFileDescriptor == -1)
+	{
+		log_error("Failed to open file \"%s\": %m", logfile);
+	}
+
+	program.capture = false;    /* redirect output, don't capture */
+	program.stdOutFd = logFileDescriptor;
+	program.stdErrFd = logFileDescriptor;
+
+	/* log the exact command line we're using */
+	commandSize = snprintf_program_command_line(&program, command, BUFSIZE);
+
+	if (commandSize >= BUFSIZE)
+	{
+		/* we only display the first BUFSIZE bytes of the real command */
+		log_info("%s...", command);
+	}
+	else
+	{
+		log_info("%s", command);
+	}
+
+	(void) execute_program(&program);
+
+	return program.returnCode == 0;
 }
 
 
@@ -1085,7 +1239,7 @@ pg_ctl_stop(const char *pg_ctl, const char *pgdata)
 	bool pgdata_exists = false;
 	const bool log_output = true;
 
-	log_debug("%s --pgdata %s --wait stop --mode fast", pg_ctl, pgdata);
+	log_info("%s --pgdata %s --wait stop --mode fast", pg_ctl, pgdata);
 
 	program = run_program(pg_ctl,
 						  "--pgdata", pgdata,
@@ -1158,7 +1312,8 @@ pg_ctl_status(const char *pg_ctl, const char *pgdata, bool log_output)
 	Program program = run_program(pg_ctl, "status", "-D", pgdata, NULL);
 	int returnCode = program.returnCode;
 
-	log_debug("%s status -D %s [%d]", pg_ctl, pgdata, returnCode);
+	log_level(log_output ? LOG_INFO : LOG_DEBUG,
+			  "%s status -D %s [%d]", pg_ctl, pgdata, returnCode);
 
 	if (log_output)
 	{

--- a/src/bin/pg_autoctl/pgctl.c
+++ b/src/bin/pg_autoctl/pgctl.c
@@ -1064,9 +1064,9 @@ pg_log_startup(const char *pgdata, int logLevel)
 				}
 			}
 		}
-
-		closedir(logDir);
 	}
+
+	closedir(logDir);
 
 	return true;
 }

--- a/src/bin/pg_autoctl/pgctl.h
+++ b/src/bin/pg_autoctl/pgctl.h
@@ -35,6 +35,9 @@ char * pg_ctl_version(const char *pg_ctl_path);
 bool pg_add_auto_failover_default_settings(PostgresSetup *pgSetup,
 										   char *configFilePath,
 										   GUC *settings);
+
+bool pg_auto_failover_default_settings_file_exists(PostgresSetup *pgSetup);
+
 bool pg_basebackup(const char *pgdata,
 				   const char *pg_ctl,
 				   ReplicationSource *replicationSource);
@@ -45,6 +48,8 @@ bool pg_rewind(const char *pgdata,
 bool pg_ctl_initdb(const char *pg_ctl, const char *pgdata);
 bool pg_ctl_start(const char *pg_ctl,
 				  const char *pgdata, int pgport, char *listen_addresses);
+bool pg_ctl_postgres(const char *pg_ctl, const char *pgdata, int pgport,
+					 char *listen_addresses);
 bool pg_log_startup(const char *pgdata, int logLevel);
 bool pg_ctl_stop(const char *pg_ctl, const char *pgdata);
 int pg_ctl_status(const char *pg_ctl, const char *pgdata, bool log_output);

--- a/src/bin/pg_autoctl/pgsql.c
+++ b/src/bin/pg_autoctl/pgsql.c
@@ -173,8 +173,17 @@ pgsql_open_connection(PGSQL *pgsql)
 		{
 			case PGSQL_CONN_LOCAL:
 			{
-				log_error("Connection to database failed: %s",
-						  PQerrorMessage(connection));
+				char *message = PQerrorMessage(connection);
+				char *errorLines[BUFSIZE];
+				int lineCount = splitLines(message, errorLines, BUFSIZE);
+				int lineNumber = 0;
+
+				for (lineNumber = 0; lineNumber < lineCount; lineNumber++)
+				{
+					log_error("Connection to database failed: %s",
+							  errorLines[lineNumber]);
+				}
+
 				pgsql_finish(pgsql);
 				return NULL;
 			}
@@ -331,7 +340,17 @@ pgsql_retry_open_connection(PGSQL *pgsql)
 static void
 pgAutoCtlDefaultNoticeProcessor(void *arg, const char *message)
 {
-	log_warn("%s", message);
+	char *m = strdup(message);
+	char *lines[BUFSIZE];
+	int lineCount = splitLines(m, lines, BUFSIZE);
+	int lineNumber = 0;
+
+	for (lineNumber = 0; lineNumber < lineCount; lineNumber++)
+	{
+		log_warn("%s", lines[lineNumber]);
+	}
+
+	free(m);
 }
 
 
@@ -342,7 +361,17 @@ pgAutoCtlDefaultNoticeProcessor(void *arg, const char *message)
 static void
 pgAutoCtlDebugNoticeProcessor(void *arg, const char *message)
 {
-	log_debug("%s", message);
+	char *m = strdup(message);
+	char *lines[BUFSIZE];
+	int lineCount = splitLines(m, lines, BUFSIZE);
+	int lineNumber = 0;
+
+	for (lineNumber = 0; lineNumber < lineCount; lineNumber++)
+	{
+		log_debug("%s", lines[lineNumber]);
+	}
+
+	free(m);
 }
 
 

--- a/src/bin/pg_autoctl/primary_standby.c
+++ b/src/bin/pg_autoctl/primary_standby.c
@@ -307,7 +307,7 @@ ensure_postgres_service_is_running(LocalPostgresServer *postgres)
 	int timeout = 10;       /* wait for Postgres for 10s */
 	bool pgIsRunning = pg_is_running(pgSetup->pg_ctl, pgSetup->pgdata);
 
-	log_trace("ensure_local_postgres_is_running: Postgres %s in \"%s\"",
+	log_trace("ensure_postgres_service_is_running: Postgres %s in \"%s\"",
 			  pgIsRunning ? "is running" : "is not running", pgSetup->pgdata);
 
 	/* update our data structure in-memory, then on-disk */
@@ -332,7 +332,7 @@ ensure_postgres_service_is_running(LocalPostgresServer *postgres)
 			/* update pgSetup cache with new Postgres pid and all */
 			local_postgres_init(postgres, pgSetup);
 
-			log_debug("ensure_local_postgres_is_running: Postgres is running "
+			log_debug("ensure_postgres_service_is_running: Postgres is running "
 					  "with pid %d", pgSetup->pidFile.pid);
 		}
 		else

--- a/src/bin/pg_autoctl/primary_standby.h
+++ b/src/bin/pg_autoctl/primary_standby.h
@@ -16,6 +16,15 @@
 #include "pgsql.h"
 #include "pgsetup.h"
 
+
+/* Communication device between node-active and postgres processes */
+typedef struct LocalExpectedPostgresStatus
+{
+	char pgStatusPath[MAXPGPATH];
+	KeeperStatePostgres state;
+} LocalExpectedPostgresStatus;
+
+
 /*
  * LocalPostgresServer represents a local postgres database cluster that
  * we can manage via a SQL connection and operations on the database
@@ -35,15 +44,20 @@ typedef struct LocalPostgresServer
 	uint64_t pgFirstStartFailureTs;
 	int pgStartRetries;
 	PgInstanceKind pgKind;
+	LocalExpectedPostgresStatus expectedPgStatus;
 } LocalPostgresServer;
 
 
 void local_postgres_init(LocalPostgresServer *postgres,
 						 PostgresSetup *postgresSetup);
+bool local_postgres_set_status_path(LocalPostgresServer *postgres, bool unlink);
 void local_postgres_finish(LocalPostgresServer *postgres);
 bool local_postgres_update(LocalPostgresServer *postgres,
 						   bool postgresNotRunningIsOk);
 bool ensure_local_postgres_is_running(LocalPostgresServer *postgres);
+bool ensure_postgres_service_is_running(LocalPostgresServer *postgres);
+bool ensure_postgres_service_is_stopped(LocalPostgresServer *postgres);
+
 bool primary_has_replica(LocalPostgresServer *postgres, char *userName,
 						 bool *hasStandby);
 bool primary_create_replication_slot(LocalPostgresServer *postgres,

--- a/src/bin/pg_autoctl/service.c
+++ b/src/bin/pg_autoctl/service.c
@@ -34,10 +34,12 @@
 bool
 monitor_service_init(MonitorConfig *config, pid_t *pid)
 {
+	bool exitOnQuit = true;
+
 	log_trace("monitor_service_init");
 
 	/* Establish a handler for signals. */
-	(void) set_signal_handlers();
+	(void) set_signal_handlers(exitOnQuit);
 
 	/* Check that the keeper service is not already running */
 	if (read_pidfile(config->pathnames.pid, pid))
@@ -74,11 +76,12 @@ bool
 keeper_service_init(Keeper *keeper, pid_t *pid)
 {
 	KeeperConfig *config = &(keeper->config);
+	bool exitOnQuit = true;
 
 	log_trace("keeper_service_init");
 
 	/* Establish a handler for signals. */
-	(void) set_signal_handlers();
+	(void) set_signal_handlers(exitOnQuit);
 
 	/* Check that the keeper service is not already running */
 	if (read_pidfile(config->pathnames.pid, pid))

--- a/src/bin/pg_autoctl/service_postgres.c
+++ b/src/bin/pg_autoctl/service_postgres.c
@@ -1,0 +1,146 @@
+/*
+ * src/bin/pg_autoctl/postgres_service.c
+ *   Utilities to start/stop the pg_autoctl service.
+ *
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the PostgreSQL License.
+ *
+ */
+
+#include <inttypes.h>
+#include <limits.h>
+#include <sys/select.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "cli_common.h"
+#include "cli_root.h"
+#include "defaults.h"
+#include "log.h"
+#include "monitor.h"
+#include "monitor_config.h"
+#include "pgsetup.h"
+#include "primary_standby.h"
+#include "service.h"
+#include "service_postgres.h"
+#include "signals.h"
+#include "supervisor.h"
+#include "state.h"
+#include "string_utils.h"
+
+#include "runprogram.h"
+
+int countPostgresStart = 0;
+
+/*
+ * service_postgres_start starts "postgres" in a sub-process. Rather than using
+ * pg_ctl start, which forks off a deamon, we want to control the sub-process
+ * and maintain it as a process child of pg_autoctl.
+ */
+bool
+service_postgres_start(void *context, pid_t *pid)
+{
+	PostgresSetup *pgSetup = (PostgresSetup *) context;
+	pid_t fpid;
+
+	/* Flush stdio channels just before fork, to avoid double-output problems */
+	fflush(stdout);
+	fflush(stderr);
+
+	/* time to create the node_active sub-process */
+	fpid = fork();
+
+	switch (fpid)
+	{
+		case -1:
+		{
+			log_error("Failed to fork the postgres supervisor process");
+			return false;
+		}
+
+		case 0:
+		{
+			(void) set_ps_title("postgres");
+
+			log_trace("service_postgres_start: EXEC postgres");
+
+			/* execv() the postgres binary directly, as a sub-process */
+			(void) pg_ctl_postgres(pgSetup->pg_ctl,
+								   pgSetup->pgdata,
+								   pgSetup->pgport,
+								   pgSetup->listen_addresses);
+
+			/* unexpected */
+			log_fatal("BUG: returned from service_keeper_runprogram()");
+			exit(EXIT_CODE_INTERNAL_ERROR);
+		}
+
+		default:
+		{
+			int timeout = 10;   /* wait for Postgres for 10s */
+			int logLevel = ++countPostgresStart == 1 ? LOG_INFO : LOG_DEBUG;
+			bool pgIsReady = false;
+
+			log_debug("pg_autoctl started postgres in subprocess %d", fpid);
+			*pid = fpid;
+
+			/* we're starting postgres, reset the cached value for the pid */
+			pgSetup->pidFile.pid = 0;
+
+			pgIsReady =
+				pg_setup_wait_until_is_ready(pgSetup, timeout, logLevel);
+
+			/*
+			 * If Postgres failed to start the least we can do is log the
+			 * "startup.log" file prominently to the user now.
+			 */
+			if (!pgIsReady)
+			{
+				(void) pg_log_startup(pgSetup->pgdata, LOG_ERROR);
+			}
+			else
+			{
+				(void) pg_log_startup(pgSetup->pgdata, LOG_DEBUG);
+			}
+			return pgIsReady;
+		}
+	}
+}
+
+
+/*
+ * service_postgres_stop stops the postgres service, using pg_ctl stop.
+ */
+bool
+service_postgres_stop(void *context)
+{
+	Service *service = (Service *) context;
+	PostgresSetup *pgSetup = (PostgresSetup *) service->context;
+
+	log_info("Stopping pg_autoctl postgres service");
+
+	if (!pg_ctl_stop(pgSetup->pg_ctl, pgSetup->pgdata))
+	{
+		log_error("Failed to stop Postgres, see above for details");
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * service_postgres_reload signal Postgres with a SIGHUP
+ */
+void
+service_postgres_reload(void *context)
+{
+	Service *service = (Service *) context;
+
+	log_info("Reloading pg_autoctl postgres service [%d]", service->pid);
+
+	if (kill(service->pid, SIGHUP) != 0)
+	{
+		log_error("Failed to send SIGHUP to Postgres pid %d: %m", service->pid);
+	}
+}

--- a/src/bin/pg_autoctl/service_postgres.c
+++ b/src/bin/pg_autoctl/service_postgres.c
@@ -112,9 +112,8 @@ service_postgres_start(void *context, pid_t *pid)
  * service_postgres_stop stops the postgres service, using pg_ctl stop.
  */
 bool
-service_postgres_stop(void *context)
+service_postgres_stop(Service *service)
 {
-	Service *service = (Service *) context;
 	PostgresSetup *pgSetup = (PostgresSetup *) service->context;
 
 	log_info("Stopping pg_autoctl postgres service");
@@ -133,10 +132,8 @@ service_postgres_stop(void *context)
  * service_postgres_reload signal Postgres with a SIGHUP
  */
 void
-service_postgres_reload(void *context)
+service_postgres_reload(Service *service)
 {
-	Service *service = (Service *) context;
-
 	log_info("Reloading pg_autoctl postgres service [%d]", service->pid);
 
 	if (kill(service->pid, SIGHUP) != 0)

--- a/src/bin/pg_autoctl/service_postgres.h
+++ b/src/bin/pg_autoctl/service_postgres.h
@@ -1,0 +1,24 @@
+/*
+ * src/bin/pg_autoctl/service_postgres.h
+ *   Utilities to start/stop the pg_autoctl service on a monitor node.
+ *
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the PostgreSQL License.
+ *
+ */
+#ifndef SERVICE_POSTGRES_H
+#define SERVICE_POSTGRES_H
+
+#include <inttypes.h>
+#include <signal.h>
+
+#include "keeper.h"
+#include "keeper_config.h"
+
+extern int countPostgresStart;
+
+bool service_postgres_start(void *context, pid_t *pid);
+bool service_postgres_stop(void *context);
+void service_postgres_reload(void *context);
+
+#endif /* SERVICE_POSTGRES_H */

--- a/src/bin/pg_autoctl/service_postgres.h
+++ b/src/bin/pg_autoctl/service_postgres.h
@@ -14,11 +14,12 @@
 
 #include "keeper.h"
 #include "keeper_config.h"
+#include "supervisor.h"
 
 extern int countPostgresStart;
 
 bool service_postgres_start(void *context, pid_t *pid);
-bool service_postgres_stop(void *context);
-void service_postgres_reload(void *context);
+bool service_postgres_stop(Service *service);
+void service_postgres_reload(Service *service);
 
 #endif /* SERVICE_POSTGRES_H */

--- a/src/bin/pg_autoctl/service_postgres_ctl.c
+++ b/src/bin/pg_autoctl/service_postgres_ctl.c
@@ -1,0 +1,511 @@
+/*
+ * src/bin/pg_autoctl/postgres_service_ctl.c
+ *   Utilities to start/stop the pg_autoctl service.
+ *
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the PostgreSQL License.
+ *
+ */
+
+#include <inttypes.h>
+#include <limits.h>
+#include <sys/select.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "cli_common.h"
+#include "cli_root.h"
+#include "defaults.h"
+#include "log.h"
+#include "monitor.h"
+#include "monitor_config.h"
+#include "pgsetup.h"
+#include "primary_standby.h"
+#include "service.h"
+#include "service_postgres.h"
+#include "service_postgres_ctl.h"
+#include "signals.h"
+#include "supervisor.h"
+#include "state.h"
+#include "string_utils.h"
+
+#include "runprogram.h"
+
+static bool shutdownSequenceInProgress = false;
+
+static bool ensure_postgres_status(LocalPostgresServer *postgres,
+								   Service *service);
+
+static bool ensure_postgres_status_stopped(LocalPostgresServer *postgres,
+										   Service *service);
+
+static bool ensure_postgres_status_running(LocalPostgresServer *postgres,
+										   Service *service);
+
+
+/*
+ * service_postgres_ctl_start starts a subprocess that implements the postgres
+ * service depending on the current assigned and goal state of the keeper.
+ */
+bool
+service_postgres_ctl_start(void *context, pid_t *pid)
+{
+	pid_t fpid;
+
+	/* Flush stdio channels just before fork, to avoid double-output problems */
+	fflush(stdout);
+	fflush(stderr);
+
+	/* time to create the node_active sub-process */
+	fpid = fork();
+
+	switch (fpid)
+	{
+		case -1:
+		{
+			log_error("Failed to fork the postgres controller process");
+			return false;
+		}
+
+		case 0:
+		{
+			/* here we call execv() so we never get back */
+			(void) service_postgres_ctl_runprogram();
+
+			/* unexpected */
+			log_fatal("BUG: returned from service_keeper_runprogram()");
+			exit(EXIT_CODE_INTERNAL_ERROR);
+		}
+
+		default:
+		{
+			log_debug(
+				"pg_autoctl started postgres controller in subprocess %d",
+				fpid);
+			*pid = fpid;
+
+			return true;
+		}
+	}
+}
+
+
+/*
+ * service_postgres_stop stops the postgres service, using pg_ctl stop.
+ */
+bool
+service_postgres_ctl_stop(void *context)
+{
+	Service *service = (Service *) context;
+
+	log_info("Stopping pg_autoctl: start/stop postgres service");
+
+	if (kill(service->pid, SIGTERM) != 0)
+	{
+		log_error("Failed to send SIGTERM to pid %d for service %s",
+				  service->pid, service->name);
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * service_postgres_ctl_runprogram runs the node_active protocol service:
+ *
+ *   $ pg_autoctl do service postgres --pgdata ...
+ */
+void
+service_postgres_ctl_runprogram()
+{
+	Program program;
+
+	char *args[12];
+	int argsIndex = 0;
+
+	char command[BUFSIZE];
+
+	/*
+	 * use --pgdata option rather than the config.
+	 *
+	 * On macOS when using /tmp, the file path is then redirected to being
+	 * /private/tmp when using realpath(2) as we do in normalize_filename(). So
+	 * for that case to be supported, we explicitely re-use whatever PGDATA or
+	 * --pgdata was parsed from the main command line to start our sub-process.
+	 *
+	 * The pg_autoctl postgres controller is used both in the monitor context
+	 * and in the keeper context; which means it gets started from one of the
+	 * following top-level commands:
+	 *
+	 *  - pg_autoctl create monitor
+	 *  - pg_autoctl create postgres
+	 *  - pg_autoctl run
+	 *
+	 * The monitor specific commands set monitorOptions, the generic and keeper
+	 * specific commands set keeperOptions.
+	 */
+	char *pgdata =
+		IS_EMPTY_STRING_BUFFER(monitorOptions.pgSetup.pgdata)
+		? keeperOptions.pgSetup.pgdata
+		: monitorOptions.pgSetup.pgdata;
+
+	setenv(PG_AUTOCTL_DEBUG, "1", 1);
+
+	args[argsIndex++] = (char *) pg_autoctl_program;
+	args[argsIndex++] = "do";
+	args[argsIndex++] = "service";
+	args[argsIndex++] = "postgres";
+	args[argsIndex++] = "--pgdata";
+	args[argsIndex++] = pgdata;
+	args[argsIndex++] = logLevelToString(log_get_level());
+	args[argsIndex] = NULL;
+
+	/* we do not want to call setsid() when running this program. */
+	program = initialize_program(args, false);
+
+	program.capture = false;    /* redirect output, don't capture */
+	program.stdOutFd = STDOUT_FILENO;
+	program.stdErrFd = STDERR_FILENO;
+
+	/* log the exact command line we're using */
+	(void) snprintf_program_command_line(&program, command, BUFSIZE);
+
+	log_info("%s", command);
+
+	(void) execute_program(&program);
+}
+
+
+/*
+ * service_postgres_ctl_loop loops over the current CTL state file and ensure
+ * that Postgres is running when that's expected, or that Postgres is not
+ * running when in a state where we should maintain Postgres down to avoid
+ * split-brain situations.
+ */
+void
+service_postgres_ctl_loop(LocalPostgresServer *postgres)
+{
+	PostgresSetup *pgSetup = &(postgres->postgresSetup);
+	LocalExpectedPostgresStatus *localStatus = &(postgres->expectedPgStatus);
+	KeeperStatePostgres *pgStatus = &(localStatus->state);
+
+	Service postgresService = {
+		"postgres",
+		-1,
+		&service_postgres_start,
+		&service_postgres_stop,
+		&service_postgres_reload,
+		(void *) pgSetup
+	};
+
+	bool pgStatusPathIsReady = false;
+
+	/* make sure to initialize the expected Postgres status to unknown */
+	pgStatus->pgExpectedStatus = PG_EXPECTED_STATUS_UNKNOWN;
+
+	for (;;)
+	{
+		pid_t pid;
+		int status;
+
+		/* we might have to reload, pass the signal down */
+		if (asked_to_reload)
+		{
+			(void) service_postgres_reload((void *) &postgresService);
+
+			asked_to_reload = 0;
+		}
+
+		/* that's expected the shutdown sequence from the supervisor */
+		if (asked_to_stop || asked_to_stop_fast)
+		{
+			shutdownSequenceInProgress = true;
+
+			if (!ensure_postgres_status_stopped(postgres, &postgresService))
+			{
+				log_error("Failed to stop Postgres, see above for details");
+				pg_usleep(100 * 1000);  /* 100ms */
+				continue;
+			}
+			exit(EXIT_CODE_QUIT);
+		}
+
+		/*
+		 * This postgres controller process is running Postgres as a child
+		 * process and thus is responsible for calling waitpid() from time to
+		 * time.
+		 */
+		pid = waitpid(-1, &status, WNOHANG);
+
+		switch (pid)
+		{
+			case -1:
+			{
+				/* if our PostgresService stopped, just continue */
+				if (errno != ECHILD)
+				{
+					log_error("Failed to call waitpid(): %m");
+				}
+				break;
+			}
+
+			case 0:
+			{
+				/*
+				 * We're using WNOHANG, 0 means there are no stopped or exited
+				 * children, it's all good. It's the expected case when
+				 * everything is running smoothly, so enjoy and sleep for
+				 * awhile.
+				 */
+				break;
+			}
+
+			default:
+			{
+				if (pid != postgresService.pid)
+				{
+					/* might be one of our pg_controldata... */
+					char *verb = WIFEXITED(status) ? "exited" : "failed";
+					log_debug("waitpid(): process %d has %s", pid, verb);
+				}
+
+				/*
+				 * Postgres is not running anymore, the rest of the code will
+				 * handle that situation, just continue.
+				 */
+				break;
+			}
+		}
+
+		if (pg_setup_pgdata_exists(pgSetup))
+		{
+			/*
+			 * If we have a PGDATA directory, now is a good time to initialize
+			 * our LocalPostgresServer structure and its file paths to point at
+			 * the right place: we need to normalize PGDATA to its realpath
+			 * location.
+			 */
+			if (!pgStatusPathIsReady)
+			{
+				/* initialize our Postgres state file path */
+				if (!local_postgres_set_status_path(postgres, false))
+				{
+					/* highly unexpected */
+					log_error("Failed to build postgres state file pathname, "
+							  "see above for details.");
+
+					/* maybe next round will have better luck? */
+					continue;
+				}
+
+				pgStatusPathIsReady = true;
+
+				log_trace("Reading current postgres expected status from \"%s\"",
+						  localStatus->pgStatusPath);
+			}
+		}
+		else if (!pgStatusPathIsReady)
+		{
+			/*
+			 * If PGDATA doesn't exists yet, we didn't have a chance to
+			 * normalize its filename and we might be reading the wrong file
+			 * for the Postgres expected status. So we first check if our
+			 * pgSetup reflects an existing on-disk instance and if not, update
+			 * it until it does.
+			 *
+			 * The keeper init process is reponsible for running pg_ctl initdb.
+			 *
+			 * Given that we have two processes working concurrently and
+			 * deciding at the same time what's next, we need to be cautious
+			 * about race conditions. We add extra checks around existence of
+			 * files to make sure we don't get started too early.
+			 */
+			PostgresSetup newPgSetup = { 0 };
+			bool missingPgdataIsOk = true;
+			bool postgresNotRunningIsOk = true;
+
+			if (pg_setup_init(&newPgSetup,
+							  pgSetup,
+							  missingPgdataIsOk,
+							  postgresNotRunningIsOk) &&
+				pg_setup_pgdata_exists(&newPgSetup) &&
+				pg_auto_failover_default_settings_file_exists(&newPgSetup))
+			{
+				*pgSetup = newPgSetup;
+			}
+			continue;
+		}
+
+		/*
+		 * Maintain a Postgres service as a sub-process.
+		 *
+		 * Depending on the current state of the keeper, we need to either
+		 * ensure that Postgres is running, or that it is NOT running. To avoid
+		 * split-brain situations, we need to ensure Postgres is not running in
+		 * the DEMOTED state, for instance.
+		 *
+		 * Adding to that, during the `pg_autoctl create postgres` phase we
+		 * also need to start Postgres and sometimes even restart it.
+		 */
+		if (pgStatusPathIsReady && file_exists(localStatus->pgStatusPath))
+		{
+			const char *filename = localStatus->pgStatusPath;
+
+			if (!keeper_postgres_state_read(pgStatus, filename))
+			{
+				/* errors have already been logged, will try again */
+				continue;
+			}
+
+			log_trace("service_postgres_ctl_loop: %s in %s",
+					  ExpectedPostgresStatusToString(pgStatus->pgExpectedStatus),
+					  filename);
+
+			if (!ensure_postgres_status(postgres, &postgresService))
+			{
+				pgStatusPathIsReady = false;
+			}
+		}
+
+		pg_usleep(100 * 1000);  /* 100ms */
+	}
+}
+
+
+/*
+ * service_postgres_ctl_reload sends a SIGHUP to the controller process.
+ */
+void
+service_postgres_ctl_reload(void *context)
+{
+	Service *service = (Service *) context;
+
+	log_info("Reloading pg_autoctl postgres controller service [%d]",
+			 service->pid);
+
+	if (kill(service->pid, SIGHUP) != 0)
+	{
+		log_error(
+			"Failed to send SIGHUP to pg_autoctl postgres controller pid %d: %m",
+			service->pid);
+	}
+}
+
+
+/*
+ * ensure_postgres_status ensures that the current keeper's state is met with
+ * the current PostgreSQL status, at minimum that PostgreSQL is running when
+ * it's expected to be, etc.
+ *
+ * The design choice here is in between re-using the state file for the FSM and
+ * using a dedicated file or a PIPE to pass direct Postgres service commands
+ * (start, stop, restart) to the sub-process.
+ *
+ * - using a PIPE makes the code complex: setting up the PIPE is ok, but then
+ *   we need a reader and writer that talk to each other (so we need a command
+ *   parser of sorts), and the reader itself needs to use a loop around
+ *   select(2) to be able to also process signals, etc
+ *
+ * - using a dedicated file means that we now need to handle "stale" file
+ *   staying around when one of the processes die and is restarted, and more
+ *   generally that the dedicated command file(s) is always in sync with the
+ *   FSM
+ *
+ * - using the state file from the FSM directly makes things overall simpler,
+ *   the only drawback is that this is one more place where we need to
+ *   implement the FSM semantics, it's not just the transition functions... it
+ *   was never "just the transition functions" that said.
+ */
+static bool
+ensure_postgres_status(LocalPostgresServer *postgres, Service *service)
+{
+	KeeperStatePostgres *pgStatus = &(postgres->expectedPgStatus.state);
+
+	log_trace("ensure_postgres_status: %s",
+			  ExpectedPostgresStatusToString(pgStatus->pgExpectedStatus));
+
+	switch (pgStatus->pgExpectedStatus)
+	{
+		case PG_EXPECTED_STATUS_UNKNOWN:
+		{
+			/* do nothing */
+			return true;
+		}
+
+		case PG_EXPECTED_STATUS_STOPPED:
+		{
+			return ensure_postgres_status_stopped(postgres, service);
+		}
+
+		case PG_EXPECTED_STATUS_RUNNING:
+		{
+			return ensure_postgres_status_running(postgres, service);
+		}
+	}
+
+	/* make compiler happy */
+	return false;
+}
+
+
+/*
+ * ensure_postgres_status_stopped ensures that Postgres is stopped.
+ */
+static bool
+ensure_postgres_status_stopped(LocalPostgresServer *postgres, Service *service)
+{
+	PostgresSetup *pgSetup = &(postgres->postgresSetup);
+
+	bool pgIsNotRunningIsOk = true;
+	bool pgIsRunning = pg_setup_is_ready(pgSetup, pgIsNotRunningIsOk);
+
+	if (pgIsRunning)
+	{
+		/* service_postgres_stop() logs about stopping Postgres */
+		log_debug("pg_autoctl: stop postgres (pid %d)", service->pid);
+
+		return service_postgres_stop((void *) service);
+	}
+	return true;
+}
+
+
+/*
+ * ensure_postgres_status_running ensures that Postgres is running.
+ */
+static bool
+ensure_postgres_status_running(LocalPostgresServer *postgres, Service *service)
+{
+	PostgresSetup *pgSetup = &(postgres->postgresSetup);
+
+	/* we might still be starting-up */
+	bool pgIsNotRunningIsOk = true;
+	bool pgIsRunning = pg_setup_is_ready(pgSetup, pgIsNotRunningIsOk);
+
+	log_trace("ensure_postgres_status_running: %s",
+			  pgIsRunning ? "running" : "not running");
+
+	if (pgIsRunning)
+	{
+		return true;
+	}
+
+	if (service_postgres_start(service->context, &(service->pid)))
+	{
+		if (countPostgresStart > 1)
+		{
+			log_warn("PostgreSQL was not running, restarted with pid %d",
+					 pgSetup->pidFile.pid);
+		}
+		return true;
+	}
+	else
+	{
+		log_warn("Failed to start Postgres instance at \"%s\"",
+				 pgSetup->pgdata);
+
+		return false;
+	}
+	return true;
+}

--- a/src/bin/pg_autoctl/service_postgres_ctl.c
+++ b/src/bin/pg_autoctl/service_postgres_ctl.c
@@ -91,7 +91,7 @@ service_postgres_ctl_start(void *context, pid_t *pid)
 
 
 /*
- * service_postgres_ctl_runprogram runs the postgres controler service:
+ * service_postgres_ctl_runprogram runs the postgres controller service:
  *
  *   $ pg_autoctl do service postgres --pgdata ...
  */
@@ -207,7 +207,7 @@ service_postgres_ctl_loop(LocalPostgresServer *postgres)
 			if (!shutdownSequenceInProgress)
 			{
 				shutdownSequenceInProgress = true;
-				log_info("Postgres controler service received signal %s, "
+				log_info("Postgres controller service received signal %s, "
 						 "terminating",
 						 asked_to_stop_fast ? "SIGINT" : "SIGTERM");
 			}
@@ -368,7 +368,7 @@ service_postgres_ctl_loop(LocalPostgresServer *postgres)
  * the current PostgreSQL status, at minimum that PostgreSQL is running when
  * it's expected to be, etc.
  *
- * The Postgres controler process (the code in this file) takes orders from
+ * The Postgres controller process (the code in this file) takes orders from
  * another process, either the monitor "listener" or the keeper "node active"
  * process. The orders are sent through a shared file containing the expected
  * status of the Postgres service.

--- a/src/bin/pg_autoctl/service_postgres_ctl.c
+++ b/src/bin/pg_autoctl/service_postgres_ctl.c
@@ -225,7 +225,13 @@ service_postgres_ctl_loop(LocalPostgresServer *postgres)
 		/* that's expected the shutdown sequence from the supervisor */
 		if (asked_to_stop || asked_to_stop_fast)
 		{
-			shutdownSequenceInProgress = true;
+			if (!shutdownSequenceInProgress)
+			{
+				shutdownSequenceInProgress = true;
+				log_info("Postgres controler service received signal %s, "
+						 "terminating",
+						 asked_to_stop_fast ? "SIGINT" : "SIGTERM");
+			}
 
 			if (!ensure_postgres_status_stopped(postgres, &postgresService))
 			{

--- a/src/bin/pg_autoctl/service_postgres_ctl.c
+++ b/src/bin/pg_autoctl/service_postgres_ctl.c
@@ -112,7 +112,7 @@ service_postgres_ctl_stop(void *context)
 
 
 /*
- * service_postgres_ctl_runprogram runs the node_active protocol service:
+ * service_postgres_ctl_runprogram runs the postgres controler service:
  *
  *   $ pg_autoctl do service postgres --pgdata ...
  */
@@ -190,12 +190,17 @@ service_postgres_ctl_loop(LocalPostgresServer *postgres)
 	LocalExpectedPostgresStatus *localStatus = &(postgres->expectedPgStatus);
 	KeeperStatePostgres *pgStatus = &(localStatus->state);
 
+	/*
+	 * We re-use a service definition because that's handy for our code here,
+	 * but we implement our own policy for handling the service: the keeper
+	 * process might want Postgres to not be running at times, to avoid
+	 * split-brain situations.
+	 */
 	Service postgresService = {
 		"postgres",
+		RP_PERMANENT,           /* actually micro-managed in this loop */
 		-1,
 		&service_postgres_start,
-		&service_postgres_stop,
-		&service_postgres_reload,
 		(void *) pgSetup
 	};
 

--- a/src/bin/pg_autoctl/service_postgres_ctl.h
+++ b/src/bin/pg_autoctl/service_postgres_ctl.h
@@ -1,0 +1,24 @@
+/*
+ * src/bin/pg_autoctl/service_postgres_ctl.h
+ *   Utilities to start/stop the pg_autoctl service on a keeper node.
+ *
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the PostgreSQL License.
+ *
+ */
+#ifndef SERVICE_POSTGRES_CTL_H
+#define SERVICE_POSTGRES_CTL_H
+
+#include <inttypes.h>
+#include <signal.h>
+
+#include "keeper.h"
+#include "keeper_config.h"
+
+bool service_postgres_ctl_start(void *context, pid_t *pid);
+bool service_postgres_ctl_stop(void *context);
+void service_postgres_ctl_runprogram(void);
+void service_postgres_ctl_loop(LocalPostgresServer *postgres);
+void service_postgres_ctl_reload(void *context);
+
+#endif /* SERVICE_POSTGRES_CTL_H */

--- a/src/bin/pg_autoctl/service_postgres_ctl.h
+++ b/src/bin/pg_autoctl/service_postgres_ctl.h
@@ -16,9 +16,7 @@
 #include "keeper_config.h"
 
 bool service_postgres_ctl_start(void *context, pid_t *pid);
-bool service_postgres_ctl_stop(void *context);
 void service_postgres_ctl_runprogram(void);
 void service_postgres_ctl_loop(LocalPostgresServer *postgres);
-void service_postgres_ctl_reload(void *context);
 
 #endif /* SERVICE_POSTGRES_CTL_H */

--- a/src/bin/pg_autoctl/signals.c
+++ b/src/bin/pg_autoctl/signals.c
@@ -66,7 +66,6 @@ void
 catch_int(int sig)
 {
 	asked_to_stop_fast = 1;
-	log_warn("Fast shutdown: received signal %s", strsignal(sig));
 	pqsignal(sig, catch_int);
 }
 
@@ -78,7 +77,6 @@ void
 catch_term(int sig)
 {
 	asked_to_stop = 1;
-	log_warn("Smart shutdown: received signal %s", strsignal(sig));
 	pqsignal(sig, catch_term);
 }
 
@@ -90,6 +88,5 @@ void
 catch_quit(int sig)
 {
 	/* default signal handler disposition is to core dump, we don't */
-	log_warn("Immediate shutdown: received signal %s", strsignal(sig));
 	exit(EXIT_CODE_QUIT);
 }

--- a/src/bin/pg_autoctl/signals.c
+++ b/src/bin/pg_autoctl/signals.c
@@ -12,6 +12,8 @@
 #include <string.h>
 #include <unistd.h>
 
+#include "postgres_fe.h"        /* pqsignal, portable sigaction wrapper */
+
 #include "defaults.h"
 #include "log.h"
 #include "signals.h"
@@ -21,19 +23,28 @@ volatile sig_atomic_t asked_to_stop = 0;      /* SIGTERM */
 volatile sig_atomic_t asked_to_stop_fast = 0; /* SIGINT */
 volatile sig_atomic_t asked_to_reload = 0;    /* SIGHUP */
 
-
 /*
  * set_signal_handlers sets our signal handlers for the 4 signals that we
  * specifically handle in pg_autoctl.
  */
 void
-set_signal_handlers()
+set_signal_handlers(bool exitOnQuit)
 {
 	/* Establish a handler for signals. */
-	signal(SIGHUP, catch_reload);
-	signal(SIGINT, catch_int);
-	signal(SIGTERM, catch_term);
-	signal(SIGQUIT, catch_quit);
+	log_trace("set_signal_handlers%s", exitOnQuit ? " (exit on quit)" : "");
+
+	pqsignal(SIGHUP, catch_reload);
+	pqsignal(SIGINT, catch_int);
+	pqsignal(SIGTERM, catch_term);
+
+	if (exitOnQuit)
+	{
+		pqsignal(SIGQUIT, catch_quit);
+	}
+	else
+	{
+		pqsignal(SIGQUIT, catch_int);
+	}
 }
 
 
@@ -44,8 +55,7 @@ void
 catch_reload(int sig)
 {
 	asked_to_reload = 1;
-	log_warn("Received signal %s", strsignal(sig));
-	signal(sig, catch_reload);
+	pqsignal(sig, catch_reload);
 }
 
 
@@ -57,7 +67,7 @@ catch_int(int sig)
 {
 	asked_to_stop_fast = 1;
 	log_warn("Fast shutdown: received signal %s", strsignal(sig));
-	signal(sig, catch_int);
+	pqsignal(sig, catch_int);
 }
 
 
@@ -69,7 +79,7 @@ catch_term(int sig)
 {
 	asked_to_stop = 1;
 	log_warn("Smart shutdown: received signal %s", strsignal(sig));
-	signal(sig, catch_term);
+	pqsignal(sig, catch_term);
 }
 
 

--- a/src/bin/pg_autoctl/signals.h
+++ b/src/bin/pg_autoctl/signals.h
@@ -21,7 +21,7 @@ extern volatile sig_atomic_t asked_to_reload;    /* SIGHUP */
 #define CHECK_FOR_FAST_SHUTDOWN { if (asked_to_stop_fast) { break; } \
 }
 
-void set_signal_handlers(void);
+void set_signal_handlers(bool exitOnQuit);
 void catch_reload(int sig);
 void catch_int(int sig);
 void catch_term(int sig);

--- a/src/bin/pg_autoctl/state.h
+++ b/src/bin/pg_autoctl/state.h
@@ -168,7 +168,7 @@ typedef enum
 } ExpectedPostgresStatus;
 
 /*
- *  Note: This struct is serialized/serialiazed to/from state file. Therefore
+ *  Note: This struct is serialized/deserialized to/from state file. Therefore
  *  keeping the memory layout the same is important. Please
  *  - do not change the order of fields
  *  - do not add a new field in between, always add to the end

--- a/src/bin/pg_autoctl/state.h
+++ b/src/bin/pg_autoctl/state.h
@@ -108,8 +108,21 @@ typedef struct
 } KeeperStateData;
 
 _Static_assert(sizeof(KeeperStateData) < PG_AUTOCTL_KEEPER_STATE_FILE_SIZE,
-			   "size of KeeperStateData is larger than expected. please review PG_AUTOCTL_KEEPER_STATE_FILE_SIZE");
+			   "Size of KeeperStateData is larger than expected. "
+			   "Please review PG_AUTOCTL_KEEPER_STATE_FILE_SIZE");
 
+/*
+ * The init file contains the status of the target Postgres instance when the
+ * pg_autoctl create command ran the first time. We need to be able to make
+ * init time decision again if we're interrupted half-way and later want to
+ * proceed. The instruction for the user to proceed in that case is to run the
+ * pg_autoctl create command again.
+ *
+ * We also update the init file with the current stage of the initialisation
+ * process. This allows communication to happen between the init process and
+ * the Postgres FSM supervisor process. The Postgres FSM supervisors knows it
+ * must start Postgres when reaching init stage 2.
+ */
 typedef enum
 {
 	PRE_INIT_STATE_UNKNOWN = 0,
@@ -133,7 +146,43 @@ typedef struct
 } KeeperStateInit;
 
 _Static_assert(sizeof(KeeperStateInit) < PG_AUTOCTL_KEEPER_STATE_FILE_SIZE,
-			   "size of KeeperStateInit is larger than expected. please review PG_AUTOCTL_KEEPER_STATE_FILE_SIZE");
+			   "Size of KeeperStateInit is larger than expected. "
+			   "Please review PG_AUTOCTL_KEEPER_STATE_FILE_SIZE");
+
+
+/*
+ * pg_autoctl manages Postgres as a child process. The FSM loop runs in the
+ * node-active sub-process, and that's where decisions are made depending on
+ * the current state and transition whether Postgres should be running or not.
+ *
+ * The communication between the node-active process and the Postgres
+ * start/stop controller process is done by means of the Postgres state file,
+ * which is basically a boolean. That said, we want to make sure we read the
+ * file content correctly, so 0 is unknown.
+ */
+typedef enum
+{
+	PG_EXPECTED_STATUS_UNKNOWN = 0,
+	PG_EXPECTED_STATUS_STOPPED,
+	PG_EXPECTED_STATUS_RUNNING
+} ExpectedPostgresStatus;
+
+/*
+ *  Note: This struct is serialized/serialiazed to/from state file. Therefore
+ *  keeping the memory layout the same is important. Please
+ *  - do not change the order of fields
+ *  - do not add a new field in between, always add to the end
+ *  - do not use any pointers
+ */
+typedef struct
+{
+	int pg_autoctl_state_version;
+	ExpectedPostgresStatus pgExpectedStatus;
+} KeeperStatePostgres;
+
+_Static_assert(sizeof(KeeperStatePostgres) < PG_AUTOCTL_KEEPER_STATE_FILE_SIZE,
+			   "Size of KeeperStatePostgres is larger than expected. "
+			   "Please review PG_AUTOCTL_KEEPER_STATE_FILE_SIZE");
 
 const char * NodeStateToString(NodeState s);
 NodeState NodeStateFromString(const char *str);
@@ -147,8 +196,30 @@ bool keeper_state_write(KeeperStateData *keeperState, const char *filename);
 void log_keeper_state(KeeperStateData *keeperState);
 void print_keeper_state(KeeperStateData *keeperState, FILE *fp);
 bool keeperStateAsJSON(KeeperStateData *keeperState, JSON_Value *js);
-void print_keeper_init_state(KeeperStateInit *initState, FILE *stream);
 
+void print_keeper_init_state(KeeperStateInit *initState, FILE *stream);
 char * PreInitPostgreInstanceStateToString(PreInitPostgreInstanceState pgInitState);
+
+bool keeper_init_state_create(KeeperStateInit *initState,
+							  PostgresSetup *pgSetup,
+							  const char *filename);
+bool keeper_init_state_read(KeeperStateInit *initState, const char *filename);
+bool keeper_init_state_discover(KeeperStateInit *initState,
+								PostgresSetup *pgSetup,
+								const char *filename);
+
+char * ExpectedPostgresStatusToString(ExpectedPostgresStatus pgExpectedStatus);
+
+bool keeper_set_postgres_state_unknown(KeeperStatePostgres *pgStatus,
+									   const char *filename);
+bool keeper_set_postgres_state_running(KeeperStatePostgres *pgStatus,
+									   const char *filename);
+bool keeper_set_postgres_state_stopped(KeeperStatePostgres *pgStatus,
+									   const char *filename);
+bool keeper_postgres_state_update(KeeperStatePostgres *pgStatus,
+								  const char *filename);
+bool keeper_postgres_state_read(KeeperStatePostgres *pgStatus,
+								const char *filename);
+
 
 #endif /* STATE_H */

--- a/src/bin/pg_autoctl/supervisor.c
+++ b/src/bin/pg_autoctl/supervisor.c
@@ -284,19 +284,19 @@ supervisor_loop(Supervisor *supervisor)
 				{
 					/* stop all the services. */
 					(void) supervisor_stop_subprocesses(supervisor);
+
+
+					/* allow for processing SIGINT again next time it's sent */
+					if (asked_to_stop_fast)
+					{
+						asked_to_stop_fast = 0;
+					}
 				}
 
 				if (supervisor->shutdownSequenceInProgress)
 				{
 					(void) supervisor_shutdown_sequence(stoppingLoopCounter++);
 				}
-
-				/* allow for processing SIGINT again next time it's sent */
-				if (asked_to_stop_fast)
-				{
-					asked_to_stop_fast = 0;
-				}
-
 				break;
 			}
 

--- a/src/bin/pg_autoctl/supervisor.c
+++ b/src/bin/pg_autoctl/supervisor.c
@@ -532,7 +532,7 @@ supervisor_handle_signals(Supervisor *supervisor)
 		(void) supervisor_stop_subprocesses(supervisor);
 
 		/* allow for processing SIGINT again next time it's sent: reset */
-		if (asked_to_stop_fast)
+		if (signal == SIGINT)
 		{
 			asked_to_stop_fast = 0;
 		}

--- a/src/bin/pg_autoctl/supervisor.c
+++ b/src/bin/pg_autoctl/supervisor.c
@@ -254,12 +254,12 @@ supervisor_loop(pid_t start_pid,
 															subprocessCount);
 					}
 
-					++stoppingLoopCounter;
-
 					if (stoppingLoopCounter == 1)
 					{
 						log_info("Waiting for subprocesses to terminate.");
 					}
+
+					++stoppingLoopCounter;
 
 					/*
 					 * If we've been waiting for quite a while for

--- a/src/bin/pg_autoctl/supervisor.c
+++ b/src/bin/pg_autoctl/supervisor.c
@@ -282,14 +282,12 @@ supervisor_loop(Supervisor *supervisor)
 				 */
 				if (shutdownNow)
 				{
-					/*
-					 * Stop all the services.
-					 */
-					if (stoppingLoopCounter == 0)
-					{
-						(void) supervisor_stop_subprocesses(supervisor);
-					}
+					/* stop all the services. */
+					(void) supervisor_stop_subprocesses(supervisor);
+				}
 
+				if (supervisor->shutdownSequenceInProgress)
+				{
 					(void) supervisor_shutdown_sequence(stoppingLoopCounter++);
 				}
 

--- a/src/bin/pg_autoctl/supervisor.c
+++ b/src/bin/pg_autoctl/supervisor.c
@@ -284,19 +284,26 @@ supervisor_loop(Supervisor *supervisor)
 				{
 					/* stop all the services. */
 					(void) supervisor_stop_subprocesses(supervisor);
-
-
-					/* allow for processing SIGINT again next time it's sent */
-					if (asked_to_stop_fast)
-					{
-						asked_to_stop_fast = 0;
-					}
 				}
 
 				if (supervisor->shutdownSequenceInProgress)
 				{
 					(void) supervisor_shutdown_sequence(stoppingLoopCounter++);
 				}
+
+				/*
+				 * Allow for processing SIGINT again next time it's sent.
+				 *
+				 * Be careful to only reset asked_to_stop_fast when we are
+				 * already processing it, in case we receive the signal during
+				 * this loop: we don't want to reset with without having first
+				 * processed the signal.
+				 */
+				if (shutdownNow && asked_to_stop_fast)
+				{
+					asked_to_stop_fast = 0;
+				}
+
 				break;
 			}
 

--- a/src/bin/pg_autoctl/supervisor.c
+++ b/src/bin/pg_autoctl/supervisor.c
@@ -1,0 +1,646 @@
+/*
+ * src/bin/pg_autoctl/supervisor.c
+ *   Supervisor for services run in sub-processes.
+ *
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the PostgreSQL License.
+ *
+ */
+
+#include <inttypes.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "defaults.h"
+#include "fsm.h"
+#include "keeper.h"
+#include "keeper_config.h"
+#include "keeper_pg_init.h"
+#include "log.h"
+#include "monitor.h"
+#include "pgctl.h"
+#include "state.h"
+#include "service.h"
+#include "supervisor.h"
+#include "signals.h"
+#include "string_utils.h"
+
+/*
+ * Supervisor restart strategy.
+ *
+ * The idea is to restart processes that have failed, so that we can stay
+ * available without external intervention. Sometimes though if the
+ * configuration is wrong or the data directory damaged beyond repair or for
+ * some reasons, the service can't be restarted.
+ *
+ * There is no magic or heuristic that can help us decide if a failure is
+ * transient or permanent, so we implement the simple thing: we restart our
+ * dead service up to 5 times in a row, and spend up to 10 seconds or retrying,
+ * and stop as soon as one of those conditions is reached.
+ *
+ * This strategy is inspired by http://erlang.org/doc/man/supervisor.html and
+ * http://erlang.org/doc/design_principles/sup_princ.html#maximum-restart-intensity
+ *
+ *    If more than MaxR number of restarts occur in the last MaxT seconds, the
+ *    supervisor terminates all the child processes and then itself. The
+ *    termination reason for the supervisor itself in that case will be
+ *    shutdown.
+ *
+ * SUPERVISOR_SERVICE_MAX_RETRY is MaxR, SUPERVISOR_SERVICE_MAX_TIME is MaxT.
+ *
+ * SUPERVISOR_SERVICE_RUNNING_TIME is the time we allow before considering that
+ * a restart has been successfull, because we implement async process start: we
+ * know that the process has started (fork() succeeds), only to know later that
+ * it failed (waitpid() reports a non-zero exit status).
+ */
+#define SUPERVISOR_SERVICE_MAX_RETRY 5
+#define SUPERVISOR_SERVICE_MAX_TIME 10     /* in seconds */
+#define SUPERVISOR_SERVICE_RUNNING_TIME 15 /* in seconds */
+
+static bool supervisor_init(const char *pidfile, pid_t *pid);
+
+static bool supervisor_loop(pid_t start_pid,
+							Service services[],
+							int serviceCount,
+							const char *pidfile);
+
+static bool supervisor_find_service(Service services[],
+									int serviceCount,
+									pid_t pid,
+									Service **result);
+
+static void supervisor_reset_service_restart_counters(Service services[],
+													  int serviceCount);
+
+static void supervisor_stop_subprocesses(Service services[], int serviceCount);
+
+static void supervisor_stop_other_services(pid_t pid,
+										   Service services[],
+										   int serviceCount);
+
+static bool supervisor_signal_process_group(int signal);
+
+
+/*
+ * supervisor_start starts given services as sub-processes and then supervise
+ * them.
+ */
+bool
+supervisor_start(Service services[], int serviceCount, const char *pidfile)
+{
+	pid_t start_pid = 0;
+	int serviceIndex = 0;
+	bool success = true;
+
+	/*
+	 * Create our PID file, or quit now if another pg_autoctl instance is
+	 * runnning.
+	 */
+	if (!supervisor_init(pidfile, &start_pid))
+	{
+		log_fatal("Failed to setup pg_autoctl pidfile and signal handlers");
+		return false;
+	}
+
+	/*
+	 * Start all the given services, in order.
+	 *
+	 * If we fail to start one of the given services, then we SIGQUIT the
+	 * services we managed to start before, in reverse order of starting-up,
+	 * and stop here.
+	 */
+	for (serviceIndex = 0; serviceIndex < serviceCount; serviceIndex++)
+	{
+		Service *service = &(services[serviceIndex]);
+		bool started = false;
+
+		log_debug("Starting pg_autoctl %s service", service->name);
+
+		started = (*service->startFunction)(service->context, &(service->pid));
+
+		if (started)
+		{
+			service->retries = 0;
+			service->startTime = time(NULL);
+
+			log_info("Started pg_autoctl %s service with pid %d",
+					 service->name, service->pid);
+		}
+		else
+		{
+			int idx = 0;
+
+			log_error("Failed to start service %s, "
+					  "stopping already started services and pg_autoctl",
+					  service->name);
+
+			for (idx = serviceIndex - 1; idx > 0; idx--)
+			{
+				if (kill(services[idx].pid, SIGQUIT) != 0)
+				{
+					log_error("Failed to send SIGQUIT to service %s with pid %d",
+							  services[idx].name, services[idx].pid);
+				}
+			}
+
+			/* we return false always, even if supervisor_stop is successful */
+			(void) supervisor_stop(pidfile);
+
+			return false;
+		}
+	}
+
+	/* now supervise sub-processes and implement retry strategy */
+	if (!supervisor_loop(start_pid, services, serviceCount, pidfile))
+	{
+		log_fatal("Something went wrong in sub-process supervision, "
+				  "stopping now. See above for details.");
+		success = false;
+	}
+
+	return supervisor_stop(pidfile) && success;
+}
+
+
+/*
+ * service_supervisor calls waitpid() in a loop until the sub processes that
+ * implement our main activities have stopped, and then it cleans-up the PID
+ * file.
+ */
+static bool
+supervisor_loop(pid_t start_pid,
+				Service services[],
+				int serviceCount,
+				const char *pidfile)
+{
+	int subprocessCount = serviceCount;
+	int stoppingLoopCounter = 0;
+	bool shutdownSequenceInProgress = false;
+	bool cleanExit = false;
+
+	/* wait until all subprocesses are done */
+	while (subprocessCount > 0)
+	{
+		pid_t pid;
+		int status;
+
+		/* Check that we still own our PID file, or quit now */
+		(void) check_pidfile(pidfile, start_pid);
+
+		/* If necessary, now is a good time to reload services */
+		if (asked_to_reload)
+		{
+			int serviceIndex = 0;
+
+			for (serviceIndex = 0; serviceIndex < serviceCount; serviceIndex++)
+			{
+				Service *service = &(services[serviceIndex]);
+
+				log_debug("Reloading pg_autoctl %s service", service->name);
+
+				(void) (*service->reloadFunction)(service);
+			}
+
+			/* reset our signal handling facility */
+			asked_to_reload = 0;
+		}
+
+		/* ignore errors */
+		pid = waitpid(-1, &status, WNOHANG);
+
+		switch (pid)
+		{
+			case -1:
+			{
+				if (errno == ECHILD)
+				{
+					/* no more childrens */
+					if (asked_to_stop || asked_to_stop_fast)
+					{
+						/* off we go */
+						log_info("Internal subprocesses are done, stopping");
+						return true;
+					}
+				}
+				else
+				{
+					log_fatal("Failed to call waitpid(): %m");
+					return false;
+				}
+			}
+
+			case 0:
+			{
+				/*
+				 * We're using WNOHANG, 0 means there are no stopped or exited
+				 * children, it's all good. It's the expected case when
+				 * everything is running smoothly, so enjoy and sleep for
+				 * awhile.
+				 */
+				if (asked_to_stop || asked_to_stop_fast)
+				{
+					cleanExit = true;
+
+					/*
+					 * Stop all the services.
+					 */
+					if (stoppingLoopCounter == 0)
+					{
+						(void) supervisor_stop_subprocesses(services,
+															subprocessCount);
+					}
+
+					++stoppingLoopCounter;
+
+					if (stoppingLoopCounter == 1)
+					{
+						log_info("Waiting for subprocesses to terminate.");
+					}
+
+					/*
+					 * If we've been waiting for quite a while for
+					 * sub-processes to terminate, it might be because a signal
+					 * was sent to only the process leader, such as when doing
+					 * `pkill pg_autoctl`, rather than to the process group,
+					 * such as when using killpg(2) or `pg_autoctl stop`.
+					 *
+					 * In that case let's signal all our process group
+					 * ourselves and see what happens next.
+					 */
+					else if (stoppingLoopCounter == 50)
+					{
+						log_info("pg_autoctl services are still running, "
+								 "signaling them with SIGTERM.");
+
+						if (!supervisor_signal_process_group(SIGTERM))
+						{
+							log_warn(
+								"Still waiting for subprocesses to terminate.");
+						}
+					}
+
+					/*
+					 * Wow it's been a very long time now...
+					 */
+					else if (stoppingLoopCounter > 0 &&
+							 stoppingLoopCounter % 100 == 0)
+					{
+						log_info("pg_autoctl services are still running, "
+								 "signaling them with SIGINT.");
+
+						if (!supervisor_signal_process_group(SIGINT))
+						{
+							log_warn(
+								"Still waiting for subprocesses to terminate.");
+						}
+					}
+				}
+
+				/*
+				 * No stopped or exited children, not asked to stopped.
+				 * Everything is good. Time to check if we should reset some
+				 * retries counters.
+				 */
+				else
+				{
+					(void) supervisor_reset_service_restart_counters(
+						services,
+						serviceCount);
+				}
+				break;
+			}
+
+			default:
+			{
+				char *verb = WIFEXITED(status) ? "exited" : "failed";
+				int returnCode = WEXITSTATUS(status);
+				Service *dead = NULL;
+				uint64_t now = time(NULL);
+
+				/* map the dead child pid to the known dead internal service */
+				if (!supervisor_find_service(services, serviceCount, pid, &dead))
+				{
+					log_error("Unknown subprocess died with pid %d", pid);
+					break;
+				}
+
+				/* one child process is no more */
+				--subprocessCount;
+
+				/*
+				 * One child process has terminated at least once now. Time to
+				 * update our restart strategy counters.
+				 */
+				if (dead->stopTime == 0)
+				{
+					dead->stopTime = now;
+				}
+
+				/*
+				 * One child process has terminated. If it terminated and
+				 * returned 0 as its exit status, then we consider that our job
+				 * is done here and cleanly exit.
+				 *
+				 * Before we exit though, we need to stop the other running
+				 * services.
+				 */
+				if (returnCode == 0)
+				{
+					cleanExit = true;
+
+					log_info("pg_autoctl service %s has finished, "
+							 "it was running with pid %d.",
+							 dead->name, dead->pid);
+
+					/* only stop other services once */
+					if (!shutdownSequenceInProgress)
+					{
+						shutdownSequenceInProgress = true;
+
+						(void) supervisor_stop_other_services(dead->pid,
+															  services,
+															  serviceCount);
+					}
+				}
+
+				/*
+				 * One child process has terminated, with an erroneous exit
+				 * status, and we've already tried and restarted the process 5
+				 * times or tried for more than 20s. Time to give control back
+				 * to the operator, or maybe systemd, or maybe a container
+				 * orchestration facility.
+				 */
+				else if (dead->retries >= SUPERVISOR_SERVICE_MAX_RETRY ||
+						 (now - dead->stopTime) >= SUPERVISOR_SERVICE_MAX_TIME)
+				{
+					log_error("pg_autoctl service %s %s with exit status %d",
+							  dead->name, verb, returnCode);
+
+					log_fatal("pg_autoctl service %s has already been "
+							  "restarted %d times in the last %d seconds, "
+							  "stopping now",
+							  dead->name,
+							  dead->retries,
+							  (int) (now - dead->startTime));
+
+					/* avoid calling the stopFunction again and again */
+					shutdownSequenceInProgress = true;
+					(void) supervisor_stop_other_services(dead->pid,
+														  services,
+														  serviceCount);
+				}
+
+				/*
+				 * One child process has terminated, and with an erroneous exit
+				 * status. We're concerned, of course. We'd rather ensure our
+				 * services are fine, so we're applying our restart strategy:
+				 * try to restart the service up to 5 times or 20s, whichever
+				 * comes first.
+				 */
+				else
+				{
+					bool restarted = false;
+
+					/*
+					 * Update our restart strategy counters. Well only the
+					 * count of retries, we want to keep our stopTime as it is
+					 * so as to know that we've been trying to restart 4 times
+					 * in 10s. It's not 10s each time, it's 10s total.
+					 *
+					 * Some services when asked to reload implement an "online
+					 * restart": the supervisor is expected to restart the
+					 * service from the (maybe new) on-disk program.
+					 */
+					if (returnCode != EXIT_CODE_RELOAD)
+					{
+						log_error(
+							"pg_autoctl service %s %s with exit status %d",
+							dead->name, verb, returnCode);
+
+						dead->retries += 1;
+
+						log_info("Restarting pg_autoctl service %s, "
+								 "retrying (%d time%s in %d seconds)",
+								 dead->name,
+								 dead->retries,
+								 dead->retries == 1 ? "" : "s",
+								 (int) (now - dead->stopTime));
+					}
+
+					restarted =
+						(*dead->startFunction)(dead->context, &(dead->pid));
+
+					if (restarted)
+					{
+						/* one child process has joined */
+						++subprocessCount;
+
+						dead->startTime = now;
+					}
+					else
+					{
+						log_fatal("Failed to restart service %s", dead->name);
+
+						(void) supervisor_stop_other_services(dead->pid,
+															  services,
+															  serviceCount);
+					}
+				}
+
+				break;
+			}
+		}
+
+		/* avoid buzy looping on waitpid(WNOHANG) */
+		pg_usleep(100 * 1000); /* 100 ms */
+	}
+
+	/* we track in the main loop if it's a cleanExit or not */
+	return cleanExit;
+}
+
+
+/*
+ * supervisor_find_service loops over the SubProcess array to find given pid and
+ * return its entry in the array.
+ */
+static bool
+supervisor_find_service(Service services[],
+						int serviceCount,
+						pid_t pid,
+						Service **result)
+{
+	int serviceIndex = 0;
+
+	for (serviceIndex = 0; serviceIndex < serviceCount; serviceIndex++)
+	{
+		if (pid == services[serviceIndex].pid)
+		{
+			*result = &(services[serviceIndex]);
+			return true;
+		}
+	}
+
+	return false;
+}
+
+
+/*
+ * supervisor_reset_service_restart_counters loops over known services and
+ * reset the retries count and stopTime of services that have been known
+ * running for more than a minute (SUPERVISOR_SERVICE_RUNNING_TIME is 60s).
+ */
+static void
+supervisor_reset_service_restart_counters(Service services[],
+										  int serviceCount)
+{
+	uint64_t now = time(NULL);
+	int serviceIndex = 0;
+
+	for (serviceIndex = 0; serviceIndex < serviceCount; serviceIndex++)
+	{
+		Service *target = &(services[serviceIndex]);
+
+		if (target->stopTime > 0)
+		{
+			if ((now - target->startTime) > SUPERVISOR_SERVICE_RUNNING_TIME)
+			{
+				target->retries = 0;
+				target->stopTime = 0;
+			}
+		}
+	}
+}
+
+
+/*
+ * supervisor_stop_subprocesses calls the stopFunction for all the registered
+ * services to initiate the shutdown sequence.
+ */
+static void
+supervisor_stop_subprocesses(Service services[], int serviceCount)
+{
+	int serviceIndex = 0;
+
+	for (serviceIndex = 0; serviceIndex < serviceCount; serviceIndex++)
+	{
+		Service *target = &(services[serviceIndex]);
+
+		(void) (*target->stopFunction)((void *) target);
+	}
+}
+
+
+/*
+ * supervisor_stop_other_subprocesses sends the QUIT signal to other known
+ * sub-processes when on of does is reported dead.
+ */
+static void
+supervisor_stop_other_services(pid_t pid, Service services[], int serviceCount)
+{
+	int serviceIndex = 0;
+
+	/*
+	 * In case of unexpected stop (bug), we stop the other processes too.
+	 * Someone might then notice (such as systemd) and restart the whole
+	 * thing again.
+	 */
+	if (!(asked_to_stop || asked_to_stop_fast))
+	{
+		for (serviceIndex = 0; serviceIndex < serviceCount; serviceIndex++)
+		{
+			Service *target = &(services[serviceIndex]);
+
+			if (target->pid != pid)
+			{
+				(void) (*target->stopFunction)((void *) target);
+			}
+		}
+	}
+}
+
+
+/*
+ * supervisor_signal_process_group sends a signal (SIGQUIT) to our own process
+ * group, which we are the leader of.
+ *
+ * That's used when we have received a signal already (asked_to_stop ||
+ * asked_to_stop_fast) and our sub-processes are still running after a while.
+ * It suggests that only the leader process was signaled rather than all the
+ * group.
+ */
+static bool
+supervisor_signal_process_group(int signal)
+{
+	pid_t pid = getpid();
+	pid_t pgrp = getpgid(pid);
+
+	if (pgrp == -1)
+	{
+		log_fatal("Failed to get the process group id of pid %d: %m", pid);
+		return false;
+	}
+
+	if (killpg(pgrp, signal) != 0)
+	{
+		log_error("Failed to send %s to the keeper's pid %d: %m",
+				  strsignal(signal), pgrp);
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * supervisor_init initializes our PID file and sets our signal handlers.
+ */
+static bool
+supervisor_init(const char *pidfile, pid_t *pid)
+{
+	bool exitOnQuit = false;
+	log_trace("supervisor_init");
+
+	/* Establish a handler for signals. */
+	(void) set_signal_handlers(exitOnQuit);
+
+	/* Check that the keeper service is not already running */
+	if (read_pidfile(pidfile, pid))
+	{
+		log_fatal("An instance of pg_autoctl is already running with PID %d, "
+				  "as seen in pidfile \"%s\"", *pid, pidfile);
+		return false;
+	}
+
+	/* Ok, we're going to start. Time to create our PID file. */
+	*pid = getpid();
+
+	if (!create_pidfile(pidfile, *pid))
+	{
+		log_fatal("Failed to write our PID to \"%s\"", pidfile);
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * supervisor_stop stops the service and removes the pid file.
+ */
+bool
+supervisor_stop(const char *pidfile)
+{
+	log_info("Stop pg_autoctl");
+
+	if (!remove_pidfile(pidfile))
+	{
+		log_error("Failed to remove pidfile \"%s\"", pidfile);
+		return false;
+	}
+	return true;
+}

--- a/src/bin/pg_autoctl/supervisor.c
+++ b/src/bin/pg_autoctl/supervisor.c
@@ -266,7 +266,7 @@ supervisor_loop(pid_t start_pid,
 					 * sub-processes to terminate. Let's signal again all our
 					 * process group ourselves and see what happens next.
 					 */
-					else if (stoppingLoopCounter == 50)
+					if (stoppingLoopCounter == 50)
 					{
 						log_info("pg_autoctl services are still running, "
 								 "signaling them with SIGTERM.");
@@ -281,8 +281,8 @@ supervisor_loop(pid_t start_pid,
 					/*
 					 * Wow it's been a very long time now...
 					 */
-					else if (stoppingLoopCounter > 0 &&
-							 stoppingLoopCounter % 100 == 0)
+					if (stoppingLoopCounter > 0 &&
+						stoppingLoopCounter % 100 == 0)
 					{
 						log_info("pg_autoctl services are still running, "
 								 "signaling them with SIGINT.");

--- a/src/bin/pg_autoctl/supervisor.h
+++ b/src/bin/pg_autoctl/supervisor.h
@@ -92,6 +92,8 @@ typedef struct Supervisor
 	pid_t pid;
 	bool cleanExit;
 	bool shutdownSequenceInProgress;
+	int shutdownSignal;
+	int stoppingLoopCounter;
 } Supervisor;
 
 

--- a/src/bin/pg_autoctl/supervisor.h
+++ b/src/bin/pg_autoctl/supervisor.h
@@ -39,11 +39,6 @@ typedef enum
  * configuration is wrong or the data directory damaged beyond repair or for
  * some reasons, the service can't be restarted.
  *
- * There is no magic or heuristic that can help us decide if a failure is
- * transient or permanent, so we implement the simple thing: we restart our
- * dead service up to 5 times in a row, and spend up to 10 seconds retrying,
- * and stop as soon as one of those conditions is reached.
- *
  * This strategy is inspired by http://erlang.org/doc/man/supervisor.html and
  * http://erlang.org/doc/design_principles/sup_princ.html#maximum-restart-intensity
  *

--- a/src/bin/pg_autoctl/supervisor.h
+++ b/src/bin/pg_autoctl/supervisor.h
@@ -63,7 +63,7 @@ typedef struct RestartCounters
 {
 	int count;                  /* how many restarts including first start */
 	int position;               /* array index */
-	uint64_t startTime[SUPERVISOR_SERVICE_MAX_RETRY + 1];
+	uint64_t startTime[SUPERVISOR_SERVICE_MAX_RETRY];
 }  RestartCounters;
 
 /*

--- a/src/bin/pg_autoctl/supervisor.h
+++ b/src/bin/pg_autoctl/supervisor.h
@@ -1,0 +1,51 @@
+/*
+ * src/bin/pg_autoctl/supervisor.h
+ *   Utilities to start/stop the pg_autoctl services.
+ *
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the PostgreSQL License.
+ *
+ */
+#ifndef SUPERVISOR_H
+#define SUPERVISOR_H
+
+#include <inttypes.h>
+#include <signal.h>
+
+/*
+ * start and stop function used in the struct Service.
+ *
+ * start functions get passed a context that is manually provided in the
+ * structure, typically a Monitor struct pointer for the monitor service and a
+ * Keeper struct pointer for a keeper service.
+ *
+ * stop functions get passed a context that is a pointer to the Service struct
+ * definition of the service being asked to stop, and we use a void * data type
+ * here to break out of a mutual recursive definition.
+ *
+ * reload functions get passed a context that is a pointer to the Service
+ * struct definition of the service being asked to stop.
+ */
+typedef bool (*ServiceStartFunction)(void *context, pid_t *pid);
+typedef bool (*ServiceStopFunction)(void *context);
+typedef void (*ServiceReloadFunction)(void *context);
+
+typedef struct Service
+{
+	char name[NAMEDATALEN];             /* Service name for the user */
+	pid_t pid;                          /* Service PID */
+	ServiceStartFunction startFunction; /* how to re-start the service */
+	ServiceStopFunction stopFunction;   /* how to stop the service */
+	ServiceReloadFunction reloadFunction; /* how to reload the service */
+	void *context;             /* Service Context (Monitor or Keeper struct) */
+	int retries;
+	uint64_t startTime;
+	uint64_t stopTime;
+} Service;
+
+bool supervisor_start(Service services[], int serviceCount, const char *pidfile);
+
+bool supervisor_stop(const char *pidfile);
+
+
+#endif /* SUPERVISOR_H */

--- a/src/bin/pg_autoctl/supervisor.h
+++ b/src/bin/pg_autoctl/supervisor.h
@@ -66,5 +66,9 @@ bool supervisor_start(Service services[], int serviceCount, const char *pidfile)
 
 bool supervisor_stop(Supervisor *supervisor);
 
+bool supervisor_find_service_pid(const char *pidfile,
+								 const char *serviceName,
+								 pid_t *pid);
+
 
 #endif /* SUPERVISOR_H */

--- a/src/bin/pg_autoctl/supervisor.h
+++ b/src/bin/pg_autoctl/supervisor.h
@@ -50,7 +50,7 @@ typedef enum
  * SUPERVISOR_SERVICE_MAX_RETRY is MaxR, SUPERVISOR_SERVICE_MAX_TIME is MaxT.
  */
 #define SUPERVISOR_SERVICE_MAX_RETRY 5
-#define SUPERVISOR_SERVICE_MAX_TIME 10     /* in seconds */
+#define SUPERVISOR_SERVICE_MAX_TIME 300 /* in seconds */
 
 /*
  * We use a "ring buffer" of the MaxR most recent retries.

--- a/src/bin/pg_autoctl/supervisor.h
+++ b/src/bin/pg_autoctl/supervisor.h
@@ -13,6 +13,24 @@
 #include <signal.h>
 
 /*
+ * Our supervisor process may retart a service sub-process when it quits,
+ * depending on the exit status and the restart policy that has been choosen:
+ *
+ * - A permanent child process is always restarted.
+ *
+ * - A temporary child process is never restarted.
+ *
+ * - A transient child process is restarted only if it terminates abnormally,
+ *   that is, with an exit code other EXIT_CODE_QUIT (zero).
+ */
+typedef enum
+{
+	RP_PERMANENT = 0,
+	RP_TEMPORARY,
+	RP_TRANSIENT
+} RestartPolicy;
+
+/*
  * The supervisor works with an array of Service entries. Each service defines
  * its behavior thanks to a start function, a stop function, and a reload
  * function. Those are called at different points to adjust to the situation as
@@ -20,22 +38,33 @@
  *
  * In particular, services may be started more than once when they fail.
  */
+
 typedef struct Service
 {
 	char name[NAMEDATALEN];             /* Service name for the user */
+	RestartPolicy policy;               /* Should we restart the service? */
 	pid_t pid;                          /* Service PID */
 	bool (*startFunction)(void *context, pid_t *pid);
-	bool (*stopFunction)(struct Service *service);
-	void (*reloadFunction)(struct Service *service);
 	void *context;             /* Service Context (Monitor or Keeper struct) */
 	int retries;
 	uint64_t startTime;
 	uint64_t stopTime;
 } Service;
 
+typedef struct Supervisor
+{
+	Service *services;
+	int serviceCount;
+	char pidfile[MAXPGPATH];
+	pid_t pid;
+	bool cleanExit;
+	bool shutdownSequenceInProgress;
+} Supervisor;
+
+
 bool supervisor_start(Service services[], int serviceCount, const char *pidfile);
 
-bool supervisor_stop(const char *pidfile);
+bool supervisor_stop(Supervisor *supervisor);
 
 
 #endif /* SUPERVISOR_H */

--- a/src/bin/pg_autoctl/supervisor.h
+++ b/src/bin/pg_autoctl/supervisor.h
@@ -13,28 +13,18 @@
 #include <signal.h>
 
 /*
- * start and stop function used in the struct Service.
+ * The supervisor works with an array of Service entries. Each service defines
+ * its behavior thanks to a start function, a stop function, and a reload
+ * function. Those are called at different points to adjust to the situation as
+ * seen by the supervisor.
  *
- * start functions get passed a context that is manually provided in the
- * structure, typically a Monitor struct pointer for the monitor service and a
- * Keeper struct pointer for a keeper service.
- *
- * stop functions get passed a context that is a pointer to the Service struct
- * definition of the service being asked to stop, and we use a void * data type
- * here to break out of a mutual recursive definition.
- *
- * reload functions get passed a context that is a pointer to the Service
- * struct definition of the service being asked to stop.
+ * In particular, services may be started more than once when they fail.
  */
-typedef bool (*ServiceStartFunction)(void *context, pid_t *pid);
-typedef bool (*ServiceStopFunction)(void *context);
-typedef void (*ServiceReloadFunction)(void *context);
-
 typedef struct Service
 {
 	char name[NAMEDATALEN];             /* Service name for the user */
 	pid_t pid;                          /* Service PID */
-	ServiceStartFunction startFunction; /* how to re-start the service */
+	bool (*startFunction)(void *context, pid_t *pid);
 	bool (*stopFunction)(struct Service *service);
 	void (*reloadFunction)(struct Service *service);
 	void *context;             /* Service Context (Monitor or Keeper struct) */

--- a/src/bin/pg_autoctl/supervisor.h
+++ b/src/bin/pg_autoctl/supervisor.h
@@ -35,8 +35,8 @@ typedef struct Service
 	char name[NAMEDATALEN];             /* Service name for the user */
 	pid_t pid;                          /* Service PID */
 	ServiceStartFunction startFunction; /* how to re-start the service */
-	ServiceStopFunction stopFunction;   /* how to stop the service */
-	ServiceReloadFunction reloadFunction; /* how to reload the service */
+	bool (*stopFunction)(struct Service *service);
+	void (*reloadFunction)(struct Service *service);
 	void *context;             /* Service Context (Monitor or Keeper struct) */
 	int retries;
 	uint64_t startTime;


### PR DESCRIPTION
At the moment the postgres controller process is not used in the main code
of pg_autoctl, the idea is to make use of it in later PRs implementing the
monitor and then the keeper process supervision and integration.

To use this:

```
$ export PGDATA=...
$ pg_autoctl create postgres ...
$ pg_ctl stop
$ PG_AUTOCTL_DEBUG=1 ./src/bin/pg_autoctl/pg_autoctl do service postgres
$ PG_AUTOCTL_DEBUG=1 ./src/bin/pg_autoctl/pg_autoctl do pgctl on
$ PG_AUTOCTL_DEBUG=1 ./src/bin/pg_autoctl/pg_autoctl do pgctl off
```