### PR TITLE
Improve pg_autoctl perform failover/switchover default --group.

### DIFF
--- a/src/bin/pg_autoctl/cli_perform.c
+++ b/src/bin/pg_autoctl/cli_perform.c
@@ -76,7 +76,7 @@ cli_perform_failover_getopts(int argc, char **argv)
 	};
 
 	/* set default values for our options, when we have some */
-	options.groupId = 0;
+	options.groupId = -1;
 	options.network_partition_timeout = -1;
 	options.prepare_promotion_catchup = -1;
 	options.prepare_promotion_walreceiver = -1;
@@ -198,6 +198,7 @@ cli_perform_failover(int argc, char **argv)
 {
 	KeeperConfig config = keeperOptions;
 	Monitor monitor = { 0 };
+	int groupsCount = 0;
 
 	if (!monitor_init_from_pgsetup(&monitor, &config.pgSetup))
 	{
@@ -205,9 +206,44 @@ cli_perform_failover(int argc, char **argv)
 		exit(EXIT_CODE_BAD_ARGS);
 	}
 
-	if (!monitor_perform_failover(&monitor, config.formation, config.groupId))
+	if (!monitor_count_groups(&monitor, config.formation, &groupsCount))
 	{
 		/* errors have already been logged */
+		exit(EXIT_CODE_MONITOR);
+	}
+
+	if (groupsCount == 0)
+	{
+		/* nothing to be done here */
+		log_fatal("The monitor currently has no Postgres nodes registered");
+		exit(EXIT_CODE_BAD_STATE);
+	}
+
+	/*
+	 * When --group was not given, we may proceed when there is only one
+	 * possible target group in the formation, which is the case with Postgres
+	 * standalone setups.
+	 */
+	if (config.groupId == -1)
+	{
+		if (groupsCount == 1)
+		{
+			/* we have only one group, it's group number zero, proceed */
+			config.groupId = 0;
+		}
+		else
+		{
+			log_error("Please use the --group option to target a "
+					  "specific group in formation \"%s\"",
+					  config.formation);
+			exit(EXIT_CODE_BAD_ARGS);
+		}
+	}
+
+	if (!monitor_perform_failover(&monitor, config.formation, config.groupId))
+	{
+		log_fatal("Failed to perform failover/switchover, "
+				  "see above for details");
 		exit(EXIT_CODE_MONITOR);
 	}
 }

--- a/src/bin/pg_autoctl/monitor.h
+++ b/src/bin/pg_autoctl/monitor.h
@@ -108,6 +108,7 @@ bool monitor_set_formation_number_sync_standbys(Monitor *monitor, char *formatio
 												int numberSyncStandbys);
 
 bool monitor_remove(Monitor *monitor, char *host, int port);
+bool monitor_count_groups(Monitor *monitor, char *formation, int *groupsCount);
 bool monitor_perform_failover(Monitor *monitor, char *formation, int group);
 
 bool monitor_print_state(Monitor *monitor, char *formation, int group);


### PR DESCRIPTION
Refuse to proceed with default group 0 when there is more than one group
registered in the target formation on the monitor, ask the user to specify
the target group with using the --group option.

Otherwise, suprises might ensue.