### PR TITLE
Add guards on memory allocation failure

### DIFF
--- a/src/bin/pg_autoctl/file_utils.c
+++ b/src/bin/pg_autoctl/file_utils.c
@@ -546,9 +546,20 @@ search_path(const char *filename, char ***result)
 
 	/* allocate array of pointers */
 	*result = malloc(pathListLength * sizeof(char *));
+	if (!*result)
+	{
+		log_error("Failed to allocate memory, probably because it's all used");
+		return 0;
+	}
 
 	/* allocate memory to store the strings */
 	stringSpace = malloc(pathListLength * MAXPGPATH);
+	if (!stringSpace)
+	{
+		log_error("Failed to allocate memory, probably because it's all used");
+		free(*result);
+		return 0;
+	}
 
 	path = pathlist;
 


### PR DESCRIPTION
Make sure to catch in case the memory allocation, and exit gracefully in case of memory exhaustion. This falls in the "unlikely to happen" bucket but makes static analysis easier and is generally good hygiene to follow.