### PR TITLE
Move the log semaphore clean-up function to atexit().

### DIFF
--- a/src/bin/pg_autoctl/lock_utils.c
+++ b/src/bin/pg_autoctl/lock_utils.c
@@ -92,6 +92,9 @@ semaphore_create(Semaphore *semaphore)
 		return false;
 	}
 
+	/* to see this log line, change the default log level in set_logger() */
+	log_trace("Created semaphore %d", semaphore->semId);
+
 	semun.val = 1;
 	if (semctl(semaphore->semId, 0, SETVAL, semun) < 0)
 	{
@@ -132,6 +135,9 @@ semaphore_open(Semaphore *semaphore)
 		return false;
 	}
 
+	/* to see this log line, change the default log level in set_logger() */
+	log_trace("Using semaphore %d", semaphore->semId);
+
 	/* we have the semaphore identifier, no need to call semget(2), done */
 	return true;
 }
@@ -146,6 +152,8 @@ semaphore_unlink(Semaphore *semaphore)
 	union semun semun;
 
 	semun.val = 0;              /* unused, but keep compiler quiet */
+
+	log_trace("ipcrm -s %d\n", semaphore->semId);
 
 	if (semctl(semaphore->semId, 0, IPC_RMID, semun) < 0)
 	{
@@ -197,6 +205,8 @@ semaphore_cleanup(const char *pidfile)
 		return false;
 	}
 
+	log_trace("Read semaphore id %d from stale pidfile", semaphore.semId);
+
 	return semaphore_unlink(&semaphore);
 }
 
@@ -231,7 +241,8 @@ semaphore_lock(Semaphore *semaphore)
 	if (errStatus < 0)
 	{
 		fformat(stderr,
-				"Failed to acquire a lock with semaphore %d: %m\n",
+				"%d Failed to acquire a lock with semaphore %d: %m\n",
+				getpid(),
 				semaphore->semId);
 		exit(EXIT_CODE_INTERNAL_ERROR);
 	}

--- a/src/bin/pg_autoctl/main.c
+++ b/src/bin/pg_autoctl/main.c
@@ -29,34 +29,7 @@ Semaphore log_semaphore;        /* allows inter-process locking */
 
 
 static void set_logger(void);
-
-
-/*
- * set_logger creates our log semaphore, sets the logging utility aspects such
- * as using colors in an interactive terminal and the default log level.
- */
-static void
-set_logger()
-{
-	/* we're verbose by default */
-	log_set_level(LOG_INFO);
-
-	/*
-	 * Log messages go to stderr. We use colours when stderr is being shown
-	 * directly to the user to make it easier to spot warnings and errors.
-	 */
-	log_use_colors(isatty(fileno(stderr)));
-
-	/* initialise the semaphore used for locking log output */
-	if (!semaphore_init(&log_semaphore))
-	{
-		exit(EXIT_CODE_INTERNAL_ERROR);
-	}
-
-	/* set our logging facility to use our semaphore as a lock mechanism */
-	(void) log_set_udata(&log_semaphore);
-	(void) log_set_lock(&semaphore_log_lock_function);
-}
+static void log_semaphore_unlink_atexit(void);
 
 
 /*
@@ -72,6 +45,9 @@ main(int argc, char **argv)
 
 	/* set our logging infrastructure */
 	(void) set_logger();
+
+	/* register our logging clean-up atexit */
+	atexit(log_semaphore_unlink_atexit);
 
 	/*
 	 * When PG_AUTOCTL_DEBUG is set in the environment, provide the user
@@ -120,11 +96,43 @@ main(int argc, char **argv)
 		exit(EXIT_CODE_BAD_ARGS);
 	}
 
-	if (!semaphore_finish(&log_semaphore))
+	return 0;
+}
+
+
+/*
+ * set_logger creates our log semaphore, sets the logging utility aspects such
+ * as using colors in an interactive terminal and the default log level.
+ */
+static void
+set_logger()
+{
+	/* we're verbose by default */
+	log_set_level(LOG_INFO);
+
+	/*
+	 * Log messages go to stderr. We use colours when stderr is being shown
+	 * directly to the user to make it easier to spot warnings and errors.
+	 */
+	log_use_colors(isatty(fileno(stderr)));
+
+	/* initialise the semaphore used for locking log output */
+	if (!semaphore_init(&log_semaphore))
 	{
-		/* error have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);
 	}
 
-	return 0;
+	/* set our logging facility to use our semaphore as a lock mechanism */
+	(void) log_set_udata(&log_semaphore);
+	(void) log_set_lock(&semaphore_log_lock_function);
+}
+
+
+/*
+ * log_semaphore_unlink_atexit calls semaphore_unlink() atexit.
+ */
+static void
+log_semaphore_unlink_atexit(void)
+{
+	(void) semaphore_finish(&log_semaphore);
 }

--- a/src/bin/pg_autoctl/pgctl.c
+++ b/src/bin/pg_autoctl/pgctl.c
@@ -803,7 +803,7 @@ pg_ctl_initdb(const char *pg_ctl, const char *pgdata)
 
 	/* initdb takes time, so log about the operation BEFORE doing it */
 	log_info("Initialising a PostgreSQL cluster at \"%s\"", pgdata);
-	log_info("%s initdb -s -D %s", pg_ctl, pgdata);
+	log_info("%s initdb -s -D %s --option '--auth=trust'", pg_ctl, pgdata);
 
 	program = run_program(pg_ctl, "initdb",
 						  "--silent",

--- a/src/bin/pg_autoctl/pgctl.c
+++ b/src/bin/pg_autoctl/pgctl.c
@@ -803,6 +803,7 @@ pg_ctl_initdb(const char *pg_ctl, const char *pgdata)
 
 	/* initdb takes time, so log about the operation BEFORE doing it */
 	log_info("Initialising a PostgreSQL cluster at \"%s\"", pgdata);
+	log_info("%s initdb -s -D %s", pg_ctl, pgdata);
 
 	program = run_program(pg_ctl, "initdb",
 						  "--silent",
@@ -811,7 +812,6 @@ pg_ctl_initdb(const char *pg_ctl, const char *pgdata)
 	                      /* avoid warning message */
 						  "--option", "'--auth=trust'",
 						  NULL);
-	log_info("%s initdb -s -D %s", pg_ctl, pgdata);
 
 	success = program.returnCode == 0;
 

--- a/src/bin/pg_autoctl/service_monitor_init.c
+++ b/src/bin/pg_autoctl/service_monitor_init.c
@@ -120,12 +120,6 @@ service_monitor_init_start(void *context, pid_t *pid)
 
 		case 0:
 		{
-			const char *serviceName = createAndRun ?
-									  "pg_autoctl: monitor listener" :
-									  "pg_autoctl: monitor installer";
-
-			(void) set_ps_title(serviceName);
-
 			/*
 			 * We are in a sub-process and didn't call exec() on our pg_autoctl
 			 * do service listener program yet we do not want to clean-up the
@@ -134,6 +128,12 @@ service_monitor_init_start(void *context, pid_t *pid)
 			 * function.
 			 */
 			IntString semIdString = intToString(log_semaphore.semId);
+
+			const char *serviceName = createAndRun ?
+									  "pg_autoctl: monitor listener" :
+									  "pg_autoctl: monitor installer";
+
+			(void) set_ps_title(serviceName);
 
 			setenv(PG_AUTOCTL_LOG_SEMAPHORE, semIdString.strValue, 1);
 

--- a/src/bin/pg_autoctl/service_monitor_init.c
+++ b/src/bin/pg_autoctl/service_monitor_init.c
@@ -146,6 +146,17 @@ service_monitor_init_start(void *context, pid_t *pid)
 			}
 			else
 			{
+				/*
+				 * We are in a sub-process and didn't call exec() on our
+				 * pg_autoctl do service listener program yet we do not want to
+				 * clean-up the semaphore just yet. Publish that we are a
+				 * sub-process and only then quit, avoiding to call the
+				 * atexit() semaphore clean-up function.
+				 */
+				IntString semIdString = intToString(log_semaphore.semId);
+
+				setenv(PG_AUTOCTL_LOG_SEMAPHORE, semIdString.strValue, 1);
+
 				exit(EXIT_CODE_QUIT);
 			}
 		}


### PR DESCRIPTION
Note: We can't move the pidfile cleanup to the atexit stage easily enough because of using a local supervisor variable, and we don't really need to do that anyway because of the way we handle SIGQUIT and stale pidfiles anyway.

See #272.