### PR TITLE
Allow adding a standby node from an exiting PGDATA directory.

### DIFF
--- a/docs/ref/reference.rst
+++ b/docs/ref/reference.rst
@@ -342,7 +342,6 @@ The other commands accept the same set of options.
     --monitor     pg_auto_failover Monitor Postgres URL
     --auth        authentication method for connections from monitor
     --skip-pg-hba skip editing pg_hba.conf rules
-    --allow-removing-pgdata Allow pg_autoctl to remove the database directory
 
 Three different modes of initialization are supported by this command,
 corresponding to as many implementation strategies.

--- a/src/bin/pg_autoctl/cli_common.c
+++ b/src/bin/pg_autoctl/cli_common.c
@@ -33,7 +33,6 @@
 
 /* handle command line options for our setup. */
 KeeperConfig keeperOptions;
-bool allowRemovingPgdata = false;
 bool createAndRun = false;
 bool outputJSON = false;
 int ssl_flag = 0;
@@ -62,7 +61,6 @@ static void stop_postgres_and_remove_pgdata_and_config(ConfigFilePaths *pathname
  *		{ "group", required_argument, NULL, 'g' },
  *		{ "monitor", required_argument, NULL, 'm' },
  *		{ "disable-monitor", no_argument, NULL, 'M' },
- *		{ "allow-removing-pgdata", no_argument, NULL, 'R' },
  *		{ "version", no_argument, NULL, 'V' },
  *		{ "verbose", no_argument, NULL, 'v' },
  *		{ "quiet", no_argument, NULL, 'q' },
@@ -271,14 +269,6 @@ cli_common_keeper_getopts(int argc, char **argv,
 				/* { "disable-monitor", required_argument, NULL, 'M' }, */
 				LocalOptionConfig.monitorDisabled = true;
 				log_trace("--disable-monitor");
-				break;
-			}
-
-			case 'R':
-			{
-				/* { "allow-removing-pgdata", no_argument, NULL, 'R' } */
-				allowRemovingPgdata = true;
-				log_trace("--allow-removing-pgdata");
 				break;
 			}
 
@@ -494,7 +484,6 @@ cli_common_keeper_getopts(int argc, char **argv,
  *		{ "group", required_argument, NULL, 'g' },
  *		{ "monitor", required_argument, NULL, 'm' },
  *		{ "disable-monitor", no_argument, NULL, 'M' },
- *		{ "allow-removing-pgdata", no_argument, NULL, 'R' },
  *		{ "version", no_argument, NULL, 'V' },
  *		{ "verbose", no_argument, NULL, 'v' },
  *		{ "quiet", no_argument, NULL, 'q' },

--- a/src/bin/pg_autoctl/cli_common.h
+++ b/src/bin/pg_autoctl/cli_common.h
@@ -20,7 +20,6 @@
 
 extern MonitorConfig monitorOptions;
 extern KeeperConfig keeperOptions;
-extern bool allowRemovingPgdata;
 extern bool createAndRun;
 extern bool outputJSON;
 
@@ -69,9 +68,6 @@ extern int ssl_flag;
 	"  --group           pg_auto_failover group Id\n" \
 	"  --monitor         pg_auto_failover Monitor Postgres URL\n" \
 	KEEPER_CLI_SSL_OPTIONS
-
-#define KEEPER_CLI_ALLOW_RM_PGDATA_OPTION \
-	"  --allow-removing-pgdata Allow pg_autoctl to remove the database directory\n"
 
 #define CLI_PGDATA_OPTION \
 	"  --pgdata      path to data directory\n" \

--- a/src/bin/pg_autoctl/cli_create_drop_node.c
+++ b/src/bin/pg_autoctl/cli_create_drop_node.c
@@ -97,8 +97,7 @@ CommandLine create_postgres_command =
 		"  --skip-pg-hba     skip editing pg_hba.conf rules\n"
 		"  --candidate-priority    priority of the node to be promoted to become primary\n"
 		"  --replication-quorum    true if node participates in write quorum\n"
-		KEEPER_CLI_SSL_OPTIONS
-		KEEPER_CLI_ALLOW_RM_PGDATA_OPTION,
+		KEEPER_CLI_SSL_OPTIONS,
 		cli_create_postgres_getopts,
 		cli_create_postgres);
 
@@ -267,7 +266,6 @@ cli_create_postgres_getopts(int argc, char **argv)
 		{ "formation", required_argument, NULL, 'f' },
 		{ "monitor", required_argument, NULL, 'm' },
 		{ "disable-monitor", no_argument, NULL, 'M' },
-		{ "allow-removing-pgdata", no_argument, NULL, 'R' },
 		{ "version", no_argument, NULL, 'V' },
 		{ "verbose", no_argument, NULL, 'v' },
 		{ "quiet", no_argument, NULL, 'q' },

--- a/src/bin/pg_autoctl/cli_do_misc.c
+++ b/src/bin/pg_autoctl/cli_do_misc.c
@@ -327,6 +327,7 @@ keeper_cli_init_standby(int argc, char **argv)
 {
 	const bool missing_pgdata_is_ok = true;
 	const bool pg_not_running_is_ok = true;
+	const bool skipBaseBackup = false;
 
 	KeeperConfig config = keeperOptions;
 	LocalPostgresServer postgres = { 0 };
@@ -371,7 +372,7 @@ keeper_cli_init_standby(int argc, char **argv)
 		exit(EXIT_CODE_INTERNAL_ERROR);
 	}
 
-	if (!standby_init_database(&postgres, config.nodename))
+	if (!standby_init_database(&postgres, config.nodename, skipBaseBackup))
 	{
 		log_fatal("Failed to grant access to the standby by adding "
 				  "relevant lines to pg_hba.conf for the "

--- a/src/bin/pg_autoctl/cli_do_root.c
+++ b/src/bin/pg_autoctl/cli_do_root.c
@@ -267,7 +267,6 @@ keeper_cli_keeper_setup_getopts(int argc, char **argv)
 		{ "formation", required_argument, NULL, 'f' },
 		{ "monitor", required_argument, NULL, 'm' },
 		{ "disable-monitor", no_argument, NULL, 'M' },
-		{ "allow-removing-pgdata", no_argument, NULL, 'R' },
 		{ "version", no_argument, NULL, 'V' },
 		{ "verbose", no_argument, NULL, 'v' },
 		{ "quiet", no_argument, NULL, 'q' },

--- a/src/bin/pg_autoctl/fsm_transition.c
+++ b/src/bin/pg_autoctl/fsm_transition.c
@@ -751,6 +751,18 @@ fsm_init_standby(Keeper *keeper)
 		return false;
 	}
 
+	/*
+	 * Publish our possibly new system_identifier now.
+	 */
+	if (!monitor_set_node_system_identifier(
+			monitor,
+			keeper->state.current_node_id,
+			postgres->postgresSetup.control.system_identifier))
+	{
+		log_error("Failed to update the new node system_identifier");
+		return false;
+	}
+
 	/* ensure the SSL setup is synced with the keeper config */
 	if (!keeper_create_self_signed_cert(keeper))
 	{

--- a/src/bin/pg_autoctl/fsm_transition.c
+++ b/src/bin/pg_autoctl/fsm_transition.c
@@ -732,6 +732,16 @@ fsm_init_standby(Keeper *keeper)
 		return false;
 	}
 
+	/*
+	 * At pg_autoctl create time when PGDATA already exists and we were
+	 * successful in registering the node, then we can proceed without a
+	 * pg_basebackup: we already have a copy of PGDATA on-disk.
+	 *
+	 * The existence of PGDATA at pg_autoctl create time is tracked in our init
+	 * state as the PRE_INIT_STATE_EXISTS enum value. Once init is finished, we
+	 * remove our init file: then we need to pg_basebackup again to init a
+	 * standby.
+	 */
 	skipBaseBackup = file_exists(keeper->config.pathnames.init) &&
 					 keeper->initState.pgInitState == PRE_INIT_STATE_EXISTS;
 

--- a/src/bin/pg_autoctl/keeper.c
+++ b/src/bin/pg_autoctl/keeper.c
@@ -1186,6 +1186,7 @@ keeper_register_and_init(Keeper *keeper, NodeState initialState)
 							   config->formation,
 							   config->nodename,
 							   config->pgSetup.pgport,
+							   config->pgSetup.control.system_identifier,
 							   config->pgSetup.dbname,
 							   config->groupId,
 							   initialState,

--- a/src/bin/pg_autoctl/monitor.c
+++ b/src/bin/pg_autoctl/monitor.c
@@ -537,20 +537,21 @@ monitor_get_coordinator(Monitor *monitor, char *formation, NodeAddress *node)
  */
 bool
 monitor_register_node(Monitor *monitor, char *formation, char *host, int port,
+					  uint64_t system_identifier,
 					  char *dbname, int desiredGroupId, NodeState initialState,
 					  PgInstanceKind kind, int candidatePriority, bool quorum,
 					  MonitorAssignedState *assignedState)
 {
 	PGSQL *pgsql = &monitor->pgsql;
 	const char *sql =
-		"SELECT * FROM pgautofailover.register_node($1, $2, $3, $4, $5, "
-		"$6::pgautofailover.replication_state, $7, $8, $9)";
-	int paramCount = 9;
-	Oid paramTypes[9] = {
-		TEXTOID, TEXTOID, INT4OID, NAMEOID, INT4OID,
-		TEXTOID, TEXTOID, INT4OID, BOOLOID
+		"SELECT * FROM pgautofailover.register_node($1, $2, $3, $4, $5, $6, "
+		"$7::pgautofailover.replication_state, $8, $9, $10)";
+	int paramCount = 10;
+	Oid paramTypes[10] = {
+		TEXTOID, TEXTOID, INT4OID, NAMEOID, INT8OID,
+		INT4OID, TEXTOID, TEXTOID, INT4OID, BOOLOID
 	};
-	const char *paramValues[9];
+	const char *paramValues[10];
 	MonitorAssignedStateParseContext parseContext =
 	{ { 0 }, assignedState, false };
 	const char *nodeStateString = NodeStateToString(initialState);
@@ -559,11 +560,12 @@ monitor_register_node(Monitor *monitor, char *formation, char *host, int port,
 	paramValues[1] = host;
 	paramValues[2] = intToString(port).strValue;
 	paramValues[3] = dbname;
-	paramValues[4] = intToString(desiredGroupId).strValue;
-	paramValues[5] = nodeStateString;
-	paramValues[6] = nodeKindToString(kind);
-	paramValues[7] = intToString(candidatePriority).strValue;
-	paramValues[8] = quorum ? "true" : "false";
+	paramValues[4] = intToString(system_identifier).strValue;
+	paramValues[5] = intToString(desiredGroupId).strValue;
+	paramValues[6] = nodeStateString;
+	paramValues[7] = nodeKindToString(kind);
+	paramValues[8] = intToString(candidatePriority).strValue;
+	paramValues[9] = quorum ? "true" : "false";
 
 
 	if (!pgsql_execute_with_params(pgsql, sql,
@@ -584,6 +586,7 @@ monitor_register_node(Monitor *monitor, char *formation, char *host, int port,
 
 			sleep(PG_AUTOCTL_KEEPER_SLEEP_TIME);
 			return monitor_register_node(monitor, formation, host, port,
+										 system_identifier,
 										 dbname, desiredGroupId, initialState,
 										 kind, candidatePriority, quorum,
 										 assignedState);
@@ -2259,6 +2262,54 @@ monitor_set_nodename(Monitor *monitor, int nodeId, const char *nodename)
 			"because it returned an unexpected result. "
 			"See previous line for details.",
 			nodeId, nodename);
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * monitor_set_node_system_identifier sets the node's sysidentifier column on
+ * the monitor.
+ */
+bool
+monitor_set_node_system_identifier(Monitor *monitor,
+								   int nodeId,
+								   uint64_t system_identifier)
+{
+	PGSQL *pgsql = &monitor->pgsql;
+	const char *sql =
+		"SELECT * FROM pgautofailover.set_node_system_identifier($1, $2)";
+	int paramCount = 2;
+	Oid paramTypes[2] = { INT8OID, INT8OID };
+	const char *paramValues[2];
+
+	NodeAddress node = { 0 };
+	NodeAddressParseContext parseContext = { { 0 }, &node, false };
+
+	paramValues[0] = intToString(nodeId).strValue;
+	paramValues[1] = intToString(system_identifier).strValue;
+
+	if (!pgsql_execute_with_params(pgsql, sql,
+								   paramCount, paramTypes, paramValues,
+								   &parseContext, parseNodeResult))
+	{
+		log_error("Failed to set_node_system_identifier of node %d "
+				  "from the monitor", nodeId);
+		return false;
+	}
+
+	/* disconnect from PostgreSQL now */
+	pgsql_finish(&monitor->pgsql);
+
+	if (!parseContext.parsedOK)
+	{
+		log_error(
+			"Failed to set node %d sysidentifier to \"%" PRIu64 "\""
+																" on the monitor because it returned an unexpected result. "
+																"See previous line for details.",
+			nodeId, system_identifier);
 		return false;
 	}
 

--- a/src/bin/pg_autoctl/monitor.c
+++ b/src/bin/pg_autoctl/monitor.c
@@ -601,7 +601,7 @@ monitor_register_node(Monitor *monitor, char *formation, char *host, int port,
 					  host, port, desiredGroupId, formation, system_identifier);
 
 			log_info(
-				"HINT: you may register a standby node from a non-existing"
+				"HINT: you may register a standby node from a non-existing "
 				"PGDATA directory that pg_autoctl then creates for you, or "
 				"PGDATA should be a copy of the current primary node such as "
 				"obtained from a backup and recovery tool.");

--- a/src/bin/pg_autoctl/monitor.c
+++ b/src/bin/pg_autoctl/monitor.c
@@ -591,6 +591,22 @@ monitor_register_node(Monitor *monitor, char *formation, char *host, int port,
 										 kind, candidatePriority, quorum,
 										 assignedState);
 		}
+		else if (strcmp(parseContext.sqlstate, "23P01") == 0)
+		{
+			log_error("Failed to register node %s:%d in "
+					  "group %d of formation \"%s\" "
+					  "with system_identifier %" PRIu64 ", "
+														"because another node already exists in this group with "
+														"another system_identifier",
+					  host, port, desiredGroupId, formation, system_identifier);
+
+			log_info(
+				"HINT: you may register a standby node from a non-existing"
+				"PGDATA directory that pg_autoctl then creates for you, or "
+				"PGDATA should be a copy of the current primary node such as "
+				"obtained from a backup and recovery tool.");
+			return false;
+		}
 
 		log_error("Failed to register node %s:%d in group %d of formation \"%s\" "
 				  "with initial state \"%s\", see previous lines for details",

--- a/src/bin/pg_autoctl/monitor.h
+++ b/src/bin/pg_autoctl/monitor.h
@@ -76,9 +76,17 @@ bool monitor_get_primary(Monitor *monitor, char *formation, int groupId,
 						 NodeAddress *node);
 bool monitor_get_coordinator(Monitor *monitor, char *formation,
 							 NodeAddress *node);
-bool monitor_register_node(Monitor *monitor, char *formation, char *host, int port,
-						   char *dbname, int desiredGroupId, NodeState initialSate,
-						   PgInstanceKind kind, int candidatePriority, bool quorum,
+bool monitor_register_node(Monitor *monitor,
+						   char *formation,
+						   char *host,
+						   int port,
+						   uint64_t system_identifier,
+						   char *dbname,
+						   int desiredGroupId,
+						   NodeState initialState,
+						   PgInstanceKind kind,
+						   int candidatePriority,
+						   bool quorum,
 						   MonitorAssignedState *assignedState);
 bool monitor_node_active(Monitor *monitor,
 						 char *formation, char *host, int port, int nodeId,
@@ -137,6 +145,9 @@ bool monitor_synchronous_standby_names(Monitor *monitor,
 									   int size);
 
 bool monitor_set_nodename(Monitor *monitor, int nodeId, const char *nodename);
+bool monitor_set_node_system_identifier(Monitor *monitor,
+										int nodeId,
+										uint64_t system_identifier);
 
 bool monitor_start_maintenance(Monitor *monitor, char *host, int port);
 bool monitor_stop_maintenance(Monitor *monitor, char *host, int port);

--- a/src/bin/pg_autoctl/pgsetup.c
+++ b/src/bin/pg_autoctl/pgsetup.c
@@ -1154,8 +1154,10 @@ pg_setup_wait_until_is_stopped(PostgresSetup *pgSetup, int timeout, int logLevel
 
 
 /*
- * pg_setup_is_primary returns true when the local PostgreSQL instance is known
- * to not be recovery.
+ * pg_setup_role returns an enum value representing which role the local
+ * PostgreSQL instance currently has. We detect primary and secondary when
+ * Postgres is running, and either recovery or unknown when Postgres is not
+ * running.
  */
 PostgresRole
 pg_setup_role(PostgresSetup *pgSetup)

--- a/src/bin/pg_autoctl/pgsetup.h
+++ b/src/bin/pg_autoctl/pgsetup.h
@@ -57,6 +57,24 @@ typedef enum
 } PostmasterStatus;
 
 /*
+ * When discovering Postgres we try to determine if the local $PGDATA directory
+ * belons to a primary or a secondary server. If the server is running, it's
+ * easy: connect and ask with the pg_is_in_recovery() SQL function. If the
+ * server is not running, we might be lucky and find a standby setup file and
+ * then we know it's not a primary.
+ *
+ * Otherwise we just don't know.
+ */
+typedef enum PostgresRole
+{
+	POSTGRES_ROLE_UNKNOWN,
+	POSTGRES_ROLE_PRIMARY,
+	POSTGRES_ROLE_RECOVERY,     /* Either PITR or Hot Standby */
+	POSTGRES_ROLE_STANDBY       /* We know it's an Hot Standby */
+} PostgresRole;
+
+
+/*
  * pg_auto_failover knows how to manage three kinds of PostgreSQL servers:
  *
  *  - Standalone PostgreSQL instances
@@ -173,7 +191,7 @@ bool pg_setup_get_local_connection_string(PostgresSetup *pgSetup,
 										  char *connectionString);
 bool pg_setup_pgdata_exists(PostgresSetup *pgSetup);
 bool pg_setup_is_running(PostgresSetup *pgSetup);
-bool pg_setup_is_primary(PostgresSetup *pgSetup);
+PostgresRole pg_setup_role(PostgresSetup *pgSetup);
 bool pg_setup_is_ready(PostgresSetup *pgSetup, bool pg_is_not_running_is_ok);
 bool pg_setup_wait_until_is_ready(PostgresSetup *pgSetup,
 								  int timeout, int logLevel);

--- a/src/bin/pg_autoctl/pgsetup.h
+++ b/src/bin/pg_autoctl/pgsetup.h
@@ -58,7 +58,7 @@ typedef enum
 
 /*
  * When discovering Postgres we try to determine if the local $PGDATA directory
- * belons to a primary or a secondary server. If the server is running, it's
+ * belongs to a primary or a secondary server. If the server is running, it's
  * easy: connect and ask with the pg_is_in_recovery() SQL function. If the
  * server is not running, we might be lucky and find a standby setup file and
  * then we know it's not a primary.

--- a/src/bin/pg_autoctl/pgsql.c
+++ b/src/bin/pg_autoctl/pgsql.c
@@ -431,7 +431,15 @@ pgsql_execute_with_params(PGSQL *pgsql, const char *sql, int paramCount,
 				writePointer += bytesWritten;
 			}
 
-			bytesWritten = sformat(writePointer, remainingBytes, "'%s'", value);
+			if (value == NULL)
+			{
+				bytesWritten = sformat(writePointer, remainingBytes, "NULL");
+			}
+			else
+			{
+				bytesWritten =
+					sformat(writePointer, remainingBytes, "'%s'", value);
+			}
 			remainingBytes -= bytesWritten;
 			writePointer += bytesWritten;
 		}
@@ -1374,7 +1382,7 @@ pgsql_create_extension(PGSQL *pgsql, const char *name)
 	}
 
 	/* now build the SQL command */
-	sformat(command, BUFSIZE, "CREATE EXTENSION %s", escapedIdentifier);
+	sformat(command, BUFSIZE, "CREATE EXTENSION %s CASCADE", escapedIdentifier);
 	PQfreemem(escapedIdentifier);
 	log_debug("Running command on Postgres: %s;", command);
 

--- a/src/bin/pg_autoctl/primary_standby.h
+++ b/src/bin/pg_autoctl/primary_standby.h
@@ -88,7 +88,9 @@ bool standby_init_replication_source(LocalPostgresServer *postgres,
 									 const char *backupDirectory,
 									 SSLOptions sslOptions,
 									 int currentNodeId);
-bool standby_init_database(LocalPostgresServer *postgres, const char *nodename);
+bool standby_init_database(LocalPostgresServer *postgres,
+						   const char *nodename,
+						   bool skipBaseBackup);
 bool primary_rewind_to_standby(LocalPostgresServer *postgres);
 bool standby_promote(LocalPostgresServer *postgres);
 bool check_postgresql_settings(LocalPostgresServer *postgres,

--- a/src/bin/pg_autoctl/state.c
+++ b/src/bin/pg_autoctl/state.c
@@ -712,7 +712,7 @@ keeper_init_state_discover(KeeperStateInit *initState,
 		return false;
 	}
 
-	if (pg_setup_is_running(pgSetup) && pg_setup_is_primary(pgSetup))
+	if (pg_setup_role(pgSetup) == POSTGRES_ROLE_PRIMARY)
 	{
 		initState->pgInitState = PRE_INIT_STATE_PRIMARY;
 	}

--- a/src/monitor/expected/create_extension.out
+++ b/src/monitor/expected/create_extension.out
@@ -1,3 +1,4 @@
 -- Copyright (c) Microsoft Corporation. All rights reserved.
 -- Licensed under the PostgreSQL License.
-create extension pgautofailover;
+create extension pgautofailover cascade;
+NOTICE:  installing required extension "btree_gist"

--- a/src/monitor/node_active_protocol.c
+++ b/src/monitor/node_active_protocol.c
@@ -110,11 +110,6 @@ register_node(PG_FUNCTION_ARGS)
 
 	checkPgAutoFailoverVersion();
 
-	if (!PG_ARGISNULL(4))
-	{
-		sysIdentifier = PG_GETARG_INT64(4);
-	}
-
 	currentNodeState.nodeId = -1;
 	currentNodeState.groupId = currentGroupId;
 	currentNodeState.replicationState =

--- a/src/monitor/node_active_protocol.c
+++ b/src/monitor/node_active_protocol.c
@@ -83,7 +83,7 @@ register_node(PG_FUNCTION_ARGS)
 	char *nodeName = text_to_cstring(nodeNameText);
 	int32 nodePort = PG_GETARG_INT32(2);
 	Name dbnameName = PG_GETARG_NAME(3);
-	uint64 sysIdentifier = 0;
+	uint64 sysIdentifier = PG_GETARG_INT64(4);
 	const char *expectedDBName = NameStr(*dbnameName);
 
 	int32 currentGroupId = PG_GETARG_INT32(5);

--- a/src/monitor/node_metadata.h
+++ b/src/monitor/node_metadata.h
@@ -24,24 +24,25 @@
  * indices must match with the columns given
  * in the following definition.
  */
-#define Natts_pgautofailover_node 15
+#define Natts_pgautofailover_node 18
 #define Anum_pgautofailover_node_formationid 1
 #define Anum_pgautofailover_node_nodeid 2
 #define Anum_pgautofailover_node_groupid 3
 #define Anum_pgautofailover_node_nodename 4
 #define Anum_pgautofailover_node_nodeport 5
-#define Anum_pgautofailover_node_goalstate 6
-#define Anum_pgautofailover_node_reportedstate 7
-#define Anum_pgautofailover_node_reportedpgisrunning 8
-#define Anum_pgautofailover_node_reportedrepstate 9
-#define Anum_pgautofailover_node_reporttime 10
-#define Anum_pgautofailover_node_walreporttime 11
-#define Anum_pgautofailover_node_health 12
-#define Anum_pgautofailover_node_healthchecktime 13
-#define Anum_pgautofailover_node_statechangetime 14
-#define Anum_pgautofailover_node_reportedLSN 15
-#define Anum_pgautofailover_node_candidate_priority 16
-#define Anum_pgautofailover_node_replication_quorum 17
+#define Anum_pgautofailover_node_sysidentifier 6
+#define Anum_pgautofailover_node_goalstate 7
+#define Anum_pgautofailover_node_reportedstate 8
+#define Anum_pgautofailover_node_reportedpgisrunning 9
+#define Anum_pgautofailover_node_reportedrepstate 10
+#define Anum_pgautofailover_node_reporttime 11
+#define Anum_pgautofailover_node_reportedLSN 12
+#define Anum_pgautofailover_node_walreporttime 13
+#define Anum_pgautofailover_node_health 14
+#define Anum_pgautofailover_node_healthchecktime 15
+#define Anum_pgautofailover_node_statechangetime 16
+#define Anum_pgautofailover_node_candidate_priority 17
+#define Anum_pgautofailover_node_replication_quorum 18
 
 #define AUTO_FAILOVER_NODE_TABLE_ALL_COLUMNS \
 	"formationid, " \
@@ -49,16 +50,17 @@
 	"groupid, " \
 	"nodename, " \
 	"nodeport, " \
+	"sysidentifier, " \
 	"goalstate, " \
 	"reportedstate, " \
 	"reportedpgisrunning, " \
 	"reportedrepstate, " \
 	"reporttime, " \
+	"reportedlsn, " \
 	"walreporttime, " \
 	"health, " \
 	"healthchecktime, " \
 	"statechangetime, " \
-	"reportedlsn, " \
 	"candidatepriority, " \
 	"replicationquorum"
 
@@ -88,6 +90,7 @@ typedef struct AutoFailoverNode
 	int groupId;
 	char *nodeName;
 	int nodePort;
+	uint64 sysIdentifier;
 	ReplicationState goalState;
 	ReplicationState reportedState;
 	TimestampTz reportTime;
@@ -123,8 +126,11 @@ extern AutoFailoverNode * OtherNodeInGroup(AutoFailoverNode *pgAutoFailoverNode)
 extern AutoFailoverNode * GetWritableNodeInGroup(char *formationId, int32 groupId);
 extern AutoFailoverNode * TupleToAutoFailoverNode(TupleDesc tupleDescriptor,
 												  HeapTuple heapTuple);
-extern int AddAutoFailoverNode(char *formationId, int groupId,
-							   char *nodeName, int nodePort,
+extern int AddAutoFailoverNode(char *formationId,
+							   int groupId,
+							   char *nodeName,
+							   int nodePort,
+							   uint64 sysIdentifier,
 							   ReplicationState goalState,
 							   ReplicationState reportedState,
 							   int candidatePriority,

--- a/src/monitor/pgautofailover.control
+++ b/src/monitor/pgautofailover.control
@@ -2,3 +2,4 @@ comment = 'pg_auto_failover'
 default_version = '1.3'
 module_pathname = '$libdir/pgautofailover'
 relocatable = false
+requires = 'btree_gist'

--- a/src/monitor/pgautofailover.sql
+++ b/src/monitor/pgautofailover.sql
@@ -123,7 +123,8 @@ CREATE TABLE pgautofailover.node
     -- at the time we call the register_node() function.
     --
     CONSTRAINT system_identifier_is_null_at_init_only
-         CHECK (  (sysidentifier IS NULL and reportedstate = 'init')
+         CHECK (  (    sysidentifier IS NULL
+                   AND reportedstate in ('init', 'wait_standby', 'catchingup') )
                 OR sysidentifier IS NOT NULL),
     CONSTRAINT same_system_identifier_within_group
        EXCLUDE USING gist(groupid with =, sysidentifier with <>),

--- a/src/monitor/sql/create_extension.sql
+++ b/src/monitor/sql/create_extension.sql
@@ -1,4 +1,4 @@
 -- Copyright (c) Microsoft Corporation. All rights reserved.
 -- Licensed under the PostgreSQL License.
 
-create extension pgautofailover;
+create extension pgautofailover cascade;

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -2,7 +2,6 @@ import pgautofailover_utils as pgautofailover
 from nose.tools import *
 
 import os
-import subprocess
 
 cluster = None
 node1 = None
@@ -38,17 +37,6 @@ def test_002_create_t1():
 
 def test_003_init_secondary():
     global node2
-
-    # create node2 from a manual copy of node1 to test creating a standby
-    # from an existing PGDATA (typically PGDATA would be deployed from a
-    # backup and recovery mechanism)
-    p = subprocess.Popen(["sudo", "-E", '-u', os.getenv("USER"),
-                          'env', 'PATH=' + os.getenv("PATH"),
-                          "cp", "-a", "/tmp/auth/node1", "/tmp/auth/node2"])
-    assert(p.wait() == 0)
-
-    os.remove("/tmp/auth/node2/postmaster.pid")
-
     node2 = cluster.create_datanode("/tmp/auth/node2", authMethod="md5")
 
     os.putenv('PGPASSWORD', "streaming_password")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -2,6 +2,7 @@ import pgautofailover_utils as pgautofailover
 from nose.tools import *
 
 import os
+import subprocess
 
 cluster = None
 node1 = None
@@ -37,6 +38,17 @@ def test_002_create_t1():
 
 def test_003_init_secondary():
     global node2
+
+    # create node2 from a manual copy of node1 to test creating a standby
+    # from an existing PGDATA (typically PGDATA would be deployed from a
+    # backup and recovery mechanism)
+    p = subprocess.Popen(["sudo", "-E", '-u', os.getenv("USER"),
+                          'env', 'PATH=' + os.getenv("PATH"),
+                          "cp", "-a", "/tmp/auth/node1", "/tmp/auth/node2"])
+    assert(p.wait() == 0)
+
+    os.remove("/tmp/auth/node2/postmaster.pid")
+
     node2 = cluster.create_datanode("/tmp/auth/node2", authMethod="md5")
 
     os.putenv('PGPASSWORD', "streaming_password")

--- a/tests/test_create_standby_with_pgdata.py
+++ b/tests/test_create_standby_with_pgdata.py
@@ -64,7 +64,7 @@ def test_005_cleanup_after_failure():
 def test_004_init_secondary():
     global node3
 
-    # create node2 from a manual copy of node1 to test creating a standby
+    # create node3 from a manual copy of node1 to test creating a standby
     # from an existing PGDATA (typically PGDATA would be deployed from a
     # backup and recovery mechanism)
     p = subprocess.Popen(["sudo", "-E", '-u', os.getenv("USER"),

--- a/tests/test_create_standby_with_pgdata.py
+++ b/tests/test_create_standby_with_pgdata.py
@@ -82,7 +82,7 @@ def test_006_init_secondary():
     assert node3.wait_until_state(target_state="secondary")
     assert node1.wait_until_state(target_state="primary")
 
-def test_005_failover():
+def test_007_failover():
     print()
     print("Calling pgautofailover.failover() on the monitor")
     cluster.monitor.failover()

--- a/tests/test_create_standby_with_pgdata.py
+++ b/tests/test_create_standby_with_pgdata.py
@@ -61,7 +61,7 @@ def test_005_cleanup_after_failure():
                           "rm", "-rf", "/tmp/sb-from-pgdata/node2"])
         assert(p.wait() == 0)
 
-def test_004_init_secondary():
+def test_006_init_secondary():
     global node3
 
     # create node3 from a manual copy of node1 to test creating a standby

--- a/tests/test_create_standby_with_pgdata.py
+++ b/tests/test_create_standby_with_pgdata.py
@@ -1,0 +1,86 @@
+import pgautofailover_utils as pgautofailover
+from nose.tools import *
+
+import os
+import subprocess
+
+cluster = None
+node1 = None
+node2 = None
+node3 = None
+
+def setup_module():
+    global cluster
+    cluster = pgautofailover.Cluster()
+
+def teardown_module():
+    cluster.destroy()
+
+def test_000_create_monitor():
+    monitor = cluster.create_monitor("/tmp/sb-from-pgdata/monitor")
+    monitor.run()
+
+def test_001_init_primary():
+    global node1
+    node1 = cluster.create_datanode("/tmp/sb-from-pgdata/node1")
+    node1.create()
+    node1.run()
+    assert node1.wait_until_state(target_state="single")
+
+def test_002_create_t1():
+    node1.run_sql_query("CREATE TABLE t1(a int)")
+    node1.run_sql_query("INSERT INTO t1 VALUES (1), (2)")
+
+def test_003_init_secondary():
+    global node2
+
+    # fail the registration of a node2 by using a PGDATA directory that has
+    # already been created, with another system_identifier (initdb creates a
+    # new one each time)
+    p = subprocess.Popen(["sudo", "-E", '-u', os.getenv("USER"),
+                          'env', 'PATH=' + os.getenv("PATH"),
+                          "pg_ctl", "initdb", "-s", "-D",
+                          "/tmp/sb-from-pgdata/node2"])
+    assert(p.wait() == 0)
+
+    node2 = cluster.create_datanode("/tmp/sb-from-pgdata/node2")
+    try:
+        node2.create()
+    except Exception as e:
+        # we want to see the failure here
+        print(e)
+
+        print("Failed as expected, cleaning up")
+        print("rm -rf /tmp/sb-from-pgdata/node2")
+        p = subprocess.Popen(["sudo", "-E", '-u', os.getenv("USER"),
+                          'env', 'PATH=' + os.getenv("PATH"),
+                          "rm", "-rf", "/tmp/sb-from-pgdata/node2"])
+        assert(p.wait() == 0)
+
+def test_004_init_secondary():
+    global node3
+
+    # create node2 from a manual copy of node1 to test creating a standby
+    # from an existing PGDATA (typically PGDATA would be deployed from a
+    # backup and recovery mechanism)
+    p = subprocess.Popen(["sudo", "-E", '-u', os.getenv("USER"),
+                          'env', 'PATH=' + os.getenv("PATH"),
+                          "cp", "-a",
+                          "/tmp/sb-from-pgdata/node1",
+                          "/tmp/sb-from-pgdata/node3"])
+    assert(p.wait() == 0)
+
+    os.remove("/tmp/sb-from-pgdata/node3/postmaster.pid")
+
+    node3 = cluster.create_datanode("/tmp/sb-from-pgdata/node3")
+    node3.create()
+    node3.run()
+    assert node3.wait_until_state(target_state="secondary")
+    assert node1.wait_until_state(target_state="primary")
+
+def test_005_failover():
+    print()
+    print("Calling pgautofailover.failover() on the monitor")
+    cluster.monitor.failover()
+    assert node3.wait_until_state(target_state="primary")
+    assert node1.wait_until_state(target_state="secondary")

--- a/tests/test_create_standby_with_pgdata.py
+++ b/tests/test_create_standby_with_pgdata.py
@@ -44,12 +44,16 @@ def test_003_init_secondary():
     assert(p.wait() == 0)
 
     node2 = cluster.create_datanode("/tmp/sb-from-pgdata/node2")
+@raises(Exception)
+def test_004_create_raises_error():
     try:
         node2.create()
     except Exception as e:
         # we want to see the failure here
         print(e)
-
+        raise
+        
+def test_005_cleanup_after_failure():
         print("Failed as expected, cleaning up")
         print("rm -rf /tmp/sb-from-pgdata/node2")
         p = subprocess.Popen(["sudo", "-E", '-u', os.getenv("USER"),


### PR DESCRIPTION
This allows users to use their favorite backup and restore options when
preparing to add a standby node to pg_auto_failover.

We still have a restriction that we don't know how to accept an already
running standby: we would need to check the primary conninfo authentication
options in use, the replication slot, etc. So we still bail out in that
case.

See #101.