### PR TITLE
Fix pgautofailover extension upgrade script from 1.2 to 1.3.

### DIFF
--- a/src/monitor/pgautofailover--1.2--1.3.sql
+++ b/src/monitor/pgautofailover--1.2--1.3.sql
@@ -68,6 +68,8 @@ ALTER TABLE pgautofailover.event
 
 DROP TYPE pgautofailover.old_replication_state;
 
+ALTER TABLE pgautofailover.formation
+  ADD COLUMN number_sync_standbys int  NOT NULL DEFAULT 1;
 
 DROP FUNCTION IF EXISTS pgautofailover.create_formation(text, text);
 


### PR DESCRIPTION
When using Postgres < 12 we can't ALTER an ENUM TYPE within a transaction,
and the extension upgrade script runs in a transaction. Which means we can't
upgrade pgautofailover when using Postgres 12 at the moment.

The fix requires dropping the enum type entirely, keeping the data in its
text form, and casting the data again to the new enum type after it's been
created. It's the long and painful way, but it is required for our support
of Postgres 10 and 11.