### PR TITLE
Remove useless lines caused by declaration-after-statement warning

### DIFF
--- a/src/bin/pg_autoctl/Makefile
+++ b/src/bin/pg_autoctl/Makefile
@@ -39,6 +39,7 @@ DEFAULT_CFLAGS += -Wall
 DEFAULT_CFLAGS += -Werror=implicit-int
 DEFAULT_CFLAGS += -Werror=implicit-function-declaration
 DEFAULT_CFLAGS += -Werror=return-type
+DEFAULT_CFLAGS += -Wno-declaration-after-statement
 
 # Needed for OSX
 DEFAULT_CFLAGS += -Wno-missing-braces

--- a/src/bin/pg_autoctl/cli_common.c
+++ b/src/bin/pg_autoctl/cli_common.c
@@ -1240,10 +1240,8 @@ keeper_cli_print_version(int argc, char **argv)
 void
 cli_pprint_json(JSON_Value *js)
 {
-	char *serialized_string;
-
 	/* output our nice JSON object, pretty printed please */
-	serialized_string = json_serialize_to_string_pretty(js);
+	char *serialized_string = json_serialize_to_string_pretty(js);
 	fformat(stdout, "%s\n", serialized_string);
 
 	/* free intermediate memory */

--- a/src/bin/pg_autoctl/cli_do_fsm.c
+++ b/src/bin/pg_autoctl/cli_do_fsm.c
@@ -286,7 +286,6 @@ cli_do_fsm_assign(int argc, char **argv)
 	Keeper keeper = { 0 };
 	KeeperConfig config = keeperOptions;
 	char keeperStateJSON[BUFSIZE];
-	NodeState goalState = NO_STATE;
 
 	bool missingPgdataIsOk = true;
 	bool pgIsNotRunningIsOk = true;
@@ -312,7 +311,7 @@ cli_do_fsm_assign(int argc, char **argv)
 		exit(EXIT_CODE_BAD_ARGS);
 	}
 
-	goalState = NodeStateFromString(argv[0]);
+	NodeState goalState = NodeStateFromString(argv[0]);
 
 	if (goalState == NO_STATE)
 	{
@@ -386,8 +385,6 @@ static void
 cli_do_fsm_step(int argc, char **argv)
 {
 	Keeper keeper = { 0 };
-	const char *oldRole = NULL;
-	const char *newRole = NULL;
 
 	bool missingPgdataIsOk = true;
 	bool pgIsNotRunningIsOk = true;
@@ -418,7 +415,7 @@ cli_do_fsm_step(int argc, char **argv)
 		exit(EXIT_CODE_PGCTL);
 	}
 
-	oldRole = NodeStateToString(keeper.state.current_role);
+	const char *oldRole = NodeStateToString(keeper.state.current_role);
 
 	if (!keeper_fsm_step(&keeper))
 	{
@@ -426,7 +423,7 @@ cli_do_fsm_step(int argc, char **argv)
 		exit(EXIT_CODE_BAD_STATE);
 	}
 
-	newRole = NodeStateToString(keeper.state.assigned_role);
+	const char *newRole = NodeStateToString(keeper.state.assigned_role);
 
 	if (outputJSON)
 	{

--- a/src/bin/pg_autoctl/cli_do_misc.c
+++ b/src/bin/pg_autoctl/cli_do_misc.c
@@ -159,7 +159,6 @@ keeper_cli_create_monitor_user(int argc, char **argv)
 	LocalPostgresServer postgres = { 0 };
 	bool missingPgdataOk = false;
 	bool postgresNotRunningOk = false;
-	int urlLength = 0;
 	char monitorHostname[_POSIX_HOST_NAME_MAX];
 	int monitorPort = 0;
 	int connlimit = 1;
@@ -167,7 +166,7 @@ keeper_cli_create_monitor_user(int argc, char **argv)
 	keeper_config_init(&config, missingPgdataOk, postgresNotRunningOk);
 	local_postgres_init(&postgres, &(config.pgSetup));
 
-	urlLength = strlcpy(config.monitor_pguri, argv[0], MAXCONNINFO);
+	int urlLength = strlcpy(config.monitor_pguri, argv[0], MAXCONNINFO);
 	if (urlLength >= MAXCONNINFO)
 	{
 		log_fatal("Monitor URL \"%s\" given in command line is %d characters, "
@@ -308,7 +307,6 @@ void
 keeper_cli_pgsetup_is_ready(int argc, char **argv)
 {
 	PostgresSetup pgSetup = { 0 };
-	bool pgIsReady = false;
 	bool pgIsNotRunningIsOk = false;
 
 	if (!pg_setup_init(&pgSetup, &keeperOptions.pgSetup, true, true))
@@ -318,7 +316,7 @@ keeper_cli_pgsetup_is_ready(int argc, char **argv)
 
 	log_debug("Initialized pgSetup, now calling pg_setup_is_ready()");
 
-	pgIsReady = pg_setup_is_ready(&pgSetup, pgIsNotRunningIsOk);
+	bool pgIsReady = pg_setup_is_ready(&pgSetup, pgIsNotRunningIsOk);
 
 	log_info("Postgres status is: \"%s\"", pmStatusToString(pgSetup.pm_status));
 
@@ -339,7 +337,6 @@ keeper_cli_pgsetup_wait_until_ready(int argc, char **argv)
 {
 	int timeout = 30;
 	PostgresSetup pgSetup = { 0 };
-	bool pgIsReady = false;
 
 	if (!pg_setup_init(&pgSetup, &keeperOptions.pgSetup, true, true))
 	{
@@ -348,7 +345,7 @@ keeper_cli_pgsetup_wait_until_ready(int argc, char **argv)
 
 	log_debug("Initialized pgSetup, now calling pg_setup_wait_until_is_ready()");
 
-	pgIsReady = pg_setup_wait_until_is_ready(&pgSetup, timeout, LOG_INFO);
+	bool pgIsReady = pg_setup_wait_until_is_ready(&pgSetup, timeout, LOG_INFO);
 
 	log_info("Postgres status is: \"%s\"", pmStatusToString(pgSetup.pm_status));
 
@@ -411,7 +408,6 @@ keeper_cli_init_standby(int argc, char **argv)
 
 	KeeperConfig config = keeperOptions;
 	LocalPostgresServer postgres = { 0 };
-	int hostLength = 0;
 
 	if (argc != 2)
 	{
@@ -422,8 +418,8 @@ keeper_cli_init_standby(int argc, char **argv)
 	keeper_config_init(&config, missing_pgdata_is_ok, pg_not_running_is_ok);
 	local_postgres_init(&postgres, &(config.pgSetup));
 
-	hostLength = strlcpy(postgres.replicationSource.primaryNode.host, argv[0],
-						 _POSIX_HOST_NAME_MAX);
+	int hostLength = strlcpy(postgres.replicationSource.primaryNode.host, argv[0],
+							 _POSIX_HOST_NAME_MAX);
 	if (hostLength >= _POSIX_HOST_NAME_MAX)
 	{
 		log_fatal("Hostname \"%s\" given in command line is %d characters, "
@@ -468,7 +464,6 @@ keeper_cli_rewind_old_primary(int argc, char **argv)
 {
 	const bool missing_pgdata_is_ok = false;
 	const bool pg_not_running_is_ok = true;
-	int hostLength = 0;
 
 	KeeperConfig config = keeperOptions;
 	LocalPostgresServer postgres = { 0 };
@@ -482,8 +477,8 @@ keeper_cli_rewind_old_primary(int argc, char **argv)
 	keeper_config_init(&config, missing_pgdata_is_ok, pg_not_running_is_ok);
 	local_postgres_init(&postgres, &(config.pgSetup));
 
-	hostLength = strlcpy(postgres.replicationSource.primaryNode.host, argv[0],
-						 _POSIX_HOST_NAME_MAX);
+	int hostLength = strlcpy(postgres.replicationSource.primaryNode.host, argv[0],
+							 _POSIX_HOST_NAME_MAX);
 	if (hostLength >= _POSIX_HOST_NAME_MAX)
 	{
 		log_fatal("Hostname \"%s\" given in command line is %d characters, "
@@ -561,7 +556,6 @@ keeper_cli_identify_system(int argc, char **argv)
 
 	KeeperConfig config = keeperOptions;
 	ReplicationSource replicationSource = { 0 };
-	int hostLength = 0;
 
 	if (argc != 2)
 	{
@@ -571,8 +565,8 @@ keeper_cli_identify_system(int argc, char **argv)
 
 	keeper_config_init(&config, missing_pgdata_is_ok, pg_not_running_is_ok);
 
-	hostLength = strlcpy(replicationSource.primaryNode.host, argv[0],
-						 _POSIX_HOST_NAME_MAX);
+	int hostLength = strlcpy(replicationSource.primaryNode.host, argv[0],
+							 _POSIX_HOST_NAME_MAX);
 	if (hostLength >= _POSIX_HOST_NAME_MAX)
 	{
 		log_fatal("Hostname \"%s\" given in command line is %d characters, "

--- a/src/bin/pg_autoctl/cli_do_monitor.c
+++ b/src/bin/pg_autoctl/cli_do_monitor.c
@@ -337,7 +337,6 @@ cli_do_monitor_get_coordinator(int argc, char **argv)
 static void
 cli_do_monitor_register_node(int argc, char **argv)
 {
-	NodeState initialState = NO_STATE;
 	Keeper keeper = { 0 };
 	KeeperConfig config = keeperOptions;
 
@@ -351,7 +350,7 @@ cli_do_monitor_register_node(int argc, char **argv)
 		exit(EXIT_CODE_BAD_ARGS);
 	}
 
-	initialState = NodeStateFromString(argv[0]);
+	NodeState initialState = NodeStateFromString(argv[0]);
 
 	/*
 	 * On the keeper's side we should only accept to register a local node to

--- a/src/bin/pg_autoctl/cli_do_root.c
+++ b/src/bin/pg_autoctl/cli_do_root.c
@@ -334,7 +334,6 @@ int
 keeper_cli_keeper_setup_getopts(int argc, char **argv)
 {
 	KeeperConfig options = { 0 };
-	int optind;
 
 	SSLCommandLineOptions sslCommandLineOptions = SSL_CLI_UNKNOWN;
 
@@ -380,11 +379,11 @@ keeper_cli_keeper_setup_getopts(int argc, char **argv)
 	 */
 	unsetenv("POSIXLY_CORRECT");
 
-	optind = cli_common_keeper_getopts(argc, argv,
-									   long_options,
-									   "C:D:H:p:l:U:A:Sd:n:f:m:MRVvqhP:r:xsN",
-									   &options,
-									   &sslCommandLineOptions);
+	int optind = cli_common_keeper_getopts(argc, argv,
+										   long_options,
+										   "C:D:H:p:l:U:A:Sd:n:f:m:MRVvqhP:r:xsN",
+										   &options,
+										   &sslCommandLineOptions);
 
 	/* publish our option parsing in the global variable */
 	keeperOptions = options;

--- a/src/bin/pg_autoctl/cli_do_show.c
+++ b/src/bin/pg_autoctl/cli_do_show.c
@@ -139,16 +139,13 @@ cli_show_cidr(int argc, char **argv)
 static void
 cli_show_lookup(int argc, char **argv)
 {
-	char *hostname;
-	IPType ipType = IPTYPE_NONE;
-
 	if (argc != 1)
 	{
 		commandline_print_usage(&do_show_lookup_command, stderr);
 		exit(EXIT_CODE_BAD_ARGS);
 	}
-	hostname = argv[0];
-	ipType = ip_address_type(hostname);
+	char *hostname = argv[0];
+	IPType ipType = ip_address_type(hostname);
 
 	if (ipType == IPTYPE_NONE)
 	{
@@ -303,8 +300,6 @@ cli_show_reverse(int argc, char **argv)
 {
 	char ipaddr[BUFSIZE] = { 0 };
 
-	char *hostname;
-	IPType ipType = IPTYPE_NONE;
 
 	if (argc != 1)
 	{
@@ -312,8 +307,8 @@ cli_show_reverse(int argc, char **argv)
 		exit(EXIT_CODE_BAD_ARGS);
 	}
 
-	hostname = argv[0];
-	ipType = ip_address_type(hostname);
+	char *hostname = argv[0];
+	IPType ipType = ip_address_type(hostname);
 
 	if (ipType != IPTYPE_NONE)
 	{

--- a/src/bin/pg_autoctl/cli_do_tmux.c
+++ b/src/bin/pg_autoctl/cli_do_tmux.c
@@ -581,7 +581,6 @@ prepare_tmux_script(TmuxOptions *options, PQExpBuffer script)
 		char extra_commands[BUFSIZE] = { 0 };
 
 		char *extraLines[BUFSIZE];
-		int lineCount = 0;
 		int lineNumber = 0;
 
 		if (!get_env_copy("TMUX_EXTRA_COMMANDS", extra_commands, BUFSIZE))
@@ -590,7 +589,7 @@ prepare_tmux_script(TmuxOptions *options, PQExpBuffer script)
 			exit(EXIT_CODE_INTERNAL_ERROR);
 		}
 
-		lineCount = splitLines(extra_commands, extraLines, BUFSIZE);
+		int lineCount = splitLines(extra_commands, extraLines, BUFSIZE);
 
 		for (lineNumber = 0; lineNumber < lineCount; lineNumber++)
 		{
@@ -606,8 +605,6 @@ prepare_tmux_script(TmuxOptions *options, PQExpBuffer script)
 bool
 tmux_start_server(const char *root, const char *scriptName)
 {
-	Program program;
-
 	char *args[8];
 	int argsIndex = 0;
 
@@ -639,7 +636,7 @@ tmux_start_server(const char *root, const char *scriptName)
 	args[argsIndex] = NULL;
 
 	/* we do not want to call setsid() when running this program. */
-	program = initialize_program(args, false);
+	Program program = initialize_program(args, false);
 
 	program.capture = false;    /* don't capture output */
 	program.tty = true;         /* allow sharing the parent's tty */
@@ -753,11 +750,10 @@ tmux_stop_pg_autoctl(TmuxOptions *options)
 bool
 tmux_has_session(const char *tmux_path, const char *sessionName)
 {
-	Program program;
 	int returnCode;
 	char command[BUFSIZE] = { 0 };
 
-	program = run_program(tmux_path, "has-session", "-t", sessionName, NULL);
+	Program program = run_program(tmux_path, "has-session", "-t", sessionName, NULL);
 	returnCode = program.returnCode;
 
 	(void) snprintf_program_command_line(&program, command, BUFSIZE);
@@ -806,7 +802,6 @@ tmux_has_session(const char *tmux_path, const char *sessionName)
 bool
 tmux_kill_session(TmuxOptions *options)
 {
-	Program program;
 	char tmux[MAXPGPATH] = { 0 };
 	char command[BUFSIZE] = { 0 };
 	char sessionName[BUFSIZE] = { 0 };
@@ -827,7 +822,7 @@ tmux_kill_session(TmuxOptions *options)
 		return true;
 	}
 
-	program = run_program(tmux, "kill-session", "-t", sessionName, NULL);
+	Program program = run_program(tmux, "kill-session", "-t", sessionName, NULL);
 
 	(void) snprintf_program_command_line(&program, command, BUFSIZE);
 	log_info("%s", command);
@@ -1167,7 +1162,6 @@ cli_do_tmux_wait(int argc, char **argv)
 	{
 		int timeout = 30;
 		bool ready = false;
-		Program program;
 		char pgdata[MAXPGPATH] = { 0 };
 
 		sformat(pgdata, sizeof(pgdata), "%s/%s", options.root, nodeName);
@@ -1175,8 +1169,8 @@ cli_do_tmux_wait(int argc, char **argv)
 		/* leave some time for initdb and stuff */
 		sleep(2);
 
-		program = run_program(pg_autoctl_program, "do", "pgsetup", "wait",
-							  "--pgdata", pgdata, NULL);
+		Program program = run_program(pg_autoctl_program, "do", "pgsetup", "wait",
+									  "--pgdata", pgdata, NULL);
 
 		if (program.returnCode != 0)
 		{

--- a/src/bin/pg_autoctl/cli_enable_disable.c
+++ b/src/bin/pg_autoctl/cli_enable_disable.c
@@ -495,7 +495,6 @@ cli_enable_maintenance(int argc, char **argv)
 	{
 		int nodeId = keeper.state.current_node_id;
 		bool mayRetry = false;
-		int sleepTimeMs = 0;
 
 		if (monitor_start_maintenance(&(keeper.monitor), nodeId, &mayRetry))
 		{
@@ -511,7 +510,7 @@ cli_enable_maintenance(int argc, char **argv)
 			exit(EXIT_CODE_MONITOR);
 		}
 
-		sleepTimeMs = pgsql_compute_connection_retry_sleep_time(&retryPolicy);
+		int sleepTimeMs = pgsql_compute_connection_retry_sleep_time(&retryPolicy);
 
 		log_warn("Failed to enable maintenance of node %d on the monitor, "
 				 "retrying in %d ms.",
@@ -599,7 +598,6 @@ cli_disable_maintenance(int argc, char **argv)
 	{
 		int nodeId = keeper.state.current_node_id;
 		bool mayRetry = false;
-		int sleepTimeMs = 0;
 
 		if (monitor_stop_maintenance(&(keeper.monitor), nodeId, &mayRetry))
 		{
@@ -615,7 +613,7 @@ cli_disable_maintenance(int argc, char **argv)
 			exit(EXIT_CODE_MONITOR);
 		}
 
-		sleepTimeMs = pgsql_compute_connection_retry_sleep_time(&retryPolicy);
+		int sleepTimeMs = pgsql_compute_connection_retry_sleep_time(&retryPolicy);
 
 		log_warn("Failed to disable maintenance of node %d on the monitor, "
 				 "retrying in %d ms.",

--- a/src/bin/pg_autoctl/cli_get_set_properties.c
+++ b/src/bin/pg_autoctl/cli_get_set_properties.c
@@ -437,7 +437,6 @@ cli_set_node_candidate_priority(int argc, char **argv)
 {
 	Keeper keeper = { 0 };
 
-	int candidatePriority = -1;
 
 	keeper.config = keeperOptions;
 
@@ -450,7 +449,7 @@ cli_set_node_candidate_priority(int argc, char **argv)
 		exit(EXIT_CODE_BAD_ARGS);
 	}
 
-	candidatePriority = strtol(argv[0], NULL, 10);
+	int candidatePriority = strtol(argv[0], NULL, 10);
 
 	if (errno == EINVAL || candidatePriority < 0 || candidatePriority > 100)
 	{
@@ -605,7 +604,6 @@ cli_set_formation_number_sync_standbys(int argc, char **argv)
 	KeeperConfig config = keeperOptions;
 	Monitor monitor = { 0 };
 
-	int numberSyncStandbys = -1;
 
 	char synchronous_standby_names[BUFSIZE] = { 0 };
 
@@ -618,7 +616,7 @@ cli_set_formation_number_sync_standbys(int argc, char **argv)
 		exit(EXIT_CODE_BAD_ARGS);
 	}
 
-	numberSyncStandbys = strtol(argv[0], NULL, 10);
+	int numberSyncStandbys = strtol(argv[0], NULL, 10);
 	if (errno == EINVAL || numberSyncStandbys < 0)
 	{
 		log_error("number-sync-standbys value %s is not valid."

--- a/src/bin/pg_autoctl/cli_show.c
+++ b/src/bin/pg_autoctl/cli_show.c
@@ -703,7 +703,6 @@ cli_show_standby_names(int argc, char **argv)
 	KeeperConfig config = keeperOptions;
 	Monitor monitor = { 0 };
 	char synchronous_standby_names[BUFSIZE] = { 0 };
-	pgAutoCtlNodeRole role = PG_AUTOCTL_ROLE_UNKNOWN;
 
 	/* change the default group when it's not been given on the command */
 	if (config.groupId == -1)
@@ -717,7 +716,7 @@ cli_show_standby_names(int argc, char **argv)
 		exit(EXIT_CODE_BAD_ARGS);
 	}
 
-	role = ProbeConfigurationFileRole(config.pathnames.config);
+	pgAutoCtlNodeRole role = ProbeConfigurationFileRole(config.pathnames.config);
 
 	if (role == PG_AUTOCTL_ROLE_KEEPER)
 	{
@@ -1304,9 +1303,8 @@ static void
 cli_show_file(int argc, char **argv)
 {
 	KeeperConfig config = keeperOptions;
-	pgAutoCtlNodeRole role = PG_AUTOCTL_ROLE_UNKNOWN;
 
-	role = ProbeConfigurationFileRole(config.pathnames.config);
+	pgAutoCtlNodeRole role = ProbeConfigurationFileRole(config.pathnames.config);
 
 	switch (showFileOptions.selection)
 	{
@@ -1314,7 +1312,6 @@ cli_show_file(int argc, char **argv)
 		{
 			if (outputJSON)
 			{
-				char *serialized_string = NULL;
 				JSON_Value *js = json_value_init_object();
 				JSON_Object *root = json_value_get_object(js);
 
@@ -1328,7 +1325,7 @@ cli_show_file(int argc, char **argv)
 
 				json_object_set_string(root, "pid", config.pathnames.pid);
 
-				serialized_string = json_serialize_to_string_pretty(js);
+				char *serialized_string = json_serialize_to_string_pretty(js);
 
 				fformat(stdout, "%s\n", serialized_string);
 

--- a/src/bin/pg_autoctl/debian.c
+++ b/src/bin/pg_autoctl/debian.c
@@ -296,15 +296,12 @@ buildDebianDataAndConfDirectoryNames(PostgresSetup *pgSetup,
 									 DebianPathnames *debPathnames)
 {
 	char *pgmajor = strdup(pgSetup->pg_version);
-	char *dot;
 
 	char pgdata[MAXPGPATH];
 
 	char clusterDir[MAXPGPATH] = { 0 };
 	char versionDir[MAXPGPATH] = { 0 };
 
-	char *clusterDirName = NULL;
-	char *versionDirName = NULL;
 
 	/* we need to work with the absolute pathname of PGDATA */
 	if (!normalize_filename(pgSetup->pgdata, pgdata, MAXPGPATH))
@@ -321,11 +318,11 @@ buildDebianDataAndConfDirectoryNames(PostgresSetup *pgSetup,
 	get_parent_directory(versionDir);
 
 	/* get the names of our version and cluster directories */
-	clusterDirName = strdup(basename(clusterDir));
-	versionDirName = strdup(basename(versionDir));
+	char *clusterDirName = strdup(basename(clusterDir));
+	char *versionDirName = strdup(basename(versionDir));
 
 	/* transform pgversion "11.4" to "11" to get the major version part */
-	dot = strchr(pgmajor, '.');
+	char *dot = strchr(pgmajor, '.');
 
 	if (dot)
 	{
@@ -596,8 +593,6 @@ static bool
 comment_out_configuration_parameters(const char *srcConfPath,
 									 const char *dstConfPath)
 {
-	FILE *fileStream = NULL;
-	PQExpBuffer newConfContents = NULL;
 	char lineBuffer[BUFSIZE];
 
 	/*
@@ -614,14 +609,14 @@ comment_out_configuration_parameters(const char *srcConfPath,
 		")( *)=";
 
 	/* open a file */
-	fileStream = fopen_read_only(srcConfPath);
+	FILE *fileStream = fopen_read_only(srcConfPath);
 	if (fileStream == NULL)
 	{
 		log_error("Failed to open file \"%s\": %m", srcConfPath);
 		return false;
 	}
 
-	newConfContents = createPQExpBuffer();
+	PQExpBuffer newConfContents = createPQExpBuffer();
 	if (newConfContents == NULL)
 	{
 		log_error("Failed to allocate memory");

--- a/src/bin/pg_autoctl/env_utils.c
+++ b/src/bin/pg_autoctl/env_utils.c
@@ -23,7 +23,6 @@
 bool
 env_found_empty(const char *name)
 {
-	char *envvalue = NULL;
 	if (name == NULL || strlen(name) == 0)
 	{
 		log_error("Failed to get environment setting. "
@@ -36,7 +35,7 @@ env_found_empty(const char *name)
 	 * getenv is safe here because we never provide null argument,
 	 * and only check the value it's length.
 	 */
-	envvalue = getenv(name); /* IGNORE-BANNED */
+	char *envvalue = getenv(name); /* IGNORE-BANNED */
 	return envvalue != NULL && strlen(envvalue) == 0;
 }
 
@@ -74,9 +73,6 @@ bool
 get_env_copy_with_fallback(const char *name, char *result, int maxLength,
 						   const char *fallback)
 {
-	const char *envvalue = NULL;
-	size_t actualLength = 0;
-
 	if (name == NULL || strlen(name) == 0)
 	{
 		log_error("Failed to get environment setting. "
@@ -96,7 +92,7 @@ get_env_copy_with_fallback(const char *name, char *result, int maxLength,
 	 * getenv is safe here because we never provide null argument,
 	 * and copy out the result immediately.
 	 */
-	envvalue = getenv(name); /* IGNORE-BANNED */
+	const char *envvalue = getenv(name); /* IGNORE-BANNED */
 	if (envvalue == NULL)
 	{
 		envvalue = fallback;
@@ -108,7 +104,7 @@ get_env_copy_with_fallback(const char *name, char *result, int maxLength,
 		}
 	}
 
-	actualLength = strlcpy(result, envvalue, maxLength);
+	size_t actualLength = strlcpy(result, envvalue, maxLength);
 
 	/* uses >= to make sure the nullbyte fits */
 	if (actualLength >= maxLength)

--- a/src/bin/pg_autoctl/file_utils.c
+++ b/src/bin/pg_autoctl/file_utils.c
@@ -66,7 +66,6 @@ file_exists(const char *filename)
 bool
 directory_exists(const char *path)
 {
-	bool result = false;
 	struct stat info;
 
 	if (!file_exists(path))
@@ -80,7 +79,7 @@ directory_exists(const char *path)
 		return false;
 	}
 
-	result = (info.st_mode & S_IFMT) == S_IFDIR;
+	bool result = (info.st_mode & S_IFMT) == S_IFDIR;
 	return result;
 }
 
@@ -137,14 +136,13 @@ FILE *
 fopen_with_umask(const char *filePath, const char *modes, int flags, mode_t umask)
 {
 	int fileDescriptor = open(filePath, flags, umask);
-	FILE *fileStream = NULL;
 	if (fileDescriptor == -1)
 	{
 		log_error("Failed to open file \"%s\": %m", filePath);
 		return NULL;
 	}
 
-	fileStream = fdopen(fileDescriptor, modes);
+	FILE *fileStream = fdopen(fileDescriptor, modes);
 	if (fileStream == NULL)
 	{
 		log_error("Failed to open file \"%s\": %m", filePath);
@@ -247,10 +245,8 @@ append_to_file(char *data, long fileSize, const char *filePath)
 bool
 read_file_if_exists(const char *filePath, char **contents, long *fileSize)
 {
-	FILE *fileStream = NULL;
-
 	/* open a file */
-	fileStream = fopen_read_only(filePath);
+	FILE *fileStream = fopen_read_only(filePath);
 
 	if (fileStream == NULL)
 	{
@@ -276,10 +272,8 @@ read_file_if_exists(const char *filePath, char **contents, long *fileSize)
 bool
 read_file(const char *filePath, char **contents, long *fileSize)
 {
-	FILE *fileStream = NULL;
-
 	/* open a file */
-	fileStream = fopen_read_only(filePath);
+	FILE *fileStream = fopen_read_only(filePath);
 	if (fileStream == NULL)
 	{
 		log_error("Failed to open file \"%s\": %m", filePath);
@@ -298,8 +292,6 @@ static bool
 read_file_internal(FILE *fileStream,
 				   const char *filePath, char **contents, long *fileSize)
 {
-	char *data = NULL;
-
 	/* get the file size */
 	if (fseek(fileStream, 0, SEEK_END) != 0)
 	{
@@ -324,7 +316,7 @@ read_file_internal(FILE *fileStream,
 	}
 
 	/* read the contents */
-	data = malloc(*fileSize + 1);
+	char *data = malloc(*fileSize + 1);
 	if (data == NULL)
 	{
 		log_error("Failed to allocate %ld bytes", *fileSize);
@@ -431,7 +423,6 @@ duplicate_file(char *sourcePath, char *destinationPath)
 	char *fileContents;
 	long fileSize;
 	struct stat sourceFileStat;
-	bool foundError = false;
 
 	if (!read_file(sourcePath, &fileContents, &fileSize))
 	{
@@ -446,7 +437,7 @@ duplicate_file(char *sourcePath, char *destinationPath)
 		return false;
 	}
 
-	foundError = !write_file(fileContents, fileSize, destinationPath);
+	bool foundError = !write_file(fileContents, fileSize, destinationPath);
 
 	free(fileContents);
 
@@ -561,7 +552,6 @@ search_path_first(const char *filename, char *result, int logLevel)
 bool
 search_path(const char *filename, SearchPath *result)
 {
-	char *path;
 	char pathlist[MAXPATHSIZE] = { 0 };
 
 	/* we didn't count nor find anything yet */
@@ -574,7 +564,7 @@ search_path(const char *filename, SearchPath *result)
 		return false;
 	}
 
-	path = pathlist;
+	char *path = pathlist;
 
 	while (path != NULL)
 	{
@@ -773,7 +763,6 @@ normalize_filename(const char *filename, char *dst, int size)
 int
 fformat(FILE *stream, const char *fmt, ...)
 {
-	int len;
 	va_list args;
 
 	if (stream == NULL || fmt == NULL)
@@ -783,7 +772,7 @@ fformat(FILE *stream, const char *fmt, ...)
 	}
 
 	va_start(args, fmt);
-	len = pg_vfprintf(stream, fmt, args);
+	int len = pg_vfprintf(stream, fmt, args);
 	va_end(args);
 	return len;
 }
@@ -795,7 +784,6 @@ fformat(FILE *stream, const char *fmt, ...)
 int
 sformat(char *str, size_t count, const char *fmt, ...)
 {
-	int len;
 	va_list args;
 
 	if (str == NULL || fmt == NULL)
@@ -805,7 +793,7 @@ sformat(char *str, size_t count, const char *fmt, ...)
 	}
 
 	va_start(args, fmt);
-	len = pg_vsnprintf(str, count, fmt, args);
+	int len = pg_vsnprintf(str, count, fmt, args);
 	va_end(args);
 
 	if (len >= count)
@@ -870,15 +858,13 @@ init_ps_buffer(int argc, char **argv)
 void
 set_ps_title(const char *title)
 {
-	int n;
-
 	if (ps_buffer == NULL)
 	{
 		/* noop */
 		return;
 	}
 
-	n = sformat(ps_buffer, ps_buffer_size, "%s", title);
+	int n = sformat(ps_buffer, ps_buffer_size, "%s", title);
 
 	/* pad our process title string */
 	for (size_t i = n; i < ps_buffer_size; i++)

--- a/src/bin/pg_autoctl/fsm_transition.c
+++ b/src/bin/pg_autoctl/fsm_transition.c
@@ -64,7 +64,6 @@ fsm_init_primary(Keeper *keeper)
 	KeeperStateInit *initState = &(keeper->initState);
 	PostgresSetup *pgSetup = &(postgres->postgresSetup);
 	bool postgresInstanceExists = pg_setup_pgdata_exists(pgSetup);
-	bool pgInstanceIsOurs = false;
 
 	log_info("Initialising postgres as a primary");
 
@@ -103,7 +102,7 @@ fsm_init_primary(Keeper *keeper)
 		}
 	}
 
-	pgInstanceIsOurs =
+	bool pgInstanceIsOurs =
 		initState->pgInitState == PRE_INIT_STATE_EMPTY ||
 		initState->pgInitState == PRE_INIT_STATE_EXISTS;
 
@@ -848,7 +847,6 @@ fsm_init_standby(Keeper *keeper)
 
 	NodeAddress *primaryNode = NULL;
 
-	bool skipBaseBackup = false;
 
 	/* get the primary node to follow */
 	if (!keeper_get_primary(keeper, &(postgres->replicationSource.primaryNode)))
@@ -883,8 +881,8 @@ fsm_init_standby(Keeper *keeper)
 	 * remove our init file: then we need to pg_basebackup again to init a
 	 * standby.
 	 */
-	skipBaseBackup = file_exists(keeper->config.pathnames.init) &&
-					 keeper->initState.pgInitState == PRE_INIT_STATE_EXISTS;
+	bool skipBaseBackup = file_exists(keeper->config.pathnames.init) &&
+						  keeper->initState.pgInitState == PRE_INIT_STATE_EXISTS;
 
 	if (!standby_init_database(postgres, config->hostname, skipBaseBackup))
 	{

--- a/src/bin/pg_autoctl/ini_file.c
+++ b/src/bin/pg_autoctl/ini_file.c
@@ -24,7 +24,6 @@
 bool
 read_ini_file(const char *filename, IniOption *optionList)
 {
-	ini_t *ini = NULL;
 	char *fileContents = NULL;
 	long fileSize = 0L;
 	IniOption *option;
@@ -36,7 +35,7 @@ read_ini_file(const char *filename, IniOption *optionList)
 	}
 
 	/* parse the content of the file as per INI syntax rules */
-	ini = ini_load(fileContents, NULL);
+	ini_t *ini = ini_load(fileContents, NULL);
 	free(fileContents);
 
 	/*
@@ -45,11 +44,10 @@ read_ini_file(const char *filename, IniOption *optionList)
 	 */
 	for (option = optionList; option->type != INI_END_T; option++)
 	{
-		int sectionIndex;
 		int optionIndex;
 		char *val;
 
-		sectionIndex = ini_find_section(ini, option->section, 0);
+		int sectionIndex = ini_find_section(ini, option->section, 0);
 
 		if (sectionIndex == INI_NOT_FOUND)
 		{
@@ -147,10 +145,9 @@ ini_validate_options(IniOption *optionList)
 
 	for (option = optionList; option->type != INI_END_T; option++)
 	{
-		int n;
 		char optionName[BUFSIZE];
 
-		n = sformat(optionName, BUFSIZE, "%s.%s", option->section, option->name);
+		int n = sformat(optionName, BUFSIZE, "%s.%s", option->section, option->name);
 
 		if (option->optName)
 		{
@@ -552,7 +549,6 @@ IniOption *
 lookup_ini_path_value(IniOption *optionList, const char *path)
 {
 	char *section_name, *option_name, *ptr;
-	IniOption *option;
 
 	/*
 	 * Split path into section/option.
@@ -569,7 +565,7 @@ lookup_ini_path_value(IniOption *optionList, const char *path)
 	option_name = section_name + (ptr - path) + 1; /* apply same offset */
 	*(option_name - 1) = '\0';                     /* split string at the dot */
 
-	option = lookup_ini_option(optionList, section_name, option_name);
+	IniOption *option = lookup_ini_option(optionList, section_name, option_name);
 
 	if (option == NULL)
 	{
@@ -656,8 +652,6 @@ bool
 ini_get_setting(const char *filename, IniOption *optionList,
 				const char *path, char *value, size_t size)
 {
-	IniOption *option = NULL;
-
 	log_debug("Reading configuration from \"%s\"", filename);
 
 	if (!read_ini_file(filename, optionList))
@@ -666,7 +660,7 @@ ini_get_setting(const char *filename, IniOption *optionList,
 		return false;
 	}
 
-	option = lookup_ini_path_value(optionList, path);
+	IniOption *option = lookup_ini_path_value(optionList, path);
 
 	if (option)
 	{

--- a/src/bin/pg_autoctl/ipaddr.c
+++ b/src/bin/pg_autoctl/ipaddr.c
@@ -60,7 +60,6 @@ fetchLocalIPAddress(char *localIpAddress, int size,
 	struct addrinfo *ai;
 	struct addrinfo hints;
 
-	int error = 0;
 	bool couldConnect = false;
 
 	int sock;
@@ -72,10 +71,10 @@ fetchLocalIPAddress(char *localIpAddress, int size,
 	hints.ai_socktype = SOCK_STREAM; /* we only want TCP sockets */
 	hints.ai_protocol = IPPROTO_TCP; /* we only want TCP sockets */
 
-	error = getaddrinfo(serviceName,
-						intToString(servicePort).strValue,
-						&hints,
-						&lookup);
+	int error = getaddrinfo(serviceName,
+							intToString(servicePort).strValue,
+							&hints,
+							&lookup);
 	if (error != 0)
 	{
 		log_warn("Failed to parse host name or IP address \"%s\": %s",
@@ -85,7 +84,6 @@ fetchLocalIPAddress(char *localIpAddress, int size,
 
 	for (ai = lookup; ai; ai = ai->ai_next)
 	{
-		int err = -1;
 		char addr[BUFSIZE] = { 0 };
 
 		if (!ipaddr_sockaddr_to_string(ai, addr, sizeof(addr)))
@@ -105,7 +103,7 @@ fetchLocalIPAddress(char *localIpAddress, int size,
 		/* connect timeout can be quite long by default */
 		log_info("Connecting to %s (port %d)", addr, servicePort);
 
-		err = connect(sock, ai->ai_addr, ai->ai_addrlen);
+		int err = connect(sock, ai->ai_addr, ai->ai_addrlen);
 
 		if (err < 0)
 		{
@@ -464,12 +462,11 @@ ipv6eq(struct sockaddr_in6 *a, struct sockaddr_in6 *b)
 bool
 findHostnameLocalAddress(const char *hostname, char *localIpAddress, int size)
 {
-	int error;
 	struct addrinfo *dns_lookup_addr;
 	struct addrinfo *dns_addr;
 	struct ifaddrs *ifaddrList, *ifaddr;
 
-	error = getaddrinfo(hostname, NULL, 0, &dns_lookup_addr);
+	int error = getaddrinfo(hostname, NULL, 0, &dns_lookup_addr);
 	if (error != 0)
 	{
 		log_warn("Failed to resolve DNS name \"%s\": %s",
@@ -615,12 +612,11 @@ ip_address_type(const char *hostname)
 bool
 findHostnameFromLocalIpAddress(char *localIpAddress, char *hostname, int size)
 {
-	int ret = 0;
 	char hbuf[NI_MAXHOST];
 	struct addrinfo *lookup, *ai;
 
 	/* parse ipv4 or ipv6 address using getaddrinfo() */
-	ret = getaddrinfo(localIpAddress, NULL, 0, &lookup);
+	int ret = getaddrinfo(localIpAddress, NULL, 0, &lookup);
 	if (ret != 0)
 	{
 		log_warn("Failed to resolve DNS name \"%s\": %s",
@@ -673,12 +669,11 @@ findHostnameFromLocalIpAddress(char *localIpAddress, char *hostname, int size)
 bool
 resolveHostnameForwardAndReverse(const char *hostname, char *ipaddr, int size)
 {
-	int error;
 	struct addrinfo *lookup, *ai;
 
 	bool foundHostnameFromAddress = false;
 
-	error = getaddrinfo(hostname, NULL, 0, &lookup);
+	int error = getaddrinfo(hostname, NULL, 0, &lookup);
 	if (error != 0)
 	{
 		log_warn("Failed to resolve DNS name \"%s\": %s",
@@ -689,7 +684,6 @@ resolveHostnameForwardAndReverse(const char *hostname, char *ipaddr, int size)
 	/* loop over the forward DNS results for hostname */
 	for (ai = lookup; ai; ai = ai->ai_next)
 	{
-		int ret;
 		char hbuf[NI_MAXHOST] = { 0 };
 
 		if (!ipaddr_sockaddr_to_string(ai, hbuf, sizeof(hbuf)))
@@ -699,8 +693,8 @@ resolveHostnameForwardAndReverse(const char *hostname, char *ipaddr, int size)
 		}
 
 		/* now reverse lookup (NI_NAMEREQD) the address with getnameinfo() */
-		ret = getnameinfo(ai->ai_addr, ai->ai_addrlen,
-						  hbuf, sizeof(hbuf), NULL, 0, NI_NAMEREQD);
+		int ret = getnameinfo(ai->ai_addr, ai->ai_addrlen,
+							  hbuf, sizeof(hbuf), NULL, 0, NI_NAMEREQD);
 
 		if (ret != 0)
 		{
@@ -769,9 +763,8 @@ ipaddr_getsockname(int sock, char *ipaddr, size_t size)
 	struct sockaddr_storage address = { 0 };
 	socklen_t sockaddrlen = sizeof(address);
 
-	int err = -1;
 
-	err = getsockname(sock, (struct sockaddr *) (&address), &sockaddrlen);
+	int err = getsockname(sock, (struct sockaddr *) (&address), &sockaddrlen);
 	if (err < 0)
 	{
 		log_warn("Failed to get IP address from socket: %m");

--- a/src/bin/pg_autoctl/keeper_config.c
+++ b/src/bin/pg_autoctl/keeper_config.c
@@ -459,19 +459,17 @@ bool
 keeper_config_write_file(KeeperConfig *config)
 {
 	const char *filePath = config->pathnames.config;
-	bool success = false;
-	FILE *fileStream = NULL;
 
 	log_trace("keeper_config_write_file \"%s\"", filePath);
 
-	fileStream = fopen_with_umask(filePath, "w", FOPEN_FLAGS_W, 0644);
+	FILE *fileStream = fopen_with_umask(filePath, "w", FOPEN_FLAGS_W, 0644);
 	if (fileStream == NULL)
 	{
 		/* errors have already been logged */
 		return false;
 	}
 
-	success = keeper_config_write(fileStream, config);
+	bool success = keeper_config_write(fileStream, config);
 
 	if (fclose(fileStream) == EOF)
 	{

--- a/src/bin/pg_autoctl/lock_utils.c
+++ b/src/bin/pg_autoctl/lock_utils.c
@@ -179,7 +179,6 @@ semaphore_cleanup(const char *pidfile)
 	long fileSize = 0L;
 	char *fileContents = NULL;
 	char *fileLines[BUFSIZE] = { 0 };
-	int lineCount = 0;
 
 	if (!file_exists(pidfile))
 	{
@@ -191,7 +190,7 @@ semaphore_cleanup(const char *pidfile)
 		return false;
 	}
 
-	lineCount = splitLines(fileContents, fileLines, BUFSIZE);
+	int lineCount = splitLines(fileContents, fileLines, BUFSIZE);
 
 	if (lineCount < PIDFILE_LINE_SEM_ID)
 	{

--- a/src/bin/pg_autoctl/monitor.c
+++ b/src/bin/pg_autoctl/monitor.c
@@ -1040,7 +1040,6 @@ parseNodeReplicationSettings(void *ctx, PGresult *result)
 {
 	NodeReplicationSettingsParseContext *context =
 		(NodeReplicationSettingsParseContext *) ctx;
-	char *value = NULL;
 	int errors = 0;
 
 	if (PQntuples(result) != 1)
@@ -1057,7 +1056,7 @@ parseNodeReplicationSettings(void *ctx, PGresult *result)
 		return;
 	}
 
-	value = PQgetvalue(result, 0, 0);
+	char *value = PQgetvalue(result, 0, 0);
 	if (!stringToInt(value, &context->candidatePriority))
 	{
 		log_error("Invalid failover candidate priority \"%s\" "
@@ -1363,9 +1362,6 @@ monitor_perform_promotion(Monitor *monitor, char *formation, char *name)
 static bool
 parseNode(PGresult *result, int rowNumber, NodeAddress *node)
 {
-	char *value = NULL;
-	int length = 0;
-
 	if (PQgetisnull(result, rowNumber, 0) ||
 		PQgetisnull(result, rowNumber, 1) ||
 		PQgetisnull(result, rowNumber, 2) ||
@@ -1375,7 +1371,7 @@ parseNode(PGresult *result, int rowNumber, NodeAddress *node)
 		return false;
 	}
 
-	value = PQgetvalue(result, rowNumber, 0);
+	char *value = PQgetvalue(result, rowNumber, 0);
 	node->nodeId = strtol(value, NULL, 0);
 	if (node->nodeId == 0)
 	{
@@ -1384,7 +1380,7 @@ parseNode(PGresult *result, int rowNumber, NodeAddress *node)
 	}
 
 	value = PQgetvalue(result, rowNumber, 1);
-	length = strlcpy(node->name, value, _POSIX_HOST_NAME_MAX);
+	int length = strlcpy(node->name, value, _POSIX_HOST_NAME_MAX);
 	if (length >= _POSIX_HOST_NAME_MAX)
 	{
 		log_error("Node name \"%s\" returned by monitor is %d characters, "
@@ -1510,7 +1506,6 @@ parseNodeState(void *ctx, PGresult *result)
 {
 	MonitorAssignedStateParseContext *context =
 		(MonitorAssignedStateParseContext *) ctx;
-	char *value = NULL;
 	int errors = 0;
 
 	if (PQntuples(result) != 1)
@@ -1531,7 +1526,7 @@ parseNodeState(void *ctx, PGresult *result)
 		return;
 	}
 
-	value = PQgetvalue(result, 0, 0);
+	char *value = PQgetvalue(result, 0, 0);
 
 	if (!stringToInt(value, &context->assignedState->nodeId))
 	{
@@ -1672,8 +1667,6 @@ static bool
 parseCurrentNodeState(PGresult *result, int rowNumber,
 					  CurrentNodeState *nodeState)
 {
-	char *value = NULL;
-	int length = 0;
 	int colNumber = 0;
 	int errors = 0;
 
@@ -1705,8 +1698,8 @@ parseCurrentNodeState(PGresult *result, int rowNumber,
 	 * We need the groupId to parse the formation kind into a nodeKind, so we
 	 * begin at column 1 and get back to column 0 later, after column 4.
 	 */
-	value = PQgetvalue(result, rowNumber, 1);
-	length = strlcpy(nodeState->node.name, value, _POSIX_HOST_NAME_MAX);
+	char *value = PQgetvalue(result, rowNumber, 1);
+	int length = strlcpy(nodeState->node.name, value, _POSIX_HOST_NAME_MAX);
 	if (length >= _POSIX_HOST_NAME_MAX)
 	{
 		log_error("Node name \"%s\" returned by monitor is %d characters, "
@@ -2972,8 +2965,6 @@ static void
 parseCoordinatorNode(void *ctx, PGresult *result)
 {
 	NodeAddressParseContext *context = (NodeAddressParseContext *) ctx;
-	char *value = NULL;
-	int hostLength = 0;
 
 	/* no rows, set the node to NULL, return */
 	if (PQntuples(result) == 0)
@@ -3005,8 +2996,8 @@ parseCoordinatorNode(void *ctx, PGresult *result)
 		return;
 	}
 
-	value = PQgetvalue(result, 0, 0);
-	hostLength = strlcpy(context->node->host, value, _POSIX_HOST_NAME_MAX);
+	char *value = PQgetvalue(result, 0, 0);
+	int hostLength = strlcpy(context->node->host, value, _POSIX_HOST_NAME_MAX);
 	if (hostLength >= _POSIX_HOST_NAME_MAX)
 	{
 		log_error("Hostname \"%s\" returned by monitor is %d characters, "
@@ -3142,8 +3133,6 @@ monitor_process_notifications(Monitor *monitor,
 	PGconn *connection = monitor->pgsql.connection;
 	PGnotify *notify;
 
-	int ret;
-	int sock;
 
 	sigset_t sig_mask;
 	sigset_t sig_mask_orig;
@@ -3196,7 +3185,7 @@ monitor_process_notifications(Monitor *monitor,
 	 *
 	 * https://www.postgresql.org/docs/current/libpq-example.html#LIBPQ-EXAMPLE-2
 	 */
-	sock = PQsocket(monitor->pgsql.connection);
+	int sock = PQsocket(monitor->pgsql.connection);
 
 	if (sock < 0)
 	{
@@ -3209,7 +3198,7 @@ monitor_process_notifications(Monitor *monitor,
 	FD_ZERO(&input_mask);
 	FD_SET(sock, &input_mask);
 
-	ret = pselect(sock + 1, &input_mask, NULL, NULL, &timeout, &sig_mask_orig);
+	int ret = pselect(sock + 1, &input_mask, NULL, NULL, &timeout, &sig_mask_orig);
 
 	/* restore signal masks (un block them) now that pselect() is done */
 	(void) unblock_signals(&sig_mask_orig);
@@ -3719,8 +3708,6 @@ parseExtensionVersion(void *ctx, PGresult *result)
 	MonitorExtensionVersionParseContext *context =
 		(MonitorExtensionVersionParseContext *) ctx;
 
-	char *value = NULL;
-	int length = -1;
 
 	/* we have rows: we accept only one */
 	if (PQntuples(result) != 1)
@@ -3745,8 +3732,8 @@ parseExtensionVersion(void *ctx, PGresult *result)
 		return;
 	}
 
-	value = PQgetvalue(result, 0, 0);
-	length = strlcpy(context->version->defaultVersion, value, BUFSIZE);
+	char *value = PQgetvalue(result, 0, 0);
+	int length = strlcpy(context->version->defaultVersion, value, BUFSIZE);
 	if (length >= BUFSIZE)
 	{
 		log_error("default_version \"%s\" returned by monitor is %d characters, "

--- a/src/bin/pg_autoctl/monitor_config.c
+++ b/src/bin/pg_autoctl/monitor_config.c
@@ -318,19 +318,17 @@ bool
 monitor_config_write_file(MonitorConfig *config)
 {
 	const char *filePath = config->pathnames.config;
-	bool success = false;
-	FILE *fileStream = NULL;
 
 	log_trace("monitor_config_write_file \"%s\"", filePath);
 
-	fileStream = fopen_with_umask(filePath, "w", FOPEN_FLAGS_W, 0644);
+	FILE *fileStream = fopen_with_umask(filePath, "w", FOPEN_FLAGS_W, 0644);
 	if (fileStream == NULL)
 	{
 		/* errors have already been logged */
 		return false;
 	}
 
-	success = monitor_config_write(fileStream, config);
+	bool success = monitor_config_write(fileStream, config);
 
 	if (fclose(fileStream) == EOF)
 	{

--- a/src/bin/pg_autoctl/parsing.c
+++ b/src/bin/pg_autoctl/parsing.c
@@ -47,17 +47,15 @@ char *
 regexp_first_match(const char *string, const char *regex)
 {
 	regex_t compiledRegex;
-	int status = 0;
 
 	regmatch_t m[RE_MATCH_COUNT];
-	int matchStatus;
 
 	if (string == NULL)
 	{
 		return NULL;
 	}
 
-	status = regcomp(&compiledRegex, regex, REG_EXTENDED | REG_NEWLINE);
+	int status = regcomp(&compiledRegex, regex, REG_EXTENDED | REG_NEWLINE);
 
 	if (status != 0)
 	{
@@ -85,7 +83,7 @@ regexp_first_match(const char *string, const char *regex)
 	 * regexec returns 0 if the regular expression matches; otherwise, it
 	 * returns a nonzero value.
 	 */
-	matchStatus = regexec(&compiledRegex, string, RE_MATCH_COUNT, m, 0);
+	int matchStatus = regexec(&compiledRegex, string, RE_MATCH_COUNT, m, 0);
 	regfree(&compiledRegex);
 
 	/* We're interested into 1. re matches 2. captured at least one group */
@@ -171,10 +169,9 @@ parse_controldata_field_uint32(const char *controlDataString,
 							   uint32_t *dest)
 {
 	char regex[BUFSIZE];
-	char *match;
 
 	sformat(regex, BUFSIZE, "^%s: *([0-9]+)$", fieldName);
-	match = regexp_first_match(controlDataString, regex);
+	char *match = regexp_first_match(controlDataString, regex);
 
 	if (match == NULL)
 	{
@@ -204,10 +201,9 @@ parse_controldata_field_uint64(const char *controlDataString,
 							   uint64_t *dest)
 {
 	char regex[BUFSIZE];
-	char *match;
 
 	sformat(regex, BUFSIZE, "^%s: *([0-9]+)$", fieldName);
-	match = regexp_first_match(controlDataString, regex);
+	char *match = regexp_first_match(controlDataString, regex);
 
 	if (match == NULL)
 	{
@@ -237,10 +233,9 @@ parse_controldata_field_lsn(const char *controlDataString,
 							char lsn[])
 {
 	char regex[BUFSIZE];
-	char *match;
 
 	sformat(regex, BUFSIZE, "^%s: *([0-9A-F]+/[0-9A-F]+)$", fieldName);
-	match = regexp_first_match(controlDataString, regex);
+	char *match = regexp_first_match(controlDataString, regex);
 
 	if (match == NULL)
 	{
@@ -264,8 +259,6 @@ bool
 parse_state_notification_message(CurrentNodeState *nodeState,
 								 const char *message)
 {
-	char *str;
-	double number;
 	JSON_Value *json = json_parse_string(message);
 	JSON_Object *jsobj = json_value_get_object(json);
 
@@ -277,7 +270,7 @@ parse_state_notification_message(CurrentNodeState *nodeState,
 		return false;
 	}
 
-	str = (char *) json_object_get_string(jsobj, "type");
+	char *str = (char *) json_object_get_string(jsobj, "type");
 
 	if (strcmp(str, "state") != 0)
 	{
@@ -296,7 +289,7 @@ parse_state_notification_message(CurrentNodeState *nodeState,
 	}
 	strlcpy(nodeState->formation, str, sizeof(nodeState->formation));
 
-	number = json_object_get_number(jsobj, "groupId");
+	double number = json_object_get_number(jsobj, "groupId");
 	nodeState->groupId = (int) number;
 
 	number = json_object_get_number(jsobj, "nodeId");
@@ -746,8 +739,6 @@ parseNodesArray(const char *nodesJSON,
 				NodeAddressArray *nodesArray,
 				int nodeId)
 {
-	JSON_Value *json = NULL;
-	JSON_Array *jsArray = NULL;
 	JSON_Value *template =
 		json_parse_string("[{"
 						  "\"node_id\": 0,"
@@ -757,11 +748,10 @@ parseNodesArray(const char *nodesJSON,
 						  "\"node_port\": 0,"
 						  "\"node_is_primary\": false"
 						  "}]");
-	int len = -1;
 	int nodesArrayIndex = 0;
 	int primaryCount = 0;
 
-	json = json_parse_string(nodesJSON);
+	JSON_Value *json = json_parse_string(nodesJSON);
 
 	/* validate the JSON input as an array of object with required fields */
 	if (json_validate(template, json) == JSONFailure)
@@ -774,8 +764,8 @@ parseNodesArray(const char *nodesJSON,
 		return false;
 	}
 
-	jsArray = json_value_get_array(json);
-	len = json_array_get_count(jsArray);
+	JSON_Array *jsArray = json_value_get_array(json);
+	int len = json_array_get_count(jsArray);
 
 	if (NODE_ARRAY_MAX_COUNT < len)
 	{

--- a/src/bin/pg_autoctl/pghba.c
+++ b/src/bin/pg_autoctl/pghba.c
@@ -110,9 +110,7 @@ pghba_ensure_host_rule_exists(const char *hbaFilePath,
 {
 	char *currentHbaContents = NULL;
 	long currentHbaSize = 0L;
-	char *includeLine = NULL;
 	PQExpBuffer hbaLineBuffer = createPQExpBuffer();
-	PQExpBuffer newHbaContents = NULL;
 
 	if (hbaLineBuffer == NULL)
 	{
@@ -149,7 +147,7 @@ pghba_ensure_host_rule_exists(const char *hbaFilePath,
 		return false;
 	}
 
-	includeLine = strstr(currentHbaContents, hbaLineBuffer->data);
+	char *includeLine = strstr(currentHbaContents, hbaLineBuffer->data);
 
 	/*
 	 * If the rule was found and it starts on a new line. We can
@@ -191,7 +189,7 @@ pghba_ensure_host_rule_exists(const char *hbaFilePath,
 	(void) pghba_check_hostname(host);
 
 	/* build the new postgresql.conf contents */
-	newHbaContents = createPQExpBuffer();
+	PQExpBuffer newHbaContents = createPQExpBuffer();
 	if (newHbaContents == NULL)
 	{
 		log_error("Failed to allocate memory");

--- a/src/bin/pg_autoctl/pgsetup.c
+++ b/src/bin/pg_autoctl/pgsetup.c
@@ -50,7 +50,6 @@ pg_setup_init(PostgresSetup *pgSetup,
 			  bool missing_pgdata_is_ok,
 			  bool pg_is_not_running_is_ok)
 {
-	bool pgIsReady = false;
 	int errors = 0;
 
 	/*
@@ -203,7 +202,7 @@ pg_setup_init(PostgresSetup *pgSetup,
 	 * Read the postmaster.pid file to find out pid, port and unix socket
 	 * directory of a running PostgreSQL instance.
 	 */
-	pgIsReady = pg_setup_is_ready(pgSetup, pg_is_not_running_is_ok);
+	bool pgIsReady = pg_setup_is_ready(pgSetup, pg_is_not_running_is_ok);
 
 	if (!pgIsReady && !pg_is_not_running_is_ok)
 	{
@@ -533,8 +532,6 @@ read_pg_pidfile(PostgresSetup *pgSetup, bool pgIsNotRunningIsOk, int maxRetries)
 
 	for (lineno = 1; lineno <= LOCK_FILE_LINE_PM_STATUS; lineno++)
 	{
-		int lineLength = -1;
-
 		if (fgets(line, sizeof(line), fp) == NULL)
 		{
 			/* later lines are added during start-up, will appear later */
@@ -566,7 +563,7 @@ read_pg_pidfile(PostgresSetup *pgSetup, bool pgIsNotRunningIsOk, int maxRetries)
 			}
 		}
 
-		lineLength = strlen(line);
+		int lineLength = strlen(line);
 
 		/* chomp the ending Newline (\n) */
 		if (lineLength > 0)
@@ -1310,8 +1307,6 @@ pg_setup_role(PostgresSetup *pgSetup)
 char *
 pg_setup_get_username(PostgresSetup *pgSetup)
 {
-	uid_t uid;
-	struct passwd *pw;
 	char userEnv[NAMEDATALEN];
 
 	/* use a configured username if provided */
@@ -1323,8 +1318,8 @@ pg_setup_get_username(PostgresSetup *pgSetup)
 	log_trace("username not configured");
 
 	/* use the passwd file to find the username, same as whoami */
-	uid = geteuid();
-	pw = getpwuid(uid);
+	uid_t uid = geteuid();
+	struct passwd *pw = getpwuid(uid);
 	if (pw)
 	{
 		log_trace("username found in passwd: %s", pw->pw_name);

--- a/src/bin/pg_autoctl/pidfile.c
+++ b/src/bin/pg_autoctl/pidfile.c
@@ -51,7 +51,6 @@ create_pidfile(const char *pidfile, pid_t pid)
 {
 	PQExpBuffer content = createPQExpBuffer();
 
-	bool success = false;
 
 	log_trace("create_pidfile(%d): \"%s\"", pid, pidfile);
 
@@ -77,7 +76,7 @@ create_pidfile(const char *pidfile, pid_t pid)
 		return false;
 	}
 
-	success = write_file(content->data, content->len, pidfile);
+	bool success = write_file(content->data, content->len, pidfile);
 	destroyPQExpBuffer(content);
 
 	return success;
@@ -304,7 +303,6 @@ read_service_pidfile_version_strings(const char *pidfile,
 	long fileSize = 0L;
 	char *fileContents = NULL;
 	char *fileLines[BUFSIZE] = { 0 };
-	int lineCount = 0;
 	int lineNumber;
 
 	if (!read_file_if_exists(pidfile, &fileContents, &fileSize))
@@ -312,7 +310,7 @@ read_service_pidfile_version_strings(const char *pidfile,
 		return false;
 	}
 
-	lineCount = splitLines(fileContents, fileLines, BUFSIZE);
+	int lineCount = splitLines(fileContents, fileLines, BUFSIZE);
 
 	for (lineNumber = 0; lineNumber < lineCount; lineNumber++)
 	{
@@ -357,7 +355,6 @@ pidfile_as_json(JSON_Value *js, const char *pidfile, bool includeStatus)
 	long fileSize = 0L;
 	char *fileContents = NULL;
 	char *fileLines[BUFSIZE] = { 0 };
-	int lineCount = 0;
 	int lineNumber;
 
 	if (!read_file_if_exists(pidfile, &fileContents, &fileSize))
@@ -365,7 +362,7 @@ pidfile_as_json(JSON_Value *js, const char *pidfile, bool includeStatus)
 		exit(EXIT_CODE_INTERNAL_ERROR);
 	}
 
-	lineCount = splitLines(fileContents, fileLines, BUFSIZE);
+	int lineCount = splitLines(fileContents, fileLines, BUFSIZE);
 
 	for (lineNumber = 0; lineNumber < lineCount; lineNumber++)
 	{

--- a/src/bin/pg_autoctl/primary_standby.c
+++ b/src/bin/pg_autoctl/primary_standby.c
@@ -406,12 +406,11 @@ ensure_postgres_service_is_stopped(LocalPostgresServer *postgres)
 bool
 primary_has_replica(LocalPostgresServer *postgres, char *userName, bool *hasStandby)
 {
-	bool result = false;
 	PGSQL *pgsql = &(postgres->sqlClient);
 
 	log_trace("primary_has_replica");
 
-	result = pgsql_has_replica(pgsql, userName, hasStandby);
+	bool result = pgsql_has_replica(pgsql, userName, hasStandby);
 
 	pgsql_finish(pgsql);
 	return result;
@@ -476,11 +475,10 @@ primary_create_replication_slot(LocalPostgresServer *postgres,
 								char *replicationSlotName)
 {
 	PGSQL *pgsql = &(postgres->sqlClient);
-	bool result = false;
 
 	log_trace("primary_create_replication_slot(%s)", replicationSlotName);
 
-	result = pgsql_create_replication_slot(pgsql, replicationSlotName);
+	bool result = pgsql_create_replication_slot(pgsql, replicationSlotName);
 
 	pgsql_finish(pgsql);
 	return result;
@@ -495,12 +493,11 @@ bool
 primary_drop_replication_slot(LocalPostgresServer *postgres,
 							  char *replicationSlotName)
 {
-	bool result = false;
 	PGSQL *pgsql = &(postgres->sqlClient);
 
 	log_trace("primary_drop_replication_slot");
 
-	result = pgsql_drop_replication_slot(pgsql, replicationSlotName);
+	bool result = pgsql_drop_replication_slot(pgsql, replicationSlotName);
 
 	pgsql_finish(pgsql);
 	return result;
@@ -516,12 +513,11 @@ bool
 postgres_replication_slot_create_and_drop(LocalPostgresServer *postgres,
 										  NodeAddressArray *nodeArray)
 {
-	bool result = false;
 	PGSQL *pgsql = &(postgres->sqlClient);
 
 	log_trace("postgres_replication_slot_drop_removed");
 
-	result = pgsql_replication_slot_create_and_drop(pgsql, nodeArray);
+	bool result = pgsql_replication_slot_create_and_drop(pgsql, nodeArray);
 
 	pgsql_finish(pgsql);
 	return result;
@@ -536,12 +532,11 @@ bool
 postgres_replication_slot_maintain(LocalPostgresServer *postgres,
 								   NodeAddressArray *nodeArray)
 {
-	bool result = false;
 	PGSQL *pgsql = &(postgres->sqlClient);
 
 	log_trace("postgres_replication_slot_maintain");
 
-	result = pgsql_replication_slot_maintain(pgsql, nodeArray);
+	bool result = pgsql_replication_slot_maintain(pgsql, nodeArray);
 
 	pgsql_finish(pgsql);
 	return result;
@@ -555,13 +550,12 @@ postgres_replication_slot_maintain(LocalPostgresServer *postgres,
 bool
 primary_set_synchronous_standby_names(LocalPostgresServer *postgres)
 {
-	bool result = false;
 	PGSQL *pgsql = &(postgres->sqlClient);
 
 	log_info("Setting synchronous_standby_names to '%s'",
 			 postgres->synchronousStandbyNames);
 
-	result =
+	bool result =
 		pgsql_set_synchronous_standby_names(pgsql,
 											postgres->synchronousStandbyNames);
 
@@ -577,12 +571,11 @@ primary_set_synchronous_standby_names(LocalPostgresServer *postgres)
 bool
 primary_enable_synchronous_replication(LocalPostgresServer *postgres)
 {
-	bool result = false;
 	PGSQL *pgsql = &(postgres->sqlClient);
 
 	log_trace("primary_enable_synchronous_replication");
 
-	result = pgsql_enable_synchronous_replication(pgsql);
+	bool result = pgsql_enable_synchronous_replication(pgsql);
 
 	pgsql_finish(pgsql);
 	return result;
@@ -596,12 +589,11 @@ primary_enable_synchronous_replication(LocalPostgresServer *postgres)
 bool
 primary_disable_synchronous_replication(LocalPostgresServer *postgres)
 {
-	bool result = false;
 	PGSQL *pgsql = &(postgres->sqlClient);
 
 	log_trace("primary_disable_synchronous_replication");
 
-	result = pgsql_disable_synchronous_replication(pgsql);
+	bool result = pgsql_disable_synchronous_replication(pgsql);
 
 	pgsql_finish(pgsql);
 	return result;
@@ -750,7 +742,6 @@ primary_create_replication_user(LocalPostgresServer *postgres,
 								char *replicationUsername,
 								char *replicationPassword)
 {
-	bool result = false;
 	PGSQL *pgsql = &(postgres->sqlClient);
 	bool login = true;
 	bool superuser = true;
@@ -759,8 +750,8 @@ primary_create_replication_user(LocalPostgresServer *postgres,
 
 	log_trace("primary_create_replication_user");
 
-	result = pgsql_create_user(pgsql, replicationUsername, replicationPassword,
-							   login, superuser, replication, connlimit);
+	bool result = pgsql_create_user(pgsql, replicationUsername, replicationPassword,
+									login, superuser, replication, connlimit);
 
 	pgsql_finish(pgsql);
 
@@ -1122,13 +1113,12 @@ standby_promote(LocalPostgresServer *postgres)
 bool
 check_postgresql_settings(LocalPostgresServer *postgres, bool *settings_are_ok)
 {
-	bool result = false;
 	PGSQL *pgsql = &(postgres->sqlClient);
 	bool isCitusInstanceKind = IS_CITUS_INSTANCE_KIND(postgres->pgKind);
 
-	result = pgsql_check_postgresql_settings(pgsql,
-											 isCitusInstanceKind,
-											 settings_are_ok);
+	bool result = pgsql_check_postgresql_settings(pgsql,
+												  isCitusInstanceKind,
+												  settings_are_ok);
 
 	pgsql_finish(pgsql);
 	return result;

--- a/src/bin/pg_autoctl/service_keeper.c
+++ b/src/bin/pg_autoctl/service_keeper.c
@@ -90,14 +90,13 @@ bool
 service_keeper_start(void *context, pid_t *pid)
 {
 	Keeper *keeper = (Keeper *) context;
-	pid_t fpid;
 
 	/* Flush stdio channels just before fork, to avoid double-output problems */
 	fflush(stdout);
 	fflush(stderr);
 
 	/* time to create the node_active sub-process */
-	fpid = fork();
+	pid_t fpid = fork();
 
 	switch (fpid)
 	{
@@ -141,8 +140,6 @@ service_keeper_start(void *context, pid_t *pid)
 void
 service_keeper_runprogram(Keeper *keeper)
 {
-	Program program;
-
 	char *args[12];
 	int argsIndex = 0;
 
@@ -172,7 +169,7 @@ service_keeper_runprogram(Keeper *keeper)
 	args[argsIndex] = NULL;
 
 	/* we do not want to call setsid() when running this program. */
-	program = initialize_program(args, false);
+	Program program = initialize_program(args, false);
 
 	program.capture = false;    /* redirect output, don't capture */
 	program.stdOutFd = STDOUT_FILENO;

--- a/src/bin/pg_autoctl/service_keeper_init.c
+++ b/src/bin/pg_autoctl/service_keeper_init.c
@@ -83,14 +83,13 @@ service_keeper_init_start(void *context, pid_t *pid)
 	Keeper *keeper = (Keeper *) context;
 	KeeperConfig *config = &(keeper->config);
 
-	pid_t fpid = -1;
 
 	/* Flush stdio channels just before fork, to avoid double-output problems */
 	fflush(stdout);
 	fflush(stderr);
 
 	/* time to create the node_active sub-process */
-	fpid = fork();
+	pid_t fpid = fork();
 
 	switch (fpid)
 	{

--- a/src/bin/pg_autoctl/service_monitor.c
+++ b/src/bin/pg_autoctl/service_monitor.c
@@ -80,14 +80,13 @@ bool
 service_monitor_start(void *context, pid_t *pid)
 {
 	Monitor *monitor = (Monitor *) context;
-	pid_t fpid;
 
 	/* Flush stdio channels just before fork, to avoid double-output problems */
 	fflush(stdout);
 	fflush(stderr);
 
 	/* time to create the node_active sub-process */
-	fpid = fork();
+	pid_t fpid = fork();
 
 	switch (fpid)
 	{
@@ -131,8 +130,6 @@ service_monitor_start(void *context, pid_t *pid)
 void
 service_monitor_runprogram(Monitor *monitor)
 {
-	Program program;
-
 	char *args[12];
 	int argsIndex = 0;
 
@@ -174,7 +171,7 @@ service_monitor_runprogram(Monitor *monitor)
 	args[argsIndex] = NULL;
 
 	/* we do not want to call setsid() when running this program. */
-	program = initialize_program(args, false);
+	Program program = initialize_program(args, false);
 
 	program.capture = false;    /* redirect output, don't capture */
 	program.stdOutFd = STDOUT_FILENO;

--- a/src/bin/pg_autoctl/service_monitor_init.c
+++ b/src/bin/pg_autoctl/service_monitor_init.c
@@ -101,14 +101,13 @@ service_monitor_init_start(void *context, pid_t *pid)
 	MonitorConfig *config = &monitor->config;
 	PostgresSetup *pgSetup = &config->pgSetup;
 
-	pid_t fpid;
 
 	/* Flush stdio channels just before fork, to avoid double-output problems */
 	fflush(stdout);
 	fflush(stderr);
 
 	/* time to create the node_active sub-process */
-	fpid = fork();
+	pid_t fpid = fork();
 
 	switch (fpid)
 	{

--- a/src/bin/pg_autoctl/service_postgres.c
+++ b/src/bin/pg_autoctl/service_postgres.c
@@ -41,14 +41,13 @@ bool
 service_postgres_start(void *context, pid_t *pid)
 {
 	PostgresSetup *pgSetup = (PostgresSetup *) context;
-	pid_t fpid;
 
 	/* Flush stdio channels just before fork, to avoid double-output problems */
 	fflush(stdout);
 	fflush(stderr);
 
 	/* time to create the node_active sub-process */
-	fpid = fork();
+	pid_t fpid = fork();
 
 	switch (fpid)
 	{
@@ -79,7 +78,6 @@ service_postgres_start(void *context, pid_t *pid)
 		{
 			int timeout = 10;   /* wait for Postgres for 10s */
 			int logLevel = ++countPostgresStart == 1 ? LOG_INFO : LOG_DEBUG;
-			bool pgIsReady = false;
 
 			log_debug("pg_autoctl started postgres in subprocess %d", fpid);
 			*pid = fpid;
@@ -87,7 +85,7 @@ service_postgres_start(void *context, pid_t *pid)
 			/* we're starting postgres, reset the cached value for the pid */
 			pgSetup->pidFile.pid = 0;
 
-			pgIsReady =
+			bool pgIsReady =
 				pg_setup_wait_until_is_ready(pgSetup, timeout, logLevel);
 
 			/*

--- a/src/bin/pg_autoctl/service_postgres_ctl.c
+++ b/src/bin/pg_autoctl/service_postgres_ctl.c
@@ -51,14 +51,12 @@ static bool ensure_postgres_status_running(LocalPostgresServer *postgres,
 bool
 service_postgres_ctl_start(void *context, pid_t *pid)
 {
-	pid_t fpid;
-
 	/* Flush stdio channels just before fork, to avoid double-output problems */
 	fflush(stdout);
 	fflush(stderr);
 
 	/* time to create the node_active sub-process */
-	fpid = fork();
+	pid_t fpid = fork();
 
 	switch (fpid)
 	{
@@ -99,8 +97,6 @@ service_postgres_ctl_start(void *context, pid_t *pid)
 void
 service_postgres_ctl_runprogram()
 {
-	Program program;
-
 	char *args[12];
 	int argsIndex = 0;
 
@@ -144,7 +140,7 @@ service_postgres_ctl_runprogram()
 	args[argsIndex] = NULL;
 
 	/* we do not want to call setsid() when running this program. */
-	program = initialize_program(args, false);
+	Program program = initialize_program(args, false);
 
 	program.capture = false;    /* redirect output, don't capture */
 	program.stdOutFd = STDOUT_FILENO;
@@ -193,7 +189,6 @@ service_postgres_ctl_loop(LocalPostgresServer *postgres)
 
 	for (;;)
 	{
-		pid_t pid;
 		int status;
 
 		/* we might have to reload, pass the signal down */
@@ -229,7 +224,7 @@ service_postgres_ctl_loop(LocalPostgresServer *postgres)
 		 * process and thus is responsible for calling waitpid() from time to
 		 * time.
 		 */
-		pid = waitpid(-1, &status, WNOHANG);
+		pid_t pid = waitpid(-1, &status, WNOHANG);
 
 		switch (pid)
 		{

--- a/src/bin/pg_autoctl/state.c
+++ b/src/bin/pg_autoctl/state.c
@@ -45,7 +45,6 @@ keeper_state_read(KeeperStateData *keeperState, const char *filename)
 {
 	char *content = NULL;
 	long fileSize;
-	int pg_autoctl_state_version = 0;
 
 	log_debug("Reading current state from \"%s\"", filename);
 
@@ -55,7 +54,7 @@ keeper_state_read(KeeperStateData *keeperState, const char *filename)
 		return false;
 	}
 
-	pg_autoctl_state_version =
+	int pg_autoctl_state_version =
 		((KeeperStateData *) content)->pg_autoctl_state_version;
 
 	if (fileSize >= sizeof(KeeperStateData) &&
@@ -96,7 +95,6 @@ keeper_state_is_readable(int pg_autoctl_state_version)
 bool
 keeper_state_write(KeeperStateData *keeperState, const char *filename)
 {
-	int fd;
 	char buffer[PG_AUTOCTL_KEEPER_STATE_FILE_SIZE];
 	char tempFileName[MAXPGPATH];
 
@@ -140,7 +138,7 @@ keeper_state_write(KeeperStateData *keeperState, const char *filename)
 	 */
 	memcpy(buffer, keeperState, sizeof(KeeperStateData)); /* IGNORE-BANNED */
 
-	fd = open(tempFileName, O_RDWR | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR);
+	int fd = open(tempFileName, O_RDWR | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR);
 	if (fd < 0)
 	{
 		log_fatal("Failed to create keeper state file \"%s\": %m",
@@ -587,13 +585,12 @@ NodeStateFromString(const char *str)
 const char *
 epoch_to_string(uint64_t seconds, char *buffer)
 {
-	char *result = NULL;
 	if (seconds <= 0)
 	{
 		strlcpy(buffer, "0", MAXCTIMESIZE);
 		return buffer;
 	}
-	result = ctime_r((time_t *) &seconds, buffer);
+	char *result = ctime_r((time_t *) &seconds, buffer);
 
 	if (result == NULL)
 	{
@@ -687,7 +684,6 @@ keeper_init_state_create(KeeperStateInit *initState,
 static bool
 keeper_init_state_write(KeeperStateInit *initState, const char *filename)
 {
-	int fd;
 	char buffer[PG_AUTOCTL_KEEPER_STATE_FILE_SIZE] = { 0 };
 
 	memset(buffer, 0, PG_AUTOCTL_KEEPER_STATE_FILE_SIZE);
@@ -703,7 +699,7 @@ keeper_init_state_write(KeeperStateInit *initState, const char *filename)
 	 */
 	memcpy(buffer, initState, sizeof(KeeperStateInit)); /* IGNORE-BANNED */
 
-	fd = open(filename, O_RDWR | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR);
+	int fd = open(filename, O_RDWR | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR);
 	if (fd < 0)
 	{
 		log_fatal("Failed to create keeper init state file \"%s\": %m",
@@ -790,7 +786,6 @@ keeper_init_state_read(KeeperStateInit *initState, const char *filename)
 {
 	char *content = NULL;
 	long fileSize;
-	int pg_autoctl_state_version = 0;
 
 	log_debug("Reading current init state from \"%s\"", filename);
 
@@ -800,7 +795,7 @@ keeper_init_state_read(KeeperStateInit *initState, const char *filename)
 		return false;
 	}
 
-	pg_autoctl_state_version =
+	int pg_autoctl_state_version =
 		((KeeperStateInit *) content)->pg_autoctl_state_version;
 
 	if (fileSize >= sizeof(KeeperStateInit) &&
@@ -938,7 +933,6 @@ static bool
 keeper_postgres_state_write(KeeperStatePostgres *pgStatus,
 							const char *filename)
 {
-	int fd;
 	char buffer[PG_AUTOCTL_KEEPER_STATE_FILE_SIZE] = { 0 };
 
 	log_trace("keeper_postgres_state_write %s in %s",
@@ -958,7 +952,7 @@ keeper_postgres_state_write(KeeperStatePostgres *pgStatus,
 	 */
 	memcpy(buffer, pgStatus, sizeof(KeeperStatePostgres)); /* IGNORE-BANNED */
 
-	fd = open(filename, O_RDWR | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
+	int fd = open(filename, O_RDWR | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
 	if (fd < 0)
 	{
 		log_fatal(
@@ -1003,7 +997,6 @@ keeper_postgres_state_read(KeeperStatePostgres *pgStatus, const char *filename)
 {
 	char *content = NULL;
 	long fileSize;
-	int pg_autoctl_state_version = 0;
 
 	if (!read_file(filename, &content, &fileSize))
 	{
@@ -1012,7 +1005,7 @@ keeper_postgres_state_read(KeeperStatePostgres *pgStatus, const char *filename)
 		return false;
 	}
 
-	pg_autoctl_state_version =
+	int pg_autoctl_state_version =
 		((KeeperStatePostgres *) content)->pg_autoctl_state_version;
 
 	if (fileSize >= sizeof(KeeperStateInit) &&

--- a/src/bin/pg_autoctl/string_utils.c
+++ b/src/bin/pg_autoctl/string_utils.c
@@ -48,7 +48,6 @@ bool
 stringToInt(const char *str, int *number)
 {
 	char *endptr;
-	long long int n;
 
 	if (str == NULL)
 	{
@@ -62,7 +61,7 @@ stringToInt(const char *str, int *number)
 
 	errno = 0;
 
-	n = strtoll(str, &endptr, 10);
+	long long int n = strtoll(str, &endptr, 10);
 
 	if (str == endptr)
 	{
@@ -95,7 +94,6 @@ bool
 stringToInt64(const char *str, int64_t *number)
 {
 	char *endptr;
-	long long int n;
 
 	if (str == NULL)
 	{
@@ -109,7 +107,7 @@ stringToInt64(const char *str, int64_t *number)
 
 	errno = 0;
 
-	n = strtoll(str, &endptr, 10);
+	long long int n = strtoll(str, &endptr, 10);
 
 	if (str == endptr)
 	{
@@ -142,7 +140,6 @@ bool
 stringToUInt(const char *str, unsigned int *number)
 {
 	char *endptr;
-	unsigned long long n = 0;
 
 	if (str == NULL)
 	{
@@ -155,7 +152,7 @@ stringToUInt(const char *str, unsigned int *number)
 	}
 
 	errno = 0;
-	n = strtoull(str, &endptr, 10);
+	unsigned long long n = strtoull(str, &endptr, 10);
 
 	if (str == endptr)
 	{
@@ -188,7 +185,6 @@ bool
 stringToUInt64(const char *str, uint64_t *number)
 {
 	char *endptr;
-	unsigned long long n = 0;
 
 	if (str == NULL)
 	{
@@ -201,7 +197,7 @@ stringToUInt64(const char *str, uint64_t *number)
 	}
 
 	errno = 0;
-	n = strtoull(str, &endptr, 10);
+	unsigned long long n = strtoull(str, &endptr, 10);
 
 	if (str == endptr)
 	{
@@ -234,7 +230,6 @@ bool
 stringToShort(const char *str, short *number)
 {
 	char *endptr;
-	long long int n;
 
 	if (str == NULL)
 	{
@@ -248,7 +243,7 @@ stringToShort(const char *str, short *number)
 
 	errno = 0;
 
-	n = strtoll(str, &endptr, 10);
+	long long int n = strtoll(str, &endptr, 10);
 
 	if (str == endptr)
 	{
@@ -281,7 +276,6 @@ bool
 stringToUShort(const char *str, unsigned short *number)
 {
 	char *endptr;
-	unsigned long long n = 0;
 
 	if (str == NULL)
 	{
@@ -294,7 +288,7 @@ stringToUShort(const char *str, unsigned short *number)
 	}
 
 	errno = 0;
-	n = strtoull(str, &endptr, 10);
+	unsigned long long n = strtoull(str, &endptr, 10);
 
 	if (str == endptr)
 	{
@@ -327,7 +321,6 @@ bool
 stringToInt32(const char *str, int32_t *number)
 {
 	char *endptr;
-	long long int n;
 
 	if (str == NULL)
 	{
@@ -341,7 +334,7 @@ stringToInt32(const char *str, int32_t *number)
 
 	errno = 0;
 
-	n = strtoll(str, &endptr, 10);
+	long long int n = strtoll(str, &endptr, 10);
 
 	if (str == endptr)
 	{
@@ -374,7 +367,6 @@ bool
 stringToUInt32(const char *str, uint32_t *number)
 {
 	char *endptr;
-	unsigned long long n = 0;
 
 	if (str == NULL)
 	{
@@ -387,7 +379,7 @@ stringToUInt32(const char *str, uint32_t *number)
 	}
 
 	errno = 0;
-	n = strtoull(str, &endptr, 10);
+	unsigned long long n = strtoull(str, &endptr, 10);
 
 	if (str == endptr)
 	{

--- a/src/bin/pg_autoctl/supervisor.c
+++ b/src/bin/pg_autoctl/supervisor.c
@@ -96,11 +96,10 @@ supervisor_start(Service services[], int serviceCount, const char *pidfile)
 	for (serviceIndex = 0; serviceIndex < serviceCount; serviceIndex++)
 	{
 		Service *service = &(services[serviceIndex]);
-		bool started = false;
 
 		log_debug("Starting pg_autoctl %s service", service->name);
 
-		started = (*service->startFunction)(service->context, &(service->pid));
+		bool started = (*service->startFunction)(service->context, &(service->pid));
 
 		if (started)
 		{
@@ -624,7 +623,6 @@ supervisor_restart_service(Supervisor *supervisor, Service *service, int status)
 	int returnCode = WEXITSTATUS(status);
 	uint64_t now = time(NULL);
 	int logLevel = LOG_ERROR;
-	bool restarted = false;
 
 	RestartCounters *counters = &(service->restartCounters);
 
@@ -717,7 +715,7 @@ supervisor_restart_service(Supervisor *supervisor, Service *service, int status)
 	 * too.
 	 */
 	log_info("Restarting service %s", service->name);
-	restarted = (*service->startFunction)(service->context, &(service->pid));
+	bool restarted = (*service->startFunction)(service->context, &(service->pid));
 
 	if (!restarted)
 	{
@@ -765,7 +763,6 @@ supervisor_may_restart(Service *service)
 	uint64_t now = time(NULL);
 	RestartCounters *counters = &(service->restartCounters);
 	int position = counters->position;
-	uint64_t oldestRestartTime = 0;
 
 	char timestring[BUFSIZE] = { 0 };
 
@@ -791,7 +788,7 @@ supervisor_may_restart(Service *service)
 	 * one:
 	 */
 	position = (position + 1) % SUPERVISOR_SERVICE_MAX_RETRY;
-	oldestRestartTime = counters->startTime[position];
+	uint64_t oldestRestartTime = counters->startTime[position];
 
 	if ((now - oldestRestartTime) <= SUPERVISOR_SERVICE_MAX_TIME)
 	{
@@ -819,7 +816,6 @@ supervisor_update_pidfile(Supervisor *supervisor)
 	int serviceIndex = 0;
 	PQExpBuffer content = createPQExpBuffer();
 
-	bool success = false;
 
 	if (content == NULL)
 	{
@@ -842,7 +838,7 @@ supervisor_update_pidfile(Supervisor *supervisor)
 		appendPQExpBuffer(content, "%d %s\n", service->pid, service->name);
 	}
 
-	success = write_file(content->data, content->len, supervisor->pidfile);
+	bool success = write_file(content->data, content->len, supervisor->pidfile);
 	destroyPQExpBuffer(content);
 
 	return success;
@@ -861,7 +857,6 @@ supervisor_find_service_pid(const char *pidfile,
 	long fileSize = 0L;
 	char *fileContents = NULL;
 	char *fileLines[BUFSIZE] = { 0 };
-	int lineCount = 0;
 	int lineNumber;
 
 	if (!file_exists(pidfile))
@@ -874,7 +869,7 @@ supervisor_find_service_pid(const char *pidfile,
 		return false;
 	}
 
-	lineCount = splitLines(fileContents, fileLines, BUFSIZE);
+	int lineCount = splitLines(fileContents, fileLines, BUFSIZE);
 
 	for (lineNumber = 0; lineNumber < lineCount; lineNumber++)
 	{

--- a/src/bin/pg_autoctl/systemd_config.c
+++ b/src/bin/pg_autoctl/systemd_config.c
@@ -78,7 +78,6 @@
 void
 systemd_config_init(SystemdServiceConfig *config, const char *pgdata)
 {
-	struct passwd *pw;
 	char *user = pg_setup_get_username(&(config->pgSetup));
 	IniOption systemdOptions[] = SET_INI_OPTIONS_ARRAY(config);
 
@@ -92,7 +91,7 @@ systemd_config_init(SystemdServiceConfig *config, const char *pgdata)
 	 * like that, at all. Let's assign WorkingDirectory to a safe place, like
 	 * the HOME of the USER running the service.
 	 */
-	pw = getpwnam(user);
+	struct passwd *pw = getpwnam(user);
 	if (pw)
 	{
 		log_debug("username found in passwd: %s's HOME is \"%s\"",

--- a/src/monitor/Makefile
+++ b/src/monitor/Makefile
@@ -24,8 +24,15 @@ USE_PGXS = 1
 
 DEFAULT_CFLAGS = -std=c99 -D_GNU_SOURCE -g
 DEFAULT_CFLAGS += $(shell $(PG_CONFIG) --cflags)
+DEFAULT_CFLAGS += -Wformat
+DEFAULT_CFLAGS += -Wall
+DEFAULT_CFLAGS += -Werror=implicit-int
+DEFAULT_CFLAGS += -Werror=implicit-function-declaration
+DEFAULT_CFLAGS += -Werror=return-type
 DEFAULT_CFLAGS += -Wno-declaration-after-statement
 
+# Needed for OSX
+DEFAULT_CFLAGS += -Wno-missing-braces
 override CFLAGS := $(DEFAULT_CFLAGS) $(CFLAGS)
 
 include $(PGXS)

--- a/src/monitor/conninfo.c
+++ b/src/monitor/conninfo.c
@@ -37,18 +37,16 @@ static char * ReadPrimaryConnInfoFromRecoveryConf(void);
 int
 ReadPrimaryHostAddress(char **primaryName, char **primaryPort)
 {
-	char *connInfo = NULL;
 	char *errorMessage = NULL;
-	PQconninfoOption *options = NULL;
 	PQconninfoOption *currentOption = NULL;
 
-	connInfo = ReadPrimaryConnInfoFromRecoveryConf();
+	char *connInfo = ReadPrimaryConnInfoFromRecoveryConf();
 	if (connInfo == NULL)
 	{
 		return -1;
 	}
 
-	options = PQconninfoParse(connInfo, &errorMessage);
+	PQconninfoOption *options = PQconninfoParse(connInfo, &errorMessage);
 	if (options == NULL)
 	{
 		pfree(connInfo);
@@ -90,13 +88,12 @@ ReadPrimaryHostAddress(char **primaryName, char **primaryPort)
 static char *
 ReadPrimaryConnInfoFromRecoveryConf(void)
 {
-	FILE *fd = NULL;
 	ConfigVariable *item = NULL;
 	ConfigVariable *head = NULL;
 	ConfigVariable *tail = NULL;
 	char *primaryConnInfo = NULL;
 
-	fd = AllocateFile(RECOVERY_COMMAND_FILE, "r");
+	FILE *fd = AllocateFile(RECOVERY_COMMAND_FILE, "r");
 	if (fd == NULL)
 	{
 		ereport(LOG, (errcode_for_file_access(),

--- a/src/monitor/formation_metadata.c
+++ b/src/monitor/formation_metadata.c
@@ -61,15 +61,14 @@ GetFormation(const char *formationId)
 		CStringGetTextDatum(formationId), /* formationid */
 	};
 	const int argCount = sizeof(argValues) / sizeof(argValues[0]);
-	int spiStatus = 0;
 
 	const char *selectQuery =
 		"SELECT * FROM " AUTO_FAILOVER_FORMATION_TABLE " WHERE formationId = $1";
 
 	SPI_connect();
 
-	spiStatus = SPI_execute_with_args(selectQuery, argCount, argTypes, argValues,
-									  NULL, false, 1);
+	int spiStatus = SPI_execute_with_args(selectQuery, argCount, argTypes, argValues,
+										  NULL, false, 1);
 	if (spiStatus != SPI_OK_SELECT)
 	{
 		elog(ERROR, "could not select from " AUTO_FAILOVER_FORMATION_TABLE);
@@ -138,14 +137,12 @@ create_formation(PG_FUNCTION_ARGS)
 	Name formationDBNameName = PG_GETARG_NAME(2);
 	bool formationOptionSecondary = PG_GETARG_BOOL(3);
 	int formationNumberSyncStandbys = PG_GETARG_INT32(4);
-	AutoFailoverFormation *formation = NULL;
-	Datum resultDatum = 0;
 
 	AddFormation(formationId, formationKind, formationDBNameName,
 				 formationOptionSecondary, formationNumberSyncStandbys);
 
-	formation = GetFormation(formationId);
-	resultDatum = AutoFailoverFormationGetDatum(fcinfo, formation);
+	AutoFailoverFormation *formation = GetFormation(formationId);
+	Datum resultDatum = AutoFailoverFormationGetDatum(fcinfo, formation);
 
 	PG_RETURN_DATUM(resultDatum);
 }
@@ -239,7 +236,6 @@ AddFormation(const char *formationId,
 	};
 
 	const int argCount = sizeof(argValues) / sizeof(argValues[0]);
-	int spiStatus = 0;
 
 	const char *insertQuery =
 		"INSERT INTO " AUTO_FAILOVER_FORMATION_TABLE
@@ -248,8 +244,8 @@ AddFormation(const char *formationId,
 
 	SPI_connect();
 
-	spiStatus = SPI_execute_with_args(insertQuery, argCount, argTypes,
-									  argValues, NULL, false, 0);
+	int spiStatus = SPI_execute_with_args(insertQuery, argCount, argTypes,
+										  argValues, NULL, false, 0);
 
 	if (spiStatus != SPI_OK_INSERT)
 	{
@@ -277,16 +273,15 @@ RemoveFormation(const char *formationId)
 	};
 
 	const int argCount = sizeof(argValues) / sizeof(argValues[0]);
-	int spiStatus = 0;
 
 	const char *deleteQuery =
 		"DELETE FROM " AUTO_FAILOVER_FORMATION_TABLE " WHERE formationid = $1";
 
 	SPI_connect();
 
-	spiStatus = SPI_execute_with_args(deleteQuery,
-									  argCount, argTypes, argValues,
-									  NULL, false, 0);
+	int spiStatus = SPI_execute_with_args(deleteQuery,
+										  argCount, argTypes, argValues,
+										  NULL, false, 0);
 
 	if (spiStatus != SPI_OK_DELETE)
 	{
@@ -325,7 +320,6 @@ SetFormationKind(const char *formationId, FormationKind kind)
 		CStringGetTextDatum(formationId)                  /* formationId */
 	};
 	const int argCount = sizeof(argValues) / sizeof(argValues[0]);
-	int spiStatus = 0;
 
 	const char *updateQuery =
 		"UPDATE " AUTO_FAILOVER_FORMATION_TABLE
@@ -334,9 +328,9 @@ SetFormationKind(const char *formationId, FormationKind kind)
 
 	SPI_connect();
 
-	spiStatus = SPI_execute_with_args(updateQuery,
-									  argCount, argTypes, argValues,
-									  NULL, false, 0);
+	int spiStatus = SPI_execute_with_args(updateQuery,
+										  argCount, argTypes, argValues,
+										  NULL, false, 0);
 	if (spiStatus != SPI_OK_UPDATE)
 	{
 		elog(ERROR, "could not update " AUTO_FAILOVER_FORMATION_TABLE);
@@ -362,7 +356,6 @@ SetFormationDBName(const char *formationId, const char *dbname)
 		CStringGetTextDatum(formationId)     /* formationId */
 	};
 	const int argCount = sizeof(argValues) / sizeof(argValues[0]);
-	int spiStatus = 0;
 
 	const char *updateQuery =
 		"UPDATE " AUTO_FAILOVER_FORMATION_TABLE
@@ -371,9 +364,9 @@ SetFormationDBName(const char *formationId, const char *dbname)
 
 	SPI_connect();
 
-	spiStatus = SPI_execute_with_args(updateQuery,
-									  argCount, argTypes, argValues,
-									  NULL, false, 0);
+	int spiStatus = SPI_execute_with_args(updateQuery,
+										  argCount, argTypes, argValues,
+										  NULL, false, 0);
 	if (spiStatus != SPI_OK_UPDATE)
 	{
 		elog(ERROR, "could not update " AUTO_FAILOVER_FORMATION_TABLE);
@@ -403,7 +396,6 @@ SetFormationOptSecondary(const char *formationId, bool optSecondary)
 		CStringGetTextDatum(formationId)     /* formationId */
 	};
 	const int argCount = sizeof(argValues) / sizeof(argValues[0]);
-	int spiStatus = 0;
 
 	const char *updateQuery =
 		"UPDATE " AUTO_FAILOVER_FORMATION_TABLE
@@ -412,9 +404,9 @@ SetFormationOptSecondary(const char *formationId, bool optSecondary)
 
 	SPI_connect();
 
-	spiStatus = SPI_execute_with_args(updateQuery,
-									  argCount, argTypes, argValues,
-									  NULL, false, 0);
+	int spiStatus = SPI_execute_with_args(updateQuery,
+										  argCount, argTypes, argValues,
+										  NULL, false, 0);
 	if (spiStatus != SPI_OK_UPDATE)
 	{
 		elog(ERROR, "could not update " AUTO_FAILOVER_FORMATION_TABLE);
@@ -550,14 +542,12 @@ set_formation_number_sync_standbys(PG_FUNCTION_ARGS)
 	char *formationId = text_to_cstring(formationIdText);
 	int number_sync_standbys = PG_GETARG_INT32(1);
 
-	AutoFailoverNode *primaryNode = NULL;
 	AutoFailoverFormation *formation = GetFormation(formationId);
 
 	/* at the moment, only test with the number of standbys in group 0 */
 	int groupId = 0;
 	int standbyCount = 0;
 
-	bool success = false;
 
 	char message[BUFSIZE] = { 0 };
 
@@ -579,7 +569,8 @@ set_formation_number_sync_standbys(PG_FUNCTION_ARGS)
 				 errdetail("A non-negative integer is expected")));
 	}
 
-	primaryNode = GetPrimaryNodeInGroup(formation->formationId, groupId);
+	AutoFailoverNode *primaryNode = GetPrimaryNodeInGroup(formation->formationId,
+														  groupId);
 
 	if (primaryNode == NULL)
 	{
@@ -622,7 +613,7 @@ set_formation_number_sync_standbys(PG_FUNCTION_ARGS)
 	}
 
 	/* SetFormationNumberSyncStandbys reports ERROR when returning false */
-	success = SetFormationNumberSyncStandbys(formationId, number_sync_standbys);
+	bool success = SetFormationNumberSyncStandbys(formationId, number_sync_standbys);
 
 	/* and now ask the primary to change its settings */
 	LogAndNotifyMessage(
@@ -652,7 +643,6 @@ FormationNumSyncStandbyIsValid(AutoFailoverFormation *formation,
 							   int *standbyCount)
 {
 	ListCell *nodeCell = NULL;
-	List *standbyNodesGroupList = NIL;
 	int count = 0;
 
 	if (formation == NULL)
@@ -662,7 +652,7 @@ FormationNumSyncStandbyIsValid(AutoFailoverFormation *formation,
 				 errmsg("the given formation must not be NULL")));
 	}
 
-	standbyNodesGroupList = AutoFailoverOtherNodesList(primaryNode);
+	List *standbyNodesGroupList = AutoFailoverOtherNodesList(primaryNode);
 
 	foreach(nodeCell, standbyNodesGroupList)
 	{
@@ -711,7 +701,6 @@ SetFormationNumberSyncStandbys(const char *formationId, int numberSyncStandbys)
 		CStringGetTextDatum(formationId)      /* formationId */
 	};
 	const int argCount = sizeof(argValues) / sizeof(argValues[0]);
-	int spiStatus = 0;
 
 	const char *updateQuery =
 		"UPDATE " AUTO_FAILOVER_FORMATION_TABLE
@@ -720,9 +709,9 @@ SetFormationNumberSyncStandbys(const char *formationId, int numberSyncStandbys)
 
 	SPI_connect();
 
-	spiStatus = SPI_execute_with_args(updateQuery,
-									  argCount, argTypes, argValues,
-									  NULL, false, 0);
+	int spiStatus = SPI_execute_with_args(updateQuery,
+										  argCount, argTypes, argValues,
+										  NULL, false, 0);
 	SPI_finish();
 
 	if (spiStatus != SPI_OK_UPDATE)
@@ -743,11 +732,8 @@ SetFormationNumberSyncStandbys(const char *formationId, int numberSyncStandbys)
 Datum
 AutoFailoverFormationGetDatum(FunctionCallInfo fcinfo, AutoFailoverFormation *formation)
 {
-	Datum resultDatum = 0;
 	TupleDesc resultDescriptor = NULL;
-	TypeFuncClass resultTypeClass = 0;
 
-	HeapTuple resultTuple = NULL;
 	Datum values[5];
 	bool isNulls[5];
 
@@ -767,14 +753,14 @@ AutoFailoverFormationGetDatum(FunctionCallInfo fcinfo, AutoFailoverFormation *fo
 	values[3] = BoolGetDatum(formation->opt_secondary);
 	values[4] = Int32GetDatum(formation->number_sync_standbys);
 
-	resultTypeClass = get_call_result_type(fcinfo, NULL, &resultDescriptor);
+	TypeFuncClass resultTypeClass = get_call_result_type(fcinfo, NULL, &resultDescriptor);
 	if (resultTypeClass != TYPEFUNC_COMPOSITE)
 	{
 		ereport(ERROR, (errmsg("return type must be a row type")));
 	}
 
-	resultTuple = heap_form_tuple(resultDescriptor, values, isNulls);
-	resultDatum = HeapTupleGetDatum(resultTuple);
+	HeapTuple resultTuple = heap_form_tuple(resultDescriptor, values, isNulls);
+	Datum resultDatum = HeapTupleGetDatum(resultTuple);
 
 	PG_RETURN_DATUM(resultDatum);
 }

--- a/src/monitor/health_check_metadata.c
+++ b/src/monitor/health_check_metadata.c
@@ -116,7 +116,6 @@ LoadNodeHealthList(void)
 static bool
 HaMonitorHasBeenLoaded(void)
 {
-	bool extensionLoaded = false;
 	bool extensionPresent = false;
 	bool extensionScriptExecuted = true;
 
@@ -139,7 +138,7 @@ HaMonitorHasBeenLoaded(void)
 		}
 	}
 
-	extensionLoaded = extensionPresent && extensionScriptExecuted;
+	bool extensionLoaded = extensionPresent && extensionScriptExecuted;
 
 	return extensionLoaded;
 }
@@ -152,7 +151,6 @@ HaMonitorHasBeenLoaded(void)
 NodeHealth *
 TupleToNodeHealth(HeapTuple heapTuple, TupleDesc tupleDescriptor)
 {
-	NodeHealth *nodeHealth = NULL;
 	bool isNull = false;
 
 	Datum nodeIdDatum = SPI_getbinval(heapTuple, tupleDescriptor,
@@ -164,7 +162,7 @@ TupleToNodeHealth(HeapTuple heapTuple, TupleDesc tupleDescriptor)
 	Datum healthStateDatum = SPI_getbinval(heapTuple, tupleDescriptor,
 										   TLIST_NUM_HEALTH_STATUS, &isNull);
 
-	nodeHealth = palloc0(sizeof(NodeHealth));
+	NodeHealth *nodeHealth = palloc0(sizeof(NodeHealth));
 	nodeHealth->nodeId = DatumGetInt32(nodeIdDatum);
 	nodeHealth->nodeHost = TextDatumGetCString(nodeHostDatum);
 	nodeHealth->nodePort = DatumGetInt32(nodePortDatum);

--- a/src/monitor/metadata.c
+++ b/src/monitor/metadata.c
@@ -86,23 +86,21 @@ pgAutoFailoverSchemaId(void)
 Oid
 pgAutoFailoverExtensionOwner(void)
 {
-	Relation pgExtension = NULL;
-	SysScanDesc scanDescriptor;
 	ScanKeyData scanKey[1];
 	bool indexOK = true;
-	HeapTuple extensionTuple = NULL;
 	Form_pg_extension extensionForm = NULL;
 	Oid extensionOwner = InvalidOid;
 
-	pgExtension = heap_open(ExtensionRelationId, AccessShareLock);
+	Relation pgExtension = heap_open(ExtensionRelationId, AccessShareLock);
 
 	ScanKeyInit(&scanKey[0], Anum_pg_extension_extname, BTEqualStrategyNumber,
 				F_NAMEEQ, CStringGetDatum(AUTO_FAILOVER_EXTENSION_NAME));
 
-	scanDescriptor = systable_beginscan(pgExtension, ExtensionNameIndexId, indexOK,
-										NULL, 1, scanKey);
+	SysScanDesc scanDescriptor = systable_beginscan(pgExtension, ExtensionNameIndexId,
+													indexOK,
+													NULL, 1, scanKey);
 
-	extensionTuple = systable_getnext(scanDescriptor);
+	HeapTuple extensionTuple = systable_getnext(scanDescriptor);
 
 	if (HeapTupleIsValid(extensionTuple))
 	{
@@ -188,7 +186,6 @@ checkPgAutoFailoverVersion()
 	char *installedVersion = NULL;
 	char *availableVersion = NULL;
 
-	int spiStatus = 0;
 	const int argCount = 1;
 	Oid argTypes[] = { TEXTOID };
 	Datum argValues[] = { CStringGetTextDatum(AUTO_FAILOVER_EXTENSION_NAME) };
@@ -205,8 +202,8 @@ checkPgAutoFailoverVersion()
 
 	SPI_connect();
 
-	spiStatus = SPI_execute_with_args(selectQuery, argCount, argTypes, argValues,
-									  NULL, false, 1);
+	int spiStatus = SPI_execute_with_args(selectQuery, argCount, argTypes, argValues,
+										  NULL, false, 1);
 	if (spiStatus != SPI_OK_SELECT)
 	{
 		elog(ERROR, "could not select from pg_catalog.pg_available_extensions");

--- a/src/monitor/notifications.c
+++ b/src/monitor/notifications.c
@@ -34,7 +34,6 @@
 void
 LogAndNotifyMessage(char *message, size_t size, const char *fmt, ...)
 {
-	int n;
 	va_list args;
 
 	va_start(args, fmt);
@@ -45,7 +44,7 @@ LogAndNotifyMessage(char *message, size_t size, const char *fmt, ...)
 	 * do not write before the allocated buffer.
 	 *
 	 */
-	n = vsnprintf(message, size - 2, fmt, args); /* IGNORE-BANNED */
+	int n = vsnprintf(message, size - 2, fmt, args); /* IGNORE-BANNED */
 	va_end(args);
 
 	if (n < 0)
@@ -67,13 +66,12 @@ LogAndNotifyMessage(char *message, size_t size, const char *fmt, ...)
 int64
 NotifyStateChange(AutoFailoverNode *node, char *description)
 {
-	int64 eventid;
 	StringInfo payload = makeStringInfo();
 
 	/*
 	 * Insert the event in our events table.
 	 */
-	eventid = InsertEvent(node, description);
+	int64 eventid = InsertEvent(node, description);
 
 	/* build a json object from the notification pieces */
 	appendStringInfoChar(payload, '{');
@@ -157,7 +155,6 @@ InsertEvent(AutoFailoverNode *node, char *description)
 	};
 
 	const int argCount = sizeof(argValues) / sizeof(argValues[0]);
-	int spiStatus = 0;
 	int64 eventId = 0;
 
 	const char *insertQuery =
@@ -170,18 +167,17 @@ InsertEvent(AutoFailoverNode *node, char *description)
 
 	SPI_connect();
 
-	spiStatus = SPI_execute_with_args(insertQuery, argCount, argTypes,
-									  argValues, NULL, false, 0);
+	int spiStatus = SPI_execute_with_args(insertQuery, argCount, argTypes,
+										  argValues, NULL, false, 0);
 
 	if (spiStatus == SPI_OK_INSERT_RETURNING && SPI_processed > 0)
 	{
 		bool isNull = false;
-		Datum eventIdDatum = 0;
 
-		eventIdDatum = SPI_getbinval(SPI_tuptable->vals[0],
-									 SPI_tuptable->tupdesc,
-									 1,
-									 &isNull);
+		Datum eventIdDatum = SPI_getbinval(SPI_tuptable->vals[0],
+										   SPI_tuptable->tupdesc,
+										   1,
+										   &isNull);
 
 		eventId = DatumGetInt64(eventIdDatum);
 	}

--- a/src/monitor/replication_state.c
+++ b/src/monitor/replication_state.c
@@ -55,21 +55,16 @@ ReplicationStateTypeOid(void)
 ReplicationState
 EnumGetReplicationState(Oid replicationStateOid)
 {
-	HeapTuple enumTuple = NULL;
-	Form_pg_enum enumForm = NULL;
-	char *enumName = NULL;
-	ReplicationState replicationState = REPLICATION_STATE_UNKNOWN;
-
-	enumTuple = SearchSysCache1(ENUMOID, ObjectIdGetDatum(replicationStateOid));
+	HeapTuple enumTuple = SearchSysCache1(ENUMOID, ObjectIdGetDatum(replicationStateOid));
 	if (!HeapTupleIsValid(enumTuple))
 	{
 		ereport(ERROR, (errmsg("invalid input value for enum: %u",
 							   replicationStateOid)));
 	}
 
-	enumForm = (Form_pg_enum) GETSTRUCT(enumTuple);
-	enumName = NameStr(enumForm->enumlabel);
-	replicationState = NameGetReplicationState(enumName);
+	Form_pg_enum enumForm = (Form_pg_enum) GETSTRUCT(enumTuple);
+	char *enumName = NameStr(enumForm->enumlabel);
+	ReplicationState replicationState = NameGetReplicationState(enumName);
 
 	ReleaseSysCache(enumTuple);
 
@@ -84,21 +79,19 @@ EnumGetReplicationState(Oid replicationStateOid)
 Oid
 ReplicationStateGetEnum(ReplicationState replicationState)
 {
-	Oid replicationStateOid = InvalidOid;
 	const char *enumName = ReplicationStateGetName(replicationState);
-	HeapTuple enumTuple = NULL;
 	Oid enumTypeOid = ReplicationStateTypeOid();
 
-	enumTuple = SearchSysCache2(ENUMTYPOIDNAME,
-								ObjectIdGetDatum(enumTypeOid),
-								CStringGetDatum(enumName));
+	HeapTuple enumTuple = SearchSysCache2(ENUMTYPOIDNAME,
+										  ObjectIdGetDatum(enumTypeOid),
+										  CStringGetDatum(enumName));
 	if (!HeapTupleIsValid(enumTuple))
 	{
 		ereport(ERROR, (errmsg("invalid value for enum: %d",
 							   replicationState)));
 	}
 
-	replicationStateOid = HeapTupleGetOid(enumTuple);
+	Oid replicationStateOid = HeapTupleGetOid(enumTuple);
 
 	ReleaseSysCache(enumTuple);
 

--- a/src/tools/remove_useless_declarations.sh
+++ b/src/tools/remove_useless_declarations.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+set -eu
+
+cd "$(git rev-parse --show-toplevel)"
+files=$(find src -iname '*.c' -type f | git check-attr --stdin citus-style | grep -v ': unset$' | sed 's/: citus-style: set$//')
+while true; do
+    # A visual version of this regex can be seen here (it is MUCH clearer):
+    # https://www.debuggex.com/r/XodMNE9auT9e-bTx
+    # This visual version only contains the search bit, the replacement bit is
+    # quite simple when extracted from:
+    # \n$+{code_between}\t$+{type}$+{variable} =
+    # shellcheck disable=SC2086
+    perl -i -p0e 's/\n\t(?!return )(?P<type>(\w+ )+\**)(?>(?P<variable>\w+)( = *[\w>\s\n-]*?)?;\n(?P<code_between>(?>(?P<comment_or_string_or_not_preprocessor>\/\*.*?\*\/|"(?>\\"|.)*?"|[^#]))*?)(\t)?(?=\b(?P=variable)\b))(?<=\n\t)(?P=variable) =(?![^;]*?[^>_]\b(?P=variable)\b[^_])/\n$+{code_between}\t$+{type}$+{variable} =/sg' $files
+    # The following are simply the same regex, but repeated for different
+    # indentation levels, i.e. finding declarations indented using 2, 3, 4, 5
+    # and 6 tabs. More than 6 don't really occur in the wild.
+    # (this is needed because variable sized backtracking is not supported in perl)
+    # shellcheck disable=SC2086
+    perl -i -p0e 's/\n\t\t(?!return )(?P<type>(\w+ )+\**)(?>(?P<variable>\w+)( = *[\w>\s\n-]*?)?;\n(?P<code_between>(?>(?P<comment_or_string_or_not_preprocessor>\/\*.*?\*\/|"(?>\\"|.)*?"|[^#]))*?)(\t\t)?(?=\b(?P=variable)\b))(?<=\n\t\t)(?P=variable) =(?![^;]*?[^>_]\b(?P=variable)\b[^_])/\n$+{code_between}\t\t$+{type}$+{variable} =/sg' $files
+    # shellcheck disable=SC2086
+    perl -i -p0e 's/\n\t\t\t(?!return )(?P<type>(\w+ )+\**)(?>(?P<variable>\w+)( = *[\w>\s\n-]*?)?;\n(?P<code_between>(?>(?P<comment_or_string_or_not_preprocessor>\/\*.*?\*\/|"(?>\\"|.)*?"|[^#]))*?)(\t\t\t)?(?=\b(?P=variable)\b))(?<=\n\t\t\t)(?P=variable) =(?![^;]*?[^>_]\b(?P=variable)\b[^_])/\n$+{code_between}\t\t\t$+{type}$+{variable} =/sg' $files
+    # shellcheck disable=SC2086
+    perl -i -p0e 's/\n\t\t\t\t(?!return )(?P<type>(\w+ )+\**)(?>(?P<variable>\w+)( = *[\w>\s\n-]*?)?;\n(?P<code_between>(?>(?P<comment_or_string_or_not_preprocessor>\/\*.*?\*\/|"(?>\\"|.)*?"|[^#]))*?)(\t\t\t\t)?(?=\b(?P=variable)\b))(?<=\n\t\t\t\t)(?P=variable) =(?![^;]*?[^>_]\b(?P=variable)\b[^_])/\n$+{code_between}\t\t\t\t$+{type}$+{variable} =/sg' $files
+    # shellcheck disable=SC2086
+    perl -i -p0e 's/\n\t\t\t\t\t(?!return )(?P<type>(\w+ )+\**)(?>(?P<variable>\w+)( = *[\w>\s\n-]*?)?;\n(?P<code_between>(?>(?P<comment_or_string_or_not_preprocessor>\/\*.*?\*\/|"(?>\\"|.)*?"|[^#]))*?)(\t\t\t\t\t)?(?=\b(?P=variable)\b))(?<=\n\t\t\t\t\t)(?P=variable) =(?![^;]*?[^>_]\b(?P=variable)\b[^_])/\n$+{code_between}\t\t\t\t\t$+{type}$+{variable} =/sg' $files
+    # shellcheck disable=SC2086
+    perl -i -p0e 's/\n\t\t\t\t\t\t(?!return )(?P<type>(\w+ )+\**)(?>(?P<variable>\w+)( = *[\w>\s\n-]*?)?;\n(?P<code_between>(?>(?P<comment_or_string_or_not_preprocessor>\/\*.*?\*\/|"(?>\\"|.)*?"|[^#]))*?)(\t\t\t\t\t\t)?(?=\b(?P=variable)\b))(?<=\n\t\t\t\t\t\t)(?P=variable) =(?![^;]*?[^>_]\b(?P=variable)\b[^_])/\n$+{code_between}\t\t\t\t\t\t$+{type}$+{variable} =/sg' $files
+    # shellcheck disable=SC2086
+    git diff --quiet $files && break;
+    # shellcheck disable=SC2086
+    git add $files;
+done


### PR DESCRIPTION
This is done using the same automated technique introduced for the Citus
repo in https://github.com/citusdata/citus/pull/3181. The main idea is
to replace:

```c
int a = 0;
// some code
a = 1;
```

with:

```c
// some code
int a = 1;
```

For details of how this works see the above mentioned Citus PR.

This comment about not doing early an early return to limit the scope of
variables caused me to add this here too:
https://github.com/citusdata/pg_auto_failover/pull/244#discussion_r424306388
With this commit merged, scope of variables will always be minimal in
cases where an early return is possible.

To make sure merge conflict handling is easy the following steps should be done:
1. Before merging this, all open PRs should be rebased on master.
2. Then this can be merged.
3. Then all PRs should be rebased on master again.
4. If merge conflicts occur (which is likely), they can be resolved trivially
   by doing `git checkout --theirs src` to ignore the changes caused by this PR.
   Then running `ci/remove_useless_declarations.sh` will redo all the changes.

To further limit impact, this PR can be merged right before a release, to make
sure most open PRs have been merged. This PR can be trivially updated as well by doing:
```
git rebase
# if merge conflict run
git checkout --ours src
```