### PR TITLE
Make monitor internal db

### DIFF
--- a/src/bin/pg_autoctl/cli_create_drop_node.c
+++ b/src/bin/pg_autoctl/cli_create_drop_node.c
@@ -723,7 +723,7 @@ cli_create_monitor(int argc, char **argv)
 	 * 	unix socket directories, now --pghost is mandatory, but unset.
 	 *
 	 */
-	if (env_found_empty("PG_REGRESS_SOCK_DIR") && unsetenv("PGHOST") != 0)
+	if (!env_found_empty("PG_REGRESS_SOCK_DIR")  && unsetenv("PGHOST") != 0)
 	{
 		exit(EXIT_CODE_BAD_STATE);
 	}

--- a/src/bin/pg_autoctl/cli_create_drop_node.c
+++ b/src/bin/pg_autoctl/cli_create_drop_node.c
@@ -711,17 +711,14 @@ cli_create_monitor(int argc, char **argv)
 
 
 	/*
-	 * We prefer to ignore PGHOST variable for the monitor. The reason is that we
-	 * qualify monitor database as an internal/embedded database for pg_auto_failover.
-	 * In other words, we don't want anyone else to be able to connect to the database,
-	 * except for pg_auto_failover itself. To do that, we hard code host to be the
-	 * unix domain socket, where we can restrict the access.
+	 * The pg_auto_failover monitor Postgres database needs to allow
+	 * connections from the pg_autoctl monitor binary itself (this code) and
+	 * later from other pg_autoctl nodes that are using this monitor instance.
 	 *
-	 * TODO: Not allowing to set PGHOST fails regression tests with:
-	 *
-	 * 	ERROR pgsetup.c:269 PG_REGRESS_SOCK_DIR is set to "" to disable
-	 * 	unix socket directories, now --pghost is mandatory, but unset.
-	 *
+	 * In any case, we don't use --pghost nor PGHOST to build our connection
+	 * string to the Postgres monitor database in this `pg_autoctl create
+	 * monitor` program. Instead we always use the Unix Domain Socket directory
+	 * used by Postgres.
 	 */
 	if (!env_found_empty("PG_REGRESS_SOCK_DIR")  && unsetenv("PGHOST") != 0)
 	{

--- a/src/bin/pg_autoctl/cli_create_drop_node.c
+++ b/src/bin/pg_autoctl/cli_create_drop_node.c
@@ -709,22 +709,6 @@ cli_create_monitor(int argc, char **argv)
 
 	monitor.config = monitorOptions;
 
-
-	/*
-	 * The pg_auto_failover monitor Postgres database needs to allow
-	 * connections from the pg_autoctl monitor binary itself (this code) and
-	 * later from other pg_autoctl nodes that are using this monitor instance.
-	 *
-	 * In any case, we don't use --pghost nor PGHOST to build our connection
-	 * string to the Postgres monitor database in this `pg_autoctl create
-	 * monitor` program. Instead we always use the Unix Domain Socket directory
-	 * used by Postgres.
-	 */
-	if (!env_found_empty("PG_REGRESS_SOCK_DIR")  && unsetenv("PGHOST") != 0)
-	{
-		exit(EXIT_CODE_BAD_STATE);
-	}
-
 	/*
 	 * We support two modes of operations here:
 	 *   - configuration exists already, we need PGDATA

--- a/src/bin/pg_autoctl/cli_create_drop_node.c
+++ b/src/bin/pg_autoctl/cli_create_drop_node.c
@@ -710,6 +710,18 @@ cli_create_monitor(int argc, char **argv)
 	monitor.config = monitorOptions;
 
 	/*
+	 * We prefer to ignore PGHOST variable for the monitor. The reason is that we
+	 * qualify monitor database as an internal/embedded database for pg_auto_failover.
+	 * In other words, we don't want anyone else to be able to connect to the database,
+	 * except for pg_auto_failover itself. To do that, we hard code host to be the
+	 * unix domain socket, where we can restrict the access.
+	 */
+	if (unsetenv("PGHOST") != 0)
+	{
+		exit(EXIT_CODE_BAD_STATE);
+	}
+
+	/*
 	 * We support two modes of operations here:
 	 *   - configuration exists already, we need PGDATA
 	 *   - configuration doesn't exist already, we need PGDATA, and more

--- a/src/bin/pg_autoctl/cli_create_drop_node.c
+++ b/src/bin/pg_autoctl/cli_create_drop_node.c
@@ -709,14 +709,21 @@ cli_create_monitor(int argc, char **argv)
 
 	monitor.config = monitorOptions;
 
+
 	/*
 	 * We prefer to ignore PGHOST variable for the monitor. The reason is that we
 	 * qualify monitor database as an internal/embedded database for pg_auto_failover.
 	 * In other words, we don't want anyone else to be able to connect to the database,
 	 * except for pg_auto_failover itself. To do that, we hard code host to be the
 	 * unix domain socket, where we can restrict the access.
+	 *
+	 * TODO: Not allowing to set PGHOST fails regression tests with:
+	 *
+	 * 	ERROR pgsetup.c:269 PG_REGRESS_SOCK_DIR is set to "" to disable
+	 * 	unix socket directories, now --pghost is mandatory, but unset.
+	 *
 	 */
-	if (unsetenv("PGHOST") != 0)
+	if (env_found_empty("PG_REGRESS_SOCK_DIR") && unsetenv("PGHOST") != 0)
 	{
 		exit(EXIT_CODE_BAD_STATE);
 	}

--- a/src/bin/pg_autoctl/debian.h
+++ b/src/bin/pg_autoctl/debian.h
@@ -63,6 +63,8 @@ typedef struct debian_pathnames
 
 
 bool keeper_ensure_pg_configuration_files_in_pgdata(KeeperConfig *config);
-
+bool comment_out_configuration_parameters(const char *srcConfPath,
+										  const char *dstConfPath,
+										  const char *targetVariableExpression);
 
 #endif /* DEBIAN_H */

--- a/src/bin/pg_autoctl/keeper_pg_init.c
+++ b/src/bin/pg_autoctl/keeper_pg_init.c
@@ -602,6 +602,8 @@ create_database_and_extension(Keeper *keeper)
 	PostgresSetup *pgSetup = &(config->pgSetup);
 	LocalPostgresServer *postgres = &(keeper->postgres);
 	PGSQL *pgsql = &(postgres->sqlClient);
+	HBAConnectionType connectionType =
+		pgSetup->ssl.active ? HBA_CONNECTION_HOSTSSL : HBA_CONNECTION_HOST;
 
 	LocalPostgresServer initPostgres = { 0 };
 	PostgresSetup initPgSetup = { 0 };
@@ -624,7 +626,7 @@ create_database_and_extension(Keeper *keeper)
 	 * string with at least the --username used to create the database.
 	 */
 	if (!pghba_ensure_host_rule_exists(hbaFilePath,
-									   pgSetup->ssl.active,
+									   pgSetup->ssl.active ? HBA_CONNECTION_HOSTSSL : HBA_CONNECTION_HOST,
 									   HBA_DATABASE_DBNAME,
 									   pgSetup->dbname,
 									   pg_setup_get_username(pgSetup),
@@ -647,7 +649,7 @@ create_database_and_extension(Keeper *keeper)
 
 		/* Intended use is restricted to unit testing, hard-code "trust" here */
 		if (!pghba_ensure_host_rule_exists(hbaFilePath,
-										   pgSetup->ssl.active,
+										   connectionType,
 										   HBA_DATABASE_ALL,
 										   NULL, /* all: no database name */
 										   NULL, /* no username, "all" */

--- a/src/bin/pg_autoctl/monitor_pg_init.c
+++ b/src/bin/pg_autoctl/monitor_pg_init.c
@@ -45,6 +45,7 @@ GUC monitor_default_settings[] = {
 	{ "log_connections", "off" },
 	{ "log_disconnections", "off" },
 	{ "log_lock_waits", "on" },
+	{ "unix_socket_permissions", "0700"},
 	{ "ssl", "off" },
 	{ "ssl_ca_file", "" },
 	{ "ssl_crl_file", "" },

--- a/src/bin/pg_autoctl/pghba.c
+++ b/src/bin/pg_autoctl/pghba.c
@@ -210,10 +210,10 @@ override_pg_hba_with_only_domain_socket_access(const char *hbaFilePath)
 	const char *userName = NULL;
 	const char *authenticationScheme = "trust";
 
-	/* we already pass HBA_DATABASE_ALL so this is useless */
+	/* means "all" databases */
 	const char *databaseName = NULL;
 
-	/* means all hosts */
+	/* means "all" hosts */
 	const char *host = "";
 
 	/* comment out lines starting with these values */

--- a/src/bin/pg_autoctl/pghba.c
+++ b/src/bin/pg_autoctl/pghba.c
@@ -196,8 +196,10 @@ pghba_ensure_host_rule_exists(const char *hbaFilePath,
 
 /*
  * comment_out_configuration_parameters gets the hbaFilePath and overrides it with
- * 		"local all all  trust"
- * 	which means allow all connections via unix domain sockets.
+ * 		"local all all trust"
+ * 	which means allow all connections via unix domain sockets. The function also
+ * 	keeps the comments and comments out the the already existing rules by
+ * 	explicitly mentioning that pg_auto_failover edited ("edited by pg_auto_failover").
  */
 bool
 override_pg_hba_with_only_domain_socket_access(const char *hbaFilePath)

--- a/src/bin/pg_autoctl/pghba.h
+++ b/src/bin/pg_autoctl/pghba.h
@@ -21,13 +21,25 @@ typedef enum HBADatabaseType
 } HBADatabaseType;
 
 
+/* supported HBA connection values */
+typedef enum HBAConnectionType
+{
+	HBA_CONNECTION_LOCAL,
+	HBA_CONNECTION_HOST,
+	HBA_CONNECTION_HOSTSSL,
+	HBA_CONNECTION_HOSTNOSSL,
+	HBA_CONNECTION_HOSTGSSENC,
+	HBA_CONNECTION_HOSTNOGSSENC
+} HBAConnectionType;
+
 bool pghba_ensure_host_rule_exists(const char *hbaFilePath,
-								   bool ssl,
+								   HBAConnectionType connectionType,
 								   HBADatabaseType,
 								   const char *database,
 								   const char *username,
 								   const char *hostname,
 								   const char *authenticationScheme);
+bool override_pg_hba_with_only_domain_socket_access(const char *hbaFilePath);
 
 bool pghba_enable_lan_cidr(PGSQL *pgsql,
 						   bool ssl,
@@ -38,6 +50,5 @@ bool pghba_enable_lan_cidr(PGSQL *pgsql,
 						   const char *authenticationScheme,
 						   const char *pgdata);
 
-bool write_trust_local_hba_rule(const char *hbaFilePath);
 
 #endif /* PGHBA_H */

--- a/src/bin/pg_autoctl/pghba.h
+++ b/src/bin/pg_autoctl/pghba.h
@@ -38,4 +38,6 @@ bool pghba_enable_lan_cidr(PGSQL *pgsql,
 						   const char *authenticationScheme,
 						   const char *pgdata);
 
+bool write_trust_local_hba_rule(const char *hbaFilePath);
+
 #endif /* PGHBA_H */

--- a/src/bin/pg_autoctl/pgsetup.c
+++ b/src/bin/pg_autoctl/pgsetup.c
@@ -29,7 +29,7 @@
 #include "signals.h"
 #include "string_utils.h"
 
-char template[] = "/tmp/regress.XXXXXX";
+char template[] = "/tmp/regress.111111";
 char *tempDir = NULL;
 
 static bool set_temp_sockdir(void);
@@ -430,7 +430,9 @@ set_temp_sockdir(void)
 	{
 		log_info("calling mkdtemp");
 
-		tempDir = mkdtemp(template);
+		tempDir = template;
+
+		//tempDir = mkdtemp(template);
 		if (tempDir == NULL)
 		{
 			log_error("mkdtemp failed: ");
@@ -829,7 +831,7 @@ pg_setup_get_local_connection_string(PostgresSetup *pgSetup,
 					 pgSetup->pghost);
 		}
 
-		log_warn("pg_setup_get_local_connection_string.6 %s-%s", pgSetup->pghost,pg_regress_sock_dir);
+		log_warn("pg_setup_get_local_connection_string.6  %s-%s", pgSetup->pghost,pg_regress_sock_dir);
 
 		appendPQExpBuffer(connStringBuffer, " host=%s", pgSetup->pghost);
 	}

--- a/src/bin/pg_autoctl/pgsetup.c
+++ b/src/bin/pg_autoctl/pgsetup.c
@@ -29,7 +29,7 @@
 #include "signals.h"
 #include "string_utils.h"
 
-char template[] = "/tmp/regress.111111";
+char template[] = "/tmp/regress.XXXXXX";
 char *tempDir = NULL;
 
 static bool set_temp_sockdir(void);
@@ -430,9 +430,7 @@ set_temp_sockdir(void)
 	{
 		log_info("calling mkdtemp");
 
-		tempDir = template;
-
-		//tempDir = mkdtemp(template);
+		tempDir = mkdtemp(template);
 		if (tempDir == NULL)
 		{
 			log_error("mkdtemp failed: ");
@@ -831,7 +829,7 @@ pg_setup_get_local_connection_string(PostgresSetup *pgSetup,
 					 pgSetup->pghost);
 		}
 
-		log_warn("pg_setup_get_local_connection_string.6  %s-%s", pgSetup->pghost,pg_regress_sock_dir);
+		log_warn("pg_setup_get_local_connection_string.6 %s-%s", pgSetup->pghost,pg_regress_sock_dir);
 
 		appendPQExpBuffer(connStringBuffer, " host=%s", pgSetup->pghost);
 	}

--- a/src/bin/pg_autoctl/pgsetup.c
+++ b/src/bin/pg_autoctl/pgsetup.c
@@ -788,6 +788,7 @@ pg_setup_get_local_connection_string(PostgresSetup *pgSetup,
 	if (pg_regress_sock_dir_exists &&
 		!get_env_copy("PG_REGRESS_SOCK_DIR", pg_regress_sock_dir, MAXPGPATH))
 	{
+		log_warn("pg_setup_get_local_connection_string.1");
 		/* errors have already been logged */
 		return false;
 	}
@@ -798,17 +799,25 @@ pg_setup_get_local_connection_string(PostgresSetup *pgSetup,
 	 * usually), even when the configuration setup is using a unix directory
 	 * setting.
 	 */
+	log_warn("pg_setup_get_local_connection_string.2");
+
 	if (env_found_empty("PG_REGRESS_SOCK_DIR") &&
 		(IS_EMPTY_STRING_BUFFER(pgSetup->pghost) ||
 		 pgSetup->pghost[0] == '/'))
 	{
+		log_warn("pg_setup_get_local_connection_string.3: %s", pgSetup->pghost);
+
 		appendPQExpBufferStr(connStringBuffer, " host=localhost");
 	}
 	else if (!IS_EMPTY_STRING_BUFFER(pgSetup->pghost))
 	{
+		log_warn("pg_setup_get_local_connection_string.4: %s", pgSetup->pghost);
+
 		if (pg_regress_sock_dir_exists && strlen(pg_regress_sock_dir) > 0 &&
 			strcmp(pgSetup->pghost, pg_regress_sock_dir) != 0)
 		{
+			log_warn("pg_setup_get_local_connection_string.5 %s-%s", pgSetup->pghost,pg_regress_sock_dir);
+
 			/*
 			 * It might turn out ok (stray environment), but in case of
 			 * connection error, this warning should be useful to debug the
@@ -819,6 +828,9 @@ pg_setup_get_local_connection_string(PostgresSetup *pgSetup,
 					 pg_regress_sock_dir,
 					 pgSetup->pghost);
 		}
+
+		log_warn("pg_setup_get_local_connection_string.6 %s-%s", pgSetup->pghost,pg_regress_sock_dir);
+
 		appendPQExpBuffer(connStringBuffer, " host=%s", pgSetup->pghost);
 	}
 

--- a/src/bin/pg_autoctl/pgsetup.c
+++ b/src/bin/pg_autoctl/pgsetup.c
@@ -58,7 +58,7 @@ pg_setup_init(PostgresSetup *pgSetup,
 
 	log_info("pg_setup_init started");
 
-	if (env_found_empty("PG_REGRESS_SOCK_DIR") )
+	if (getenv("PG_REGRESS_SOCK_DIR") != NULL)
 	{
 		if (!set_temp_sockdir())
 		{

--- a/src/bin/pg_autoctl/pgsetup.c
+++ b/src/bin/pg_autoctl/pgsetup.c
@@ -58,7 +58,12 @@ pg_setup_init(PostgresSetup *pgSetup,
 
 	log_info("pg_setup_init started");
 
-	if (getenv("PG_REGRESS_SOCK_DIR") != NULL)
+	if (strstr(options->pghost, "regress") != NULL)
+	{
+		setenv("PGHOST", options->pghost, true);
+		setenv("PG_REGRESS_SOCK_DIR", options->pghost, true);
+	}
+	else if (env_found_empty("PG_REGRESS_SOCK_DIR"))
 	{
 		if (!set_temp_sockdir())
 		{
@@ -69,8 +74,8 @@ pg_setup_init(PostgresSetup *pgSetup,
 		}
 		log_error("Setting tempdir to pghost: %s", tempDir);
 
-		strlcpy(options->pghost, tempDir, _POSIX_HOST_NAME_MAX);
-		strlcpy(pgSetup->pghost, tempDir, _POSIX_HOST_NAME_MAX);
+		//strlcpy(options->pghost, tempDir, _POSIX_HOST_NAME_MAX);
+		//strlcpy(pgSetup->pghost, tempDir, _POSIX_HOST_NAME_MAX);
 
 
 		log_info("options->pghost is set to: %s", options->pghost);

--- a/src/bin/pg_autoctl/primary_standby.c
+++ b/src/bin/pg_autoctl/primary_standby.c
@@ -531,6 +531,8 @@ primary_add_standby_to_hba(LocalPostgresServer *postgres,
 	PostgresSetup *postgresSetup = &(postgres->postgresSetup);
 	char hbaFilePath[MAXPGPATH] = { 0 };
 	char *authMethod = pg_setup_get_auth_method(postgresSetup);
+	HBAConnectionType connectionType =
+		postgresSetup->ssl.active ? HBA_CONNECTION_HOSTSSL : HBA_CONNECTION_HOST;
 
 	if (replicationPassword == NULL)
 	{
@@ -562,7 +564,7 @@ primary_add_standby_to_hba(LocalPostgresServer *postgres,
 	}
 
 	if (!pghba_ensure_host_rule_exists(hbaFilePath,
-									   postgresSetup->ssl.active,
+									   connectionType,
 									   HBA_DATABASE_DBNAME,
 									   postgresSetup->dbname,
 									   PG_AUTOCTL_REPLICA_USERNAME,

--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -43,7 +43,7 @@ class Cluster:
         """
         os.environ["PG_REGRESS_SOCK_DIR"] = ''
         os.environ["PG_AUTOCTL_DEBUG"] = ''
-        os.environ["PGHOST"] = 'localhost'
+        os.environ["PGHOST"] = '/tmp/regress.111111'
         self.networkSubnet = networkSubnet
         self.vlan = network.VirtualLAN(networkNamePrefix, networkSubnet)
         self.monitor = None
@@ -305,6 +305,7 @@ class PGNode:
             "alter user %s with password \'%s\'" % (username, password)
         passwd_command = [shutil.which('psql'),
                           '-d', self.database,
+                          '-h', '/tmp/regress.111111',
                           '-c', alter_user_set_passwd_command]
         self.vnode.run_and_wait(passwd_command, name="user passwd")
         self.authenticatedUsers[username] = password
@@ -1203,6 +1204,7 @@ class MonitorNode(PGNode):
             (formation, group)
         failover_command = [shutil.which('psql'),
                             '-d', self.database,
+                            '-h', '/tmp/regress.111111',
                             '-c', failover_commmand_text]
         self.vnode.run_and_wait(failover_command, name="manual failover")
 

--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -217,7 +217,7 @@ class PGNode:
         Returns a connection string which can be used to connect to this postgres
         node.
         """
-        host = self.vnode.address
+        host = '/tmp/regress.111111'
 
         if (self.authMethod and self.username in self.authenticatedUsers):
             dsn = "postgres://%s:%s@%s:%d/%s" % \

--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -305,6 +305,7 @@ class PGNode:
             "alter user %s with password \'%s\'" % (username, password)
         passwd_command = [shutil.which('psql'),
                           '-d', self.database,
+			  '-h', '/tmp/regress.111111',
                           '-c', alter_user_set_passwd_command]
         self.vnode.run_and_wait(passwd_command, name="user passwd")
         self.authenticatedUsers[username] = password

--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -43,7 +43,7 @@ class Cluster:
         """
         os.environ["PG_REGRESS_SOCK_DIR"] = ''
         os.environ["PG_AUTOCTL_DEBUG"] = ''
-        os.environ["PGHOST"] = '/tmp/regress.111111'
+        os.environ["PGHOST"] = 'localhost'
         self.networkSubnet = networkSubnet
         self.vlan = network.VirtualLAN(networkNamePrefix, networkSubnet)
         self.monitor = None
@@ -305,7 +305,6 @@ class PGNode:
             "alter user %s with password \'%s\'" % (username, password)
         passwd_command = [shutil.which('psql'),
                           '-d', self.database,
-                          '-h', '/tmp/regress.111111',
                           '-c', alter_user_set_passwd_command]
         self.vnode.run_and_wait(passwd_command, name="user passwd")
         self.authenticatedUsers[username] = password
@@ -1204,7 +1203,6 @@ class MonitorNode(PGNode):
             (formation, group)
         failover_command = [shutil.which('psql'),
                             '-d', self.database,
-                            '-h', '/tmp/regress.111111',
                             '-c', failover_commmand_text]
         self.vnode.run_and_wait(failover_command, name="manual failover")
 


### PR DESCRIPTION
Fixes #270

With this PR, we  suggest to treat the monitor database as an internal/embedded database for pg_auto_failover. To do that, we do few things:
- Ignore PGHOST env. variable
- Only allow unix domain socket connections from local host
- Only allow the user who created the database to be able to connect via the unix domain socket.


TODO:
- [ ] I still see the following on the pg_hba.conf (`hostssl "pg_auto_failover" "autoctl_node" 192.168.2.0/24 trust # Auto-generated by pg_auto_failover`). So, `replace_monitor_pg_hba ` is probably in the wrong way
- [ ] I get some errors while trying to create postgres instances (even on master branch). So, I wasn't able to test the changes in detail yet locally
```
15:07:34 68157 TRACE pgsetup.c:1375: nodeKindFromString: "standalone" ➜ 1
68157 Failed to acquire a lock with semaphore 4325417: Invalid argument
68157 Failed to acquire a lock with semaphore 4325417: Invalid argument
```