### PR TITLE
Use a private semaphore

### DIFF
--- a/src/bin/pg_autoctl/defaults.h
+++ b/src/bin/pg_autoctl/defaults.h
@@ -23,8 +23,8 @@
 #define PG_AUTOCTL_DEBUG "PG_AUTOCTL_DEBUG"
 #define PG_AUTOCTL_EXTENSION_VERSION_VAR "PG_AUTOCTL_EXTENSION_VERSION"
 
-/* environment variable for logging semaphore and locks */
-#define PG_AUTOCTL_SERVICE "PG_AUTOCTL_SERVICE"
+/* environment variable for containing the id of the logging semaphore */
+#define PG_AUTOCTL_LOG_SEMAPHORE "PG_AUTOCTL_LOG_SEMAPHORE"
 
 /* default values for the pg_autoctl settings */
 #define POSTGRES_PORT 5432

--- a/src/bin/pg_autoctl/lock_utils.h
+++ b/src/bin/pg_autoctl/lock_utils.h
@@ -18,7 +18,6 @@
 
 typedef struct Semaphore
 {
-	pid_t pid;
 	int semId;
 } Semaphore;
 
@@ -30,7 +29,7 @@ bool semaphore_create(Semaphore *semaphore);
 bool semaphore_open(Semaphore *semaphore);
 bool semaphore_unlink(Semaphore *semaphore);
 
-bool semaphore_cleanup(pid_t pid);
+bool semaphore_cleanup(const char *pidfile);
 
 bool semaphore_lock(Semaphore *semaphore);
 bool semaphore_unlock(Semaphore *semaphore);

--- a/src/bin/pg_autoctl/service.c
+++ b/src/bin/pg_autoctl/service.c
@@ -14,6 +14,7 @@
 #include <time.h>
 #include <unistd.h>
 
+#include "cli_root.h"
 #include "defaults.h"
 #include "fsm.h"
 #include "keeper.h"
@@ -154,7 +155,7 @@ create_pidfile(const char *pidfile, pid_t pid)
 
 	log_trace("create_pidfile(%d): \"%s\"", pid, pidfile);
 
-	sformat(content, BUFSIZE, "%d", pid);
+	sformat(content, BUFSIZE, "%d\n%d\n", pid, log_semaphore.semId);
 
 	return write_file(content, strlen(content), pidfile);
 }
@@ -214,7 +215,7 @@ read_pidfile(const char *pidfile, pid_t *pid)
 			(void) remove_pidfile(pidfile);
 
 			/* we might have to cleanup a stale SysV semaphore, too */
-			(void) semaphore_cleanup(*pid);
+			(void) semaphore_cleanup(pidfile);
 
 			return false;
 		}

--- a/src/bin/pg_autoctl/service_monitor.c
+++ b/src/bin/pg_autoctl/service_monitor.c
@@ -155,9 +155,10 @@ service_monitor_runprogram(Monitor *monitor)
 		IS_EMPTY_STRING_BUFFER(monitorOptions.pgSetup.pgdata)
 		? keeperOptions.pgSetup.pgdata
 		: monitorOptions.pgSetup.pgdata;
+	IntString semIdString = intToString(log_semaphore.semId);
 
 	setenv(PG_AUTOCTL_DEBUG, "1", 1);
-	setenv(PG_AUTOCTL_SERVICE, "1", 1);
+	setenv(PG_AUTOCTL_LOG_SEMAPHORE, semIdString.strValue, 1);
 
 	args[argsIndex++] = (char *) pg_autoctl_program;
 	args[argsIndex++] = "do";

--- a/src/bin/pg_autoctl/service_postgres_ctl.c
+++ b/src/bin/pg_autoctl/service_postgres_ctl.c
@@ -129,8 +129,9 @@ service_postgres_ctl_runprogram()
 		? keeperOptions.pgSetup.pgdata
 		: monitorOptions.pgSetup.pgdata;
 
+	IntString semIdString = intToString(log_semaphore.semId);
 	setenv(PG_AUTOCTL_DEBUG, "1", 1);
-	setenv(PG_AUTOCTL_SERVICE, "1", 1);
+	setenv(PG_AUTOCTL_LOG_SEMAPHORE, semIdString.strValue, 1);
 
 	args[argsIndex++] = (char *) pg_autoctl_program;
 	args[argsIndex++] = "do";

--- a/src/bin/pg_autoctl/supervisor.c
+++ b/src/bin/pg_autoctl/supervisor.c
@@ -18,6 +18,7 @@
 #include "postgres_fe.h"
 #include "pqexpbuffer.h"
 
+#include "cli_root.h"
 #include "defaults.h"
 #include "fsm.h"
 #include "keeper.h"
@@ -805,6 +806,7 @@ supervisor_update_pidfile(Supervisor *supervisor)
 
 	/* first line should still be our supervisor pid, alone */
 	appendPQExpBuffer(content, "%d\n", supervisor->pid);
+	appendPQExpBuffer(content, "%d\n", log_semaphore.semId);
 
 	for (serviceIndex = 0; serviceIndex < serviceCount; serviceIndex++)
 	{
@@ -852,8 +854,8 @@ supervisor_find_service_pid(const char *pidfile,
 	{
 		char *separator = NULL;
 
-		/* skip first line, that's the supervisor (main) pid */
-		if (lineNumber == 0)
+		/* skip first and second lines: main pid, semaphore id */
+		if (lineNumber < 2)
 		{
 			continue;
 		}


### PR DESCRIPTION
The semaphore ID is passed to child processes using a environment variable.
This way we never conflict with other semaphores.

We need to either remove the semaphore cleanup or we should store the semaphore
id in the pidfile too.