### PR TITLE
doc: minor fixes to spelling and formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@
 * Feature add perform destroy command, and -destroy option to drop node command #141
 * Feature support debian/ubuntu style PostgreSQLclusters #135
 * Feature add files option to show command
-* Feature add --run option to create commmand #110
+* Feature add --run option to create command #110
 * Feature add --json option to all commands for json output #106
 * Feature report current LSN of Postgres nodes rather than WAL lag. (#53)
 

--- a/README.md
+++ b/README.md
@@ -155,16 +155,16 @@ Once the building and installation is done, follow those steps:
          To determine your nodename `pg_autoctl` implements the following
          three steps:
 
-           1. open a connection to the monitor and looks the TCP/IP client
+           1. open a connection to the monitor and looks up the TCP/IP client
               address that has been used to make that connection.
 
            2. Do a reverse DNS lookup on this IP address to fetch a
               hostname for our local machine.
 
-           3. If the reverse DNS lookup is successfull , then `pg_autoctl`
+           3. If the reverse DNS lookup is successful, then `pg_autoctl`
               does with a forward DNS lookup of that hostname.
 
-         When the forward DNS lookup repsonse in step 3. is an IP address
+         When the forward DNS lookup response in step 3. is an IP address
          found in one of our local network interfaces, then `pg_autoctl`
          uses the hostname found in step 2. as the default `--nodename`.
          Otherwise it uses the IP address found in step 1.

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -118,7 +118,7 @@ Client-side HA
 
 Implementing client-side High Availability is included in PostgreSQL's
 driver `libpq` from version 10 onward. Using this driver, it is possible to
-specify mulitple host names or IP addresses in the same connection string::
+specify multiple host names or IP addresses in the same connection string::
 
   $ psql -d "postgresql://host1,host2/dbname?target_session_attrs=read-write"
   $ psql -d "postgresql://host1:port2,host2:port2/dbname?target_session_attrs=read-write"
@@ -147,7 +147,7 @@ When using pg_auto_failover, configure your application connection string to use
 primary and the secondary server host names, and set
 ``target_session_attrs=read-write`` too, so that your application
 automatically connects to the current primary, even after a failover
-occured.
+occurred.
 
 Monitoring protocol
 -------------------
@@ -203,7 +203,7 @@ following to ``postgresql.conf``::
  synchronous_commit = 'local'
 
 This ensures that writes return as soon as they are committed on the primary
-under all circumstance. In that case, failover might lead to some data loss,
+under all circumstances. In that case, failover might lead to some data loss,
 but failover is not initiated if the secondary is more than 10 WAL segments
 (configurable) behind on the primary. During a manual failover, the standby
 will continue accepting writes from the old primary and will stop only if

--- a/docs/fault-tolerance.rst
+++ b/docs/fault-tolerance.rst
@@ -1,7 +1,7 @@
 pg_auto_failover Fault Tolerance
 ================================
 
-At the heart of the pg_auto_failover implemetation is a State Machine. The state
+At the heart of the pg_auto_failover implementation is a State Machine. The state
 machine is driven by the monitor, and its transitions are implemented in the
 keeper service, which then reports success to the monitor.
 
@@ -18,7 +18,7 @@ Unhealthy Nodes
 ---------------
 
 The pg_auto_failover monitor is responsible for running regular health-checks with
-every PostgreSQL node it manages. A health-check is successul when it is
+every PostgreSQL node it manages. A health-check is successful when it is
 able to connect to the PostgreSQL node using the PostgreSQL protocol
 (libpq), imitating the ``pg_isready`` command.
 

--- a/docs/fsm/node-state-machine
+++ b/docs/fsm/node-state-machine
@@ -36,7 +36,7 @@ draining : marked unhealthy, stop writes
 demote_timeout : waiting for drain timeout to expire
 demoted : drain timeout expired, node should be down
 catching_up : following a primary but not caught up
-secondary : folling a primary, caught up
+secondary : following a primary, caught up
 prepare_promotion : secondary doesn't converge to this
 prepare_promotion : state until it has caught up with the
 prepare_promotion : primary or timed-out trying

--- a/docs/operations.rst
+++ b/docs/operations.rst
@@ -123,7 +123,7 @@ minimum.
 In the case of pg_auto_failover, because we use **synchronous replication**,
 we don't face data loss risks when triggering a manual failover. Moreover,
 our monitor knows the current primary health at the time when the failover
-is triggerred, and drives the failover accordingly.
+is triggered, and drives the failover accordingly.
 
 So to trigger a controlled switchover with pg_auto_failover you can use the
 same API as for a manual failover::

--- a/docs/ref/configuration.rst
+++ b/docs/ref/configuration.rst
@@ -39,7 +39,7 @@ operations:
     safely, and the wal lag is 0 in that case.
 
     In the case when the secondary server had been detected unhealthy
-    before, then the pg_auto_failover monitor switches it from the sate SECONDARY to
+    before, then the pg_auto_failover monitor switches it from the state SECONDARY to
     the state CATCHING-UP and promotion is prevented then.
 
     The following setting allows to still promote the secondary, allowing
@@ -53,7 +53,8 @@ pg_auto_failover Monitor
 The configuration for the behavior of the monitor happens in the PostgreSQL
 database where the extension has been deployed::
 
-  pg_auto_failover=> select name, setting, unit, short_desc from pg_settings where name ~ 'pgautofailover.';                                                                                                                                                                                                                                                           -[ RECORD 1 ]----------------------------------------------------------------------------------------------------
+  pg_auto_failover=> select name, setting, unit, short_desc from pg_settings where name ~ 'pgautofailover.';
+  -[ RECORD 1 ]----------------------------------------------------------------------------------------------------
   name       | pgautofailover.enable_sync_wal_log_threshold
   setting    | 16777216
   unit       |

--- a/docs/ref/reference.rst
+++ b/docs/ref/reference.rst
@@ -118,16 +118,16 @@ commands are dealing with the monitor:
      provided, a default value is computed by running the following
      algorithm:
 
-       1. Open a connection to the 8.8.8.8:53 public service and looks the
+       1. Open a connection to the 8.8.8.8:53 public service and looks up the
           TCP/IP client address that has been used to make that connection.
 
        2. Do a reverse DNS lookup on this IP address to fetch a hostname for
           our local machine.
 
-       3. If the reverse DNS lookup is successfull , then `pg_autoctl` does
+       3. If the reverse DNS lookup is successful , then `pg_autoctl` does
           with a forward DNS lookup of that hostname.
 
-     When the forward DNS lookup repsonse in step 3. is an IP address found
+     When the forward DNS lookup response in step 3. is an IP address found
      in one of our local network interfaces, then `pg_autoctl` uses the
      hostname found in step 2. as the default `--nodename`. Otherwise it
      uses the IP address found in step 1.
@@ -356,7 +356,7 @@ corresponding to as many implementation strategies.
      The monitor answers to the registration call with a state to assign to
      the new member of the group, either *SINGLE* or *WAIT_STANDBY*. When
      the assigned state is *SINGLE*, then ``pg_autoctl create postgres``
-     procedes to initialize a new PostgreSQL instance.
+     proceedes to initialize a new PostgreSQL instance.
 
   2. Initialize an already existing primary server
 
@@ -381,7 +381,7 @@ corresponding to as many implementation strategies.
      states of registering a secondary server, which includes preparing the
      primary server PostgreSQL HBA rules and creating a replication slot.
 
-     When the command ends succesfully, a PostgreSQL secondary server has
+     When the command ends successfully, a PostgreSQL secondary server has
      been created with ``pg_basebackup`` and is now started, catching-up to
      the primary server.
 


### PR DESCRIPTION
Nothing terribly interesting, just a few tyops and a formatting error found when reading the docs.