### PR TITLE
Ignore .bc files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Global excludes across all subdirectories
 *.o
+*.bc
 *.so
 *.so.[0-9]
 *.so.[0-9].[0-9]


### PR DESCRIPTION
These are generated when you have compiled postgres with --with-llvm,
which enables JIT support for the monitor extension.