### PR TITLE
Command pg_autoctl perform failover now waits until failover is done.

### DIFF
--- a/src/bin/pg_autoctl/cli_perform.c
+++ b/src/bin/pg_autoctl/cli_perform.c
@@ -257,7 +257,9 @@ cli_perform_failover(int argc, char **argv)
 	}
 
 	/* process state changes notification until we have a new primary */
-	if (!monitor_wait_until_new_primary(&monitor, config.formation))
+	if (!monitor_wait_until_new_primary(&monitor,
+										config.formation,
+										config.groupId))
 	{
 		log_error("Failed to wait until a new primary has been notified");
 		exit(EXIT_CODE_INTERNAL_ERROR);

--- a/src/bin/pg_autoctl/cli_perform.c
+++ b/src/bin/pg_autoctl/cli_perform.c
@@ -200,6 +200,8 @@ cli_perform_failover(int argc, char **argv)
 	Monitor monitor = { 0 };
 	int groupsCount = 0;
 
+	char *channels[] = { "state", NULL };
+
 	if (!monitor_init_from_pgsetup(&monitor, &config.pgSetup))
 	{
 		/* errors have already been logged */
@@ -240,10 +242,24 @@ cli_perform_failover(int argc, char **argv)
 		}
 	}
 
+	/* start listening to the state changes before we call perform_failover */
+	if (!pgsql_listen(&(monitor.pgsql), channels))
+	{
+		log_error("Failed to listen to state changes from the monitor");
+		exit(EXIT_CODE_MONITOR);
+	}
+
 	if (!monitor_perform_failover(&monitor, config.formation, config.groupId))
 	{
 		log_fatal("Failed to perform failover/switchover, "
 				  "see above for details");
 		exit(EXIT_CODE_MONITOR);
+	}
+
+	/* process state changes notification until we have a new primary */
+	if (!monitor_wait_until_new_primary(&monitor, config.formation))
+	{
+		log_error("Failed to wait until a new primary has been notified");
+		exit(EXIT_CODE_INTERNAL_ERROR);
 	}
 }

--- a/src/bin/pg_autoctl/monitor.c
+++ b/src/bin/pg_autoctl/monitor.c
@@ -3022,9 +3022,7 @@ monitor_wait_until_new_primary(Monitor *monitor,
 			StateNotification notification = { 0 };
 
 			uint64_t now = time(NULL);
-			time_t t = time(NULL);
-			struct tm *lt;
-			char time[16];
+			char timestring[MAXCTIMESIZE];
 
 			if ((now - start) > PG_AUTOCTL_LISTEN_NOTIFICATIONS_TIMEOUT)
 			{
@@ -3058,12 +3056,14 @@ monitor_wait_until_new_primary(Monitor *monitor,
 				continue;
 			}
 
-			/* same as in src/bin/lib/log/src/log.c */
-			lt = localtime(&t);
-			time[strftime(time, sizeof(time), "%H:%M:%S", lt)] = '\0';
+			/* format the current time to be user-friendly */
+			epoch_to_string(now, timestring);
+
+			/* "Wed Jun 30 21:49:08 1993" -> "21:49:08" */
+			timestring[11 + 8] = '\0';
 
 			fformat(stdout, "%8s | %3d | %*s | %6d | %18s | %18s\n",
-					time,
+					timestring + 11,
 					notification.nodeId, maxNodeNameSize,
 					notification.nodeName,
 					notification.nodePort,

--- a/src/bin/pg_autoctl/monitor.h
+++ b/src/bin/pg_autoctl/monitor.h
@@ -159,7 +159,9 @@ bool monitor_wait_until_primary_applied_settings(Monitor *monitor,
 bool monitor_wait_until_node_reported_state(Monitor *monitor,
 											int nodeId,
 											NodeState state);
-bool monitor_wait_until_new_primary(Monitor *monitor, const char *formation);
+bool monitor_wait_until_new_primary(Monitor *monitor,
+									const char *formation,
+									int groupId);
 
 bool monitor_get_extension_version(Monitor *monitor,
 								   MonitorExtensionVersion *version);

--- a/src/bin/pg_autoctl/monitor.h
+++ b/src/bin/pg_autoctl/monitor.h
@@ -159,6 +159,7 @@ bool monitor_wait_until_primary_applied_settings(Monitor *monitor,
 bool monitor_wait_until_node_reported_state(Monitor *monitor,
 											int nodeId,
 											NodeState state);
+bool monitor_wait_until_new_primary(Monitor *monitor, const char *formation);
 
 bool monitor_get_extension_version(Monitor *monitor,
 								   MonitorExtensionVersion *version);


### PR DESCRIPTION
We use the same approach as when applying a new setting: listen to
notification messages from the monitor and parse them until we see that we
have reached the expected target state.

In this case it's easy, we now we reached the target state when we see the
notification of a node reaching state primary.