### PR TITLE
Reduce how often we exec() pg_controldata.

### DIFF
--- a/src/bin/pg_autoctl/fsm_transition.c
+++ b/src/bin/pg_autoctl/fsm_transition.c
@@ -637,7 +637,8 @@ fsm_enable_sync_rep(Keeper *keeper)
 										 config->replication_slot_name,
 										 &pgSetup->is_in_recovery,
 										 postgres->pgsrSyncState,
-										 postgres->currentLSN))
+										 postgres->currentLSN,
+										 &(postgres->postgresSetup.control)))
 		{
 			log_error("Failed to update the local Postgres metadata");
 			return false;

--- a/src/bin/pg_autoctl/keeper.c
+++ b/src/bin/pg_autoctl/keeper.c
@@ -484,7 +484,7 @@ keeper_update_pg_state(Keeper *keeper)
 
 			default:
 			{
-				missingPgDataIsOk = true;
+				missingPgDataIsOk = false;
 				break;
 			}
 		}

--- a/src/bin/pg_autoctl/keeper.c
+++ b/src/bin/pg_autoctl/keeper.c
@@ -732,7 +732,7 @@ keeper_ensure_configuration(Keeper *keeper, bool postgresNotRunningIsOk)
 	 */
 	if (pg_setup_is_running(pgSetup))
 	{
-		if (pgSetup->control.pg_control_version >= 1200)
+		if (state->pg_control_version >= 1200)
 		{
 			/* errors are logged already, and non-fatal to this function */
 			(void) pgsql_reset_primary_conninfo(&(postgres->sqlClient));
@@ -768,7 +768,7 @@ keeper_ensure_configuration(Keeper *keeper, bool postgresNotRunningIsOk)
 
 		/* either recovery.conf or AUTOCTL_STANDBY_CONF_FILENAME */
 		char *relativeConfPathName =
-			pgSetup->control.pg_control_version < 1200
+			state->pg_control_version < 1200
 			? "recovery.conf"
 			: AUTOCTL_STANDBY_CONF_FILENAME;
 
@@ -832,7 +832,7 @@ keeper_ensure_configuration(Keeper *keeper, bool postgresNotRunningIsOk)
 		}
 
 		/* now setup the replication configuration (primary_conninfo etc) */
-		if (!pg_setup_standby_mode(pgSetup->control.pg_control_version,
+		if (!pg_setup_standby_mode(state->pg_control_version,
 								   pgSetup->pgdata,
 								   upstream))
 		{

--- a/src/bin/pg_autoctl/pgctl.c
+++ b/src/bin/pg_autoctl/pgctl.c
@@ -1292,7 +1292,7 @@ pg_setup_standby_mode(uint32_t pg_control_version,
 	if (pg_control_version < 1000)
 	{
 		log_fatal("pg_auto_failover does not support PostgreSQL before "
-				  "Postgres 10, we have pg_control version numer %d from "
+				  "Postgres 10, we have pg_control version number %d from "
 				  "pg_controldata \"%s\"",
 				  pg_control_version, pgdata);
 		return false;

--- a/src/bin/pg_autoctl/pgsetup.c
+++ b/src/bin/pg_autoctl/pgsetup.c
@@ -59,6 +59,11 @@ pg_setup_init(PostgresSetup *pgSetup,
 	pgSetup->pgKind = options->pgKind;
 
 	/*
+	 * Also make sure that we keep the pg_controldata results if we have them.
+	 */
+	pgSetup->control = options->control;
+
+	/*
 	 * Make sure that we keep the SSL options too.
 	 */
 	pgSetup->ssl.active = options->ssl.active;
@@ -133,44 +138,31 @@ pg_setup_init(PostgresSetup *pgSetup,
 		}
 	}
 
-	/*
-	 * We want to know if PostgreSQL is running, and if that's the case, we
-	 * want to discover all we can about its properties: port, pid, socket
-	 * directory, is_in_recovery, etc.
-	 */
-	if (errors == 0)
+	if (!missing_pgdata_is_ok && !directory_exists(pgSetup->pgdata))
 	{
-		if (!missing_pgdata_is_ok && !directory_exists(pgSetup->pgdata))
+		log_fatal("Database directory \"%s\" not found", pgSetup->pgdata);
+		return false;
+	}
+	else
+	{
+		char globalControlPath[MAXPGPATH] = { 0 };
+
+		/* globalControlFilePath = $PGDATA/global/pg_control */
+		join_path_components(globalControlPath,
+							 pgSetup->pgdata, "global/pg_control");
+
+		if (!file_exists(globalControlPath))
 		{
-			log_fatal("Database directory \"%s\" not found", pgSetup->pgdata);
+			log_error("PGDATA exists but is not a Postgres directory, "
+					  "see above for details");
 			return false;
 		}
 
-		pg_controldata(pgSetup, missing_pgdata_is_ok);
-
-		if (pgSetup->control.pg_control_version == 0)
+		/* get the real path of PGDATA now */
+		if (!normalize_filename(pgSetup->pgdata, pgSetup->pgdata, MAXPGPATH))
 		{
-			/* we already logged about it */
-			if (!missing_pgdata_is_ok)
-			{
-				errors++;
-			}
-		}
-		else
-		{
-			/* get the real path of PGDATA now */
-			if (!normalize_filename(pgSetup->pgdata, pgSetup->pgdata, MAXPGPATH))
-			{
-				/* errors have already been logged */
-				return false;
-			}
-
-			log_debug("Found PostgreSQL system %" PRIu64 " at \"%s\", "
-														 "version %u, catalog version %u",
-					  pgSetup->control.system_identifier,
-					  pgSetup->pgdata,
-					  pgSetup->control.pg_control_version,
-					  pgSetup->control.catalog_version_no);
+			/* errors have already been logged */
+			return false;
 		}
 	}
 
@@ -354,25 +346,56 @@ pg_setup_init(PostgresSetup *pgSetup,
 	}
 
 	/*
-	 * If PostgreSQL is running, register if it's in recovery or not.
+	 * When we have a PGDATA and Postgres is not running, we need to grab more
+	 * information about the local installation: pg_controldata can give us the
+	 * pg-_control_version, catalog_version_no, and system_identifier.
 	 */
-	if (pgSetup->control.pg_control_version > 0 &&
-		pgSetup->pidFile.port > 0 &&
-		pgSetup->pgport == pgSetup->pidFile.port)
+	if (errors == 0)
 	{
 		/*
-		 * Sometimes `pg_ctl start` returns with success and Postgres is still
-		 * in crash recovery replaying WAL files, in the "starting" state
-		 * rather than the "ready" state.
-		 *
-		 * In that case, we wait until Postgres is ready for connections. The
-		 * whole pg_autoctl code is expecting to be able to connect to
-		 * Postgres, so there's no point in returning now and having the next
-		 * connection attempt fail with something like the following:
-		 *
-		 * ERROR Connection to database failed: FATAL: the database system is
-		 * starting up
+		 * Only run pg_controldata when Postgres is not running, otherwise we
+		 * get the same information later from an SQL query, see
+		 * pgsql_get_postgres_metadata.
 		 */
+		if (!pg_setup_is_running(pgSetup) &&
+			pgSetup->control.pg_control_version == 0)
+		{
+			pg_controldata(pgSetup, missing_pgdata_is_ok);
+
+			if (pgSetup->control.pg_control_version == 0)
+			{
+				/* we already logged about it */
+				if (!missing_pgdata_is_ok)
+				{
+					errors++;
+				}
+			}
+
+			log_debug("Found PostgreSQL system %" PRIu64 " at \"%s\", "
+														 "version %u, catalog version %u",
+					  pgSetup->control.system_identifier,
+					  pgSetup->pgdata,
+					  pgSetup->control.pg_control_version,
+					  pgSetup->control.catalog_version_no);
+		}
+	}
+
+	/*
+	 * Sometimes `pg_ctl start` returns with success and Postgres is still in
+	 * crash recovery replaying WAL files, in the "starting" state rather than
+	 * the "ready" state.
+	 *
+	 * In that case, we wait until Postgres is ready for connections. The whole
+	 * pg_autoctl code is expecting to be able to connect to Postgres, so
+	 * there's no point in returning now and having the next connection attempt
+	 * fail with something like the following:
+	 *
+	 * ERROR Connection to database failed: FATAL: the database system is
+	 * starting up
+	 */
+	if (pgSetup->pidFile.port > 0 &&
+		pgSetup->pgport == pgSetup->pidFile.port)
+	{
 		if (!pgIsReady)
 		{
 			if (!pg_is_not_running_is_ok)
@@ -389,6 +412,96 @@ pg_setup_init(PostgresSetup *pgSetup,
 		log_fatal("Failed to discover PostgreSQL setup, "
 				  "please fix previous errors.");
 		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * pg_setup_controldata runs pg_controldata and updates the given pgSetup
+ * control data from there. When we have conflicting values, such as an updated
+ * system identifier, return false.
+ */
+bool
+pg_setup_controldata(PostgresSetup *pgSetup, bool missingPgDataIsOk)
+{
+	PostgresSetup newPgSetup = { 0 };
+
+	PostgresControlData *oldControl = &(pgSetup->control);
+	PostgresControlData *newControl = &(newPgSetup.control);
+
+	if (!directory_exists(pgSetup->pgdata))
+	{
+		if (!missingPgDataIsOk)
+		{
+			log_fatal("Database directory \"%s\" not found", pgSetup->pgdata);
+			return false;
+		}
+
+		/* PGDATA directory does not exists, stop here, it's ok */
+		return true;
+	}
+
+	/*
+	 * Now fetch new control values from running pg_controldata on PGDATA.
+	 */
+	if (!pg_controldata(pgSetup, missingPgDataIsOk))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	if (oldControl->system_identifier != newControl->system_identifier)
+	{
+		if (oldControl->system_identifier == 0)
+		{
+			oldControl->system_identifier = newControl->system_identifier;
+		}
+		else
+		{
+			/*
+			 * This is a physical replication deal breaker, so it's mighty
+			 * confusing to get that here. In the least, the keeper should get
+			 * initialized from scratch again, but basically, we don't know
+			 * what we are doing anymore.
+			 */
+			log_error("Unknown PostgreSQL system identifier: %" PRIu64 ", "
+																	   "expected %" PRIu64,
+					  newControl->system_identifier,
+					  oldControl->system_identifier);
+			return false;
+		}
+	}
+
+	if (oldControl->pg_control_version != newControl->pg_control_version)
+	{
+		if (oldControl->pg_control_version == 0)
+		{
+			oldControl->pg_control_version = newControl->pg_control_version;
+		}
+		else
+		{
+			/* Postgres minor upgrade happened */
+			log_warn("PostgreSQL version changed from %u to %u",
+					 oldControl->pg_control_version,
+					 newControl->pg_control_version);
+		}
+	}
+
+	if (oldControl->catalog_version_no != newControl->catalog_version_no)
+	{
+		if (oldControl->catalog_version_no == 0)
+		{
+			oldControl->catalog_version_no = newControl->catalog_version_no;
+		}
+		else
+		{
+			/* Postgres major upgrade happened */
+			log_warn("PostgreSQL catalog version changed from %u to %u",
+					 oldControl->catalog_version_no,
+					 newControl->catalog_version_no);
+		}
 	}
 
 	return true;

--- a/src/bin/pg_autoctl/pgsetup.c
+++ b/src/bin/pg_autoctl/pgsetup.c
@@ -143,7 +143,7 @@ pg_setup_init(PostgresSetup *pgSetup,
 		log_fatal("Database directory \"%s\" not found", pgSetup->pgdata);
 		return false;
 	}
-	else
+	else if (!missing_pgdata_is_ok)
 	{
 		char globalControlPath[MAXPGPATH] = { 0 };
 
@@ -157,8 +157,11 @@ pg_setup_init(PostgresSetup *pgSetup,
 					  "see above for details");
 			return false;
 		}
+	}
 
-		/* get the real path of PGDATA now */
+	/* get the real path of PGDATA now */
+	if (directory_exists(pgSetup->pgdata))
+	{
 		if (!normalize_filename(pgSetup->pgdata, pgSetup->pgdata, MAXPGPATH))
 		{
 			/* errors have already been logged */

--- a/src/bin/pg_autoctl/pgsetup.h
+++ b/src/bin/pg_autoctl/pgsetup.h
@@ -180,6 +180,8 @@ bool pg_setup_init(PostgresSetup *pgSetup,
 				   bool missing_pgdata_is_ok,
 				   bool pg_is_not_running_is_ok);
 
+bool pg_setup_controldata(PostgresSetup *pgSetup, bool missingPgDataIsOk);
+
 bool read_pg_pidfile(PostgresSetup *pgSetup,
 					 bool pgIsNotRunningIsOk,
 					 int maxRetries);

--- a/src/bin/pg_autoctl/pgsql.c
+++ b/src/bin/pg_autoctl/pgsql.c
@@ -2028,11 +2028,12 @@ validate_connection_string(const char *connectionString)
  * pgsql_get_postgres_metadata returns several bits of information that we need
  * to take decisions in the rest of the code:
  *
- *  - config_file path (cache invalidation in case it changed)
- *  - hba_file path (cache invalidation in case it changed)
  *  - pg_is_in_recovery (primary or standby, as expected?)
  *  - sync_state from pg_stat_replication when a primary
  *  - current_lsn from the server
+ *  - pg_control_version
+ *  - catalog_version_no
+ *  - systemd_identifier
  *
  * With those metadata we can then check our expectations and take decisions in
  * some cases. We can obtain all the metadata that we need easily enough in a
@@ -2045,13 +2046,15 @@ typedef struct PgMetadata
 	bool pg_is_in_recovery;
 	char syncState[PGSR_SYNC_STATE_MAXLENGTH];
 	char currentLSN[PG_LSN_MAXLENGTH];
+	PostgresControlData control;
 } PgMetadata;
 
 
 bool
 pgsql_get_postgres_metadata(PGSQL *pgsql, const char *slotName,
 							bool *pg_is_in_recovery,
-							char *pgsrSyncState, char *currentLSN)
+							char *pgsrSyncState, char *currentLSN,
+							PostgresControlData *control)
 {
 	PgMetadata context = { 0 };
 
@@ -2071,8 +2074,14 @@ pgsql_get_postgres_metadata(PGSQL *pgsql, const char *slotName,
 		" case when pg_is_in_recovery()"
 		" then pg_last_wal_receive_lsn()"
 		" else pg_current_wal_lsn()"
-		" end as current_lsn"
+		" end as current_lsn,"
+		" pg_control_version, catalog_version_no, system_identifier"
 		" from (values(1)) as dummy"
+		" full outer join"
+		" (select pg_control_version, catalog_version_no, system_identifier "
+		"    from pg_control_system()"
+		" )"
+		" as control on true"
 		" full outer join"
 		" ("
 		"   select sync_state"
@@ -2123,6 +2132,9 @@ pgsql_get_postgres_metadata(PGSQL *pgsql, const char *slotName,
 		strlcpy(currentLSN, context.currentLSN, PG_LSN_MAXLENGTH);
 	}
 
+	/* overwrite the Control Data fetched from the query */
+	*control = context.control;
+
 	pgsql_finish(pgsql);
 
 	return true;
@@ -2137,8 +2149,9 @@ static void
 parsePgMetadata(void *ctx, PGresult *result)
 {
 	PgMetadata *context = (PgMetadata *) ctx;
+	char *value;
 
-	if (PQnfields(result) != 3)
+	if (PQnfields(result) != 6)
 	{
 		log_error("Query returned %d columns, expected 3", PQnfields(result));
 		context->parsedOk = false;
@@ -2156,7 +2169,7 @@ parsePgMetadata(void *ctx, PGresult *result)
 
 	if (!PQgetisnull(result, 0, 1))
 	{
-		char *value = PQgetvalue(result, 0, 1);
+		value = PQgetvalue(result, 0, 1);
 
 		strlcpy(context->syncState, value, PGSR_SYNC_STATE_MAXLENGTH);
 	}
@@ -2167,13 +2180,37 @@ parsePgMetadata(void *ctx, PGresult *result)
 
 	if (!PQgetisnull(result, 0, 2))
 	{
-		char *value = PQgetvalue(result, 0, 2);
+		value = PQgetvalue(result, 0, 2);
 
 		strlcpy(context->currentLSN, value, PG_LSN_MAXLENGTH);
 	}
 	else
 	{
 		context->currentLSN[0] = '\0';
+	}
+
+	value = PQgetvalue(result, 0, 3);
+	if (!stringToUInt(value, &(context->control.pg_control_version)))
+	{
+		log_error("Failed to parse pg_control_version \"%s\"", value);
+		context->parsedOk = true;
+		return;
+	}
+
+	value = PQgetvalue(result, 0, 4);
+	if (!stringToUInt(value, &(context->control.catalog_version_no)))
+	{
+		log_error("Failed to parse catalog_version_no \"%s\"", value);
+		context->parsedOk = true;
+		return;
+	}
+
+	value = PQgetvalue(result, 0, 5);
+	if (!stringToUInt64(value, &(context->control.system_identifier)))
+	{
+		log_error("Failed to parse system_identifier \"%s\"", value);
+		context->parsedOk = true;
+		return;
 	}
 
 	context->parsedOk = true;

--- a/src/bin/pg_autoctl/pgsql.c
+++ b/src/bin/pg_autoctl/pgsql.c
@@ -2033,7 +2033,7 @@ validate_connection_string(const char *connectionString)
  *  - current_lsn from the server
  *  - pg_control_version
  *  - catalog_version_no
- *  - systemd_identifier
+ *  - system_identifier
  *
  * With those metadata we can then check our expectations and take decisions in
  * some cases. We can obtain all the metadata that we need easily enough in a

--- a/src/bin/pg_autoctl/pgsql.h
+++ b/src/bin/pg_autoctl/pgsql.h
@@ -259,7 +259,8 @@ bool pgsql_reset_primary_conninfo(PGSQL *pgsql);
 
 bool pgsql_get_postgres_metadata(PGSQL *pgsql, const char *slotName,
 								 bool *pg_is_in_recovery,
-								 char *pgsrSyncState, char *currentLSN);
+								 char *pgsrSyncState, char *currentLSN,
+								 PostgresControlData *control);
 
 bool pgsql_one_slot_has_reached_target_lsn(PGSQL *pgsql,
 										   char *targetLSN,


### PR DESCRIPTION
When Postgres is known to be running we can update our control data
information in the cache from a SQL query rather than doing another fork()
and exec() on the pg_controldata binary and parsing its output.

There are still a few too many calls to pg_controldata after this patch, but
at least we don't do it every second anymore when Postgres is running fine.