### PR TITLE
Review the registering process & transaction.

### DIFF
--- a/src/bin/pg_autoctl/monitor.c
+++ b/src/bin/pg_autoctl/monitor.c
@@ -573,9 +573,6 @@ monitor_register_node(Monitor *monitor, char *formation, char *host, int port,
 								   paramCount, paramTypes, paramValues,
 								   &parseContext, parseNodeState))
 	{
-		/* disconnect from PostgreSQL now */
-		pgsql_finish(&monitor->pgsql);
-
 		if (strcmp(parseContext.sqlstate, STR_ERRCODE_OBJECT_IN_USE) == 0)
 		{
 			log_warn("Failed to register node %s:%d in group %d of "
@@ -594,12 +591,14 @@ monitor_register_node(Monitor *monitor, char *formation, char *host, int port,
 		}
 		else if (strcmp(parseContext.sqlstate, "23P01") == 0)
 		{
+			/* *INDENT-OFF* */
 			log_error("Failed to register node %s:%d in "
 					  "group %d of formation \"%s\" "
 					  "with system_identifier %" PRIu64 ", "
-														"because another node already exists in this group with "
-														"another system_identifier",
+					  "because another node already exists in this group with "
+					  "another system_identifier",
 					  host, port, desiredGroupId, formation, system_identifier);
+			/* *INDENT-ON* */
 
 			log_info(
 				"HINT: you may register a standby node from a non-existing "
@@ -614,9 +613,6 @@ monitor_register_node(Monitor *monitor, char *formation, char *host, int port,
 				  host, port, desiredGroupId, formation, nodeStateString);
 		return false;
 	}
-
-	/* disconnect from PostgreSQL now */
-	pgsql_finish(&monitor->pgsql);
 
 	if (!parseContext.parsedOK)
 	{

--- a/src/bin/pg_autoctl/pgsql.c
+++ b/src/bin/pg_autoctl/pgsql.c
@@ -702,7 +702,7 @@ pgAutoCtlDebugNoticeProcessor(void *arg, const char *message)
  * We avoid persisting connection across multiple commands to simplify error
  * handling.
  */
-static bool
+bool
 pgsql_execute(PGSQL *pgsql, const char *sql)
 {
 	return pgsql_execute_with_params(pgsql, sql, 0, NULL, NULL, NULL, NULL);

--- a/src/bin/pg_autoctl/pgsql.h
+++ b/src/bin/pg_autoctl/pgsql.h
@@ -224,6 +224,7 @@ void pgsql_set_init_retry_policy(PGSQL *pgsql);
 void pgsql_set_interactive_retry_policy(PGSQL *pgsql);
 void pgsql_finish(PGSQL *pgsql);
 void parseSingleValueResult(void *ctx, PGresult *result);
+bool pgsql_execute(PGSQL *pgsql, const char *sql);
 bool pgsql_execute_with_params(PGSQL *pgsql, const char *sql, int paramCount,
 							   const Oid *paramTypes, const char **paramValues,
 							   void *parseContext, ParsePostgresResultCB *parseFun);

--- a/src/bin/pg_autoctl/service_keeper.c
+++ b/src/bin/pg_autoctl/service_keeper.c
@@ -258,6 +258,8 @@ keeper_node_active_loop(Keeper *keeper, pid_t start_pid)
 	KeeperStateData *keeperState = &(keeper->state);
 	Monitor *monitor = &(keeper->monitor);
 	LocalPostgresServer *postgres = &(keeper->postgres);
+	PGSQL *pgsql = &(postgres->sqlClient);
+
 	bool doSleep = false;
 	bool couldContactMonitor = false;
 	bool firstLoop = true;
@@ -545,6 +547,10 @@ keeper_node_active_loop(Keeper *keeper, pid_t start_pid)
 						 postgres->pgIsRunning ? "is" : "is not");
 			}
 		}
+
+		/* now is a good time to make sure we're closing our connections */
+		pgsql_finish(pgsql);
+		pgsql_finish(&(keeper->monitor.pgsql));
 
 		CHECK_FOR_FAST_SHUTDOWN;
 


### PR DESCRIPTION
Ensure that when we could register successfully to the monitor but then
failed to create our local state file, we cancel (ROLLBACK) the
registration. Otherwise we have a node on the monitor and no way to relate
that node to the current pg_autoctl process.