### PR TITLE
Don't show postgres startup messages on succesful startup

### DIFF
--- a/src/bin/pg_autoctl/service_postgres.c
+++ b/src/bin/pg_autoctl/service_postgres.c
@@ -98,8 +98,14 @@ service_postgres_start(void *context, pid_t *pid)
 			{
 				(void) pg_log_startup(pgSetup->pgdata, LOG_ERROR);
 			}
-			else
+			else if (log_get_level() <= LOG_DEBUG)
 			{
+				/*
+				 * If postgres started successfully we only log startup
+				 * messages in DEBUG or TRACE loglevel. Otherwise we get might
+				 * see this confusing error, but harmless error message:
+				 * ERROR:  database "postgres" already exists
+				 */
 				(void) pg_log_startup(pgSetup->pgdata, LOG_DEBUG);
 			}
 			return pgIsReady;


### PR DESCRIPTION
Like the comment says we would get an error message like this on startup
sometimes:
```
16:31:53 21530 ERROR 2020-06-19 16:31:51.463 CEST [21801] ERROR:  database "postgres" already exists
```