### PR TITLE
Arrange to forward pg_basebackup output while it's running.

### DIFF
--- a/src/bin/lib/subcommands.c/runprogram.h
+++ b/src/bin/lib/subcommands.c/runprogram.h
@@ -40,6 +40,9 @@ typedef struct
 
 	bool capture;               /* do we capture output, or redirect it? */
 
+	/* register a function to process output as it appears */
+	void (*processBuffer)(const char *buffer, bool error);
+
 	int stdOutFd;               /* redirect stdout to file descriptor */
 	int stdErrFd;               /* redirect stderr to file descriptor */
 
@@ -62,7 +65,10 @@ static void dup2_or_exit(int fildes, int fildes2);
 static void close_or_exit(int fildes);
 static void read_from_pipes(Program *prog,
 							pid_t childPid, int *outpipe, int *errpipe);
-static size_t read_into_buf(int filedes, PQExpBuffer buffer);
+static size_t read_into_buf(Program *prog,
+							int filedes,
+							PQExpBuffer buffer,
+							bool error);
 static void waitprogram(Program *prog, pid_t childPid);
 
 /*
@@ -76,13 +82,14 @@ run_program(const char *program, ...)
 	int nb_args = 0;
 	va_list args;
 	const char *param;
-	Program prog;
+	Program prog = { 0 };
 
 	prog.program = strdup(program);
 	prog.returnCode = -1;
 	prog.error = 0;
 	prog.setsid = false;
 	prog.capture = true;
+	prog.processBuffer = NULL;
 	prog.stdOutFd = -1;
 	prog.stdErrFd = -1;
 	prog.stdOut = NULL;
@@ -494,7 +501,7 @@ read_from_pipes(Program *prog, pid_t childPid, int *outpipe, int *errpipe)
 		{
 			if (FD_ISSET(outpipe[0], &readFileDescriptorSet))
 			{
-				bytes_out = read_into_buf(outpipe[0], outbuf);
+				bytes_out = read_into_buf(prog, outpipe[0], outbuf, false);
 
 				if (bytes_out == -1 && errno != 0)
 				{
@@ -505,7 +512,7 @@ read_from_pipes(Program *prog, pid_t childPid, int *outpipe, int *errpipe)
 
 			if (FD_ISSET(errpipe[0], &readFileDescriptorSet))
 			{
-				bytes_err = read_into_buf(errpipe[0], errbuf);
+				bytes_err = read_into_buf(prog, errpipe[0], errbuf, true);
 
 				if (bytes_err == -1 && errno != 0)
 				{
@@ -568,7 +575,7 @@ waitprogram(Program *prog, pid_t childPid)
  * Read from a file descriptor and directly appends to our buffer string.
  */
 static size_t
-read_into_buf(int filedes, PQExpBuffer buffer)
+read_into_buf(Program *prog, int filedes, PQExpBuffer buffer, bool error)
 {
 	char temp_buffer[BUFSIZE] = { 0 };
 	size_t bytes = read(filedes, temp_buffer, BUFSIZE);
@@ -576,6 +583,11 @@ read_into_buf(int filedes, PQExpBuffer buffer)
 	if (bytes > 0)
 	{
 		appendPQExpBufferStr(buffer, temp_buffer);
+
+		if (prog->processBuffer)
+		{
+			(*prog->processBuffer)(temp_buffer, error);
+		}
 	}
 	return bytes;
 }

--- a/src/bin/lib/subcommands.c/runprogram.h
+++ b/src/bin/lib/subcommands.c/runprogram.h
@@ -134,7 +134,7 @@ Program
 initialize_program(char **args, bool setsid)
 {
 	int argsIndex, nb_args = 0;
-	Program prog;
+	Program prog = { 0 };
 
 	prog.returnCode = -1;
 	prog.error = 0;
@@ -142,6 +142,7 @@ initialize_program(char **args, bool setsid)
 
 	/* this could be changed by the caller before calling execute_program */
 	prog.capture = true;
+	prog.processBuffer = NULL;
 	prog.stdOutFd = -1;
 	prog.stdErrFd = -1;
 

--- a/src/bin/pg_autoctl/pgctl.c
+++ b/src/bin/pg_autoctl/pgctl.c
@@ -658,8 +658,8 @@ pg_basebackup(const char *pgdata,
 
 	/*
 	 * We do not want to call setsid() when running this program, as the
-	 * postgres subprogram is not intended to be its own session leader, but
-	 * remain a sub-process in the same group as pg_autoctl.
+	 * pg_basebackup subprogram is not intended to be its own session leader,
+	 * but remain a sub-process in the same group as pg_autoctl.
 	 */
 	program = initialize_program(args, false);
 	program.processBuffer = &processBufferCallback;

--- a/src/bin/pg_autoctl/pgctl.c
+++ b/src/bin/pg_autoctl/pgctl.c
@@ -599,6 +599,12 @@ pg_basebackup(const char *pgdata,
 	NodeAddress *primaryNode = &(replicationSource->primaryNode);
 	char primaryConnInfo[MAXCONNINFO] = { 0 };
 
+	char *args[16];
+	int argsIndex = 0;
+
+	char command[BUFSIZE];
+	int commandSize = 0;
+
 	log_debug("mkdir -p \"%s\"", replicationSource->backupDir);
 	if (!ensure_empty_dir(replicationSource->backupDir, 0700))
 	{
@@ -633,29 +639,45 @@ pg_basebackup(const char *pgdata,
 		return false;
 	}
 
-	log_info(" %s -w -d '%s' --pgdata %s -U %s "
-			 "--max-rate %s --wal-method=stream --slot %s",
-			 pg_basebackup,
-			 primaryConnInfo,
-			 replicationSource->backupDir,
-			 replicationSource->userName,
-			 replicationSource->maximumBackupRate,
-			 replicationSource->slotName);
+	args[argsIndex++] = (char *) pg_basebackup;
+	args[argsIndex++] = "-w";
+	args[argsIndex++] = "-d";
+	args[argsIndex++] = primaryConnInfo;
+	args[argsIndex++] = "--pgdata";
+	args[argsIndex++] = replicationSource->backupDir;
+	args[argsIndex++] = "-U";
+	args[argsIndex++] = replicationSource->userName;
+	args[argsIndex++] = "--verbose";
+	args[argsIndex++] = "--progress";
+	args[argsIndex++] = "--max-rate";
+	args[argsIndex++] = replicationSource->maximumBackupRate;
+	args[argsIndex++] = "--wal-method=stream";
+	args[argsIndex++] = "--slot";
+	args[argsIndex++] = replicationSource->slotName;
+	args[argsIndex] = NULL;
 
-	program = run_program(pg_basebackup,
-						  "-w",
-						  "-d", primaryConnInfo,
-						  "--pgdata", replicationSource->backupDir,
-						  "-U", replicationSource->userName,
-						  "--verbose",
-						  "--progress",
-						  "--max-rate", replicationSource->maximumBackupRate,
-						  "--wal-method=stream",
-						  "--slot", replicationSource->slotName,
-						  NULL);
+	/*
+	 * We do not want to call setsid() when running this program, as the
+	 * postgres subprogram is not intended to be its own session leader, but
+	 * remain a sub-process in the same group as pg_autoctl.
+	 */
+	program = initialize_program(args, false);
+	program.processBuffer = &processBufferCallback;
 
-	/* pg_basebackup uses stderr for all of its output */
-	(void) log_program_output(program, LOG_INFO, LOG_INFO);
+	/* log the exact command line we're using */
+	commandSize = snprintf_program_command_line(&program, command, BUFSIZE);
+
+	if (commandSize >= BUFSIZE)
+	{
+		/* we only display the first BUFSIZE bytes of the real command */
+		log_info("%s...", command);
+	}
+	else
+	{
+		log_info("%s", command);
+	}
+
+	(void) execute_subprogram(&program);
 
 	returnCode = program.returnCode;
 	free_program(&program);

--- a/src/bin/pg_autoctl/string_utils.c
+++ b/src/bin/pg_autoctl/string_utils.c
@@ -459,12 +459,13 @@ processBufferCallback(const char *buffer, bool error)
 
 	for (lineNumber = 0; lineNumber < lineCount; lineNumber++)
 	{
-		/*
-		 * pg_basebackup and other utilities write their progress output on
-		 * stderr, we don't want to have ERROR message when it's all good.
-		 */
 		if (strneq(outLines[lineNumber], ""))
 		{
+			/*
+			 * pg_basebackup and other utilities write their progress output on
+			 * stderr, we don't want to have ERROR message when it's all good.
+			 * As a result we always target INFO log level here.
+			 */
 			log_info("%s", outLines[lineNumber]);
 		}
 	}

--- a/src/bin/pg_autoctl/string_utils.c
+++ b/src/bin/pg_autoctl/string_utils.c
@@ -443,3 +443,29 @@ splitLines(char *errorMessage, char **linesArray, int size)
 
 	return lineNumber;
 }
+
+
+/*
+ * processBufferCallback is a function callback to use with the subcommands.c
+ * library when we want to output a command's output as it's running, such as
+ * when running a pg_basebackup command.
+ */
+void
+processBufferCallback(const char *buffer, bool error)
+{
+	char *outLines[BUFSIZE] = { 0 };
+	int lineCount = splitLines((char *) buffer, outLines, BUFSIZE);
+	int lineNumber = 0;
+
+	for (lineNumber = 0; lineNumber < lineCount; lineNumber++)
+	{
+		/*
+		 * pg_basebackup and other utilities write their progress output on
+		 * stderr, we don't want to have ERROR message when it's all good.
+		 */
+		if (strneq(outLines[lineNumber], ""))
+		{
+			log_info("%s", outLines[lineNumber]);
+		}
+	}
+}

--- a/src/bin/pg_autoctl/string_utils.h
+++ b/src/bin/pg_autoctl/string_utils.h
@@ -35,5 +35,6 @@ bool stringToInt32(const char *str, int32_t *number);
 bool stringToUInt32(const char *str, uint32_t *number);
 
 int splitLines(char *errorMessage, char **linesArray, int size);
+void processBufferCallback(const char *buffer, bool error);
 
 #endif /* STRING_UTILS_h */


### PR DESCRIPTION
This can be a pretty long operation and being in the dark for its whole
duration is not a great user experience.