### PR TITLE
Make sure teardown does not get stuck

### DIFF
--- a/tests/network.py
+++ b/tests/network.py
@@ -24,7 +24,9 @@ def managed_nspopen(*args, **kwds):
             # send SIGKILL to the process and wait for it to die if it's still
             # running
             proc.kill()
-            proc.communicate()
+            # If it's not dead after 2 seconds we throw an error
+            proc.communicate(timeout=2)
+
         # release proxy process resourecs
         proc.release()
 

--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -774,7 +774,7 @@ class DataNode(PGNode):
         try:
             destroy = PGAutoCtl(self)
             destroy.execute("pg_autoctl drop node --destroy",
-                            'drop', 'node', '--destroy')
+                            'drop', 'node', '--destroy', timeout=3)
         except Exception as e:
             print(str(e))
 


### PR DESCRIPTION
This is done by putting some more (aggressive) timeouts in places that
should not take long. Without this teardown would get stuck on test failure,
because then our cleanup commands would get stuck.