### PR TITLE
Report services version strings in pg_autoctl version --json.

### DIFF
--- a/src/bin/pg_autoctl/cli_common.c
+++ b/src/bin/pg_autoctl/cli_common.c
@@ -1139,6 +1139,8 @@ keeper_cli_print_version(int argc, char **argv)
 		JSON_Object *root = json_value_get_object(js);
 
 		json_object_set_string(root, "pg_autoctl", PG_AUTOCTL_VERSION);
+		json_object_set_string(root,
+							   "pgautofailover", PG_AUTOCTL_EXTENSION_VERSION);
 		json_object_set_string(root, "pg_major", PG_MAJORVERSION);
 		json_object_set_string(root, "pg_version", PG_VERSION);
 		json_object_set_string(root, "pg_version_str", PG_VERSION_STR);
@@ -1149,6 +1151,9 @@ keeper_cli_print_version(int argc, char **argv)
 	else
 	{
 		fformat(stdout, "pg_autoctl version %s\n", PG_AUTOCTL_VERSION);
+		fformat(stdout,
+				"pg_autoctl extension version %s\n",
+				PG_AUTOCTL_EXTENSION_VERSION);
 		fformat(stdout, "compiled with %s\n", PG_VERSION_STR);
 		fformat(stdout, "compatible with Postgres 10, 11, and 12\n");
 	}

--- a/src/bin/pg_autoctl/cli_common.c
+++ b/src/bin/pg_autoctl/cli_common.c
@@ -442,10 +442,7 @@ cli_common_keeper_getopts(int argc, char **argv,
 	/*
 	 * Now, all commands need PGDATA validation.
 	 */
-	if (IS_EMPTY_STRING_BUFFER(LocalOptionConfig.pgSetup.pgdata))
-	{
-		get_env_pgdata_or_exit(LocalOptionConfig.pgSetup.pgdata);
-	}
+	cli_common_get_set_pgdata_or_exit(&(LocalOptionConfig.pgSetup));
 
 	/*
 	 * We have a PGDATA setting, prepare our configuration pathnames from it.
@@ -698,6 +695,27 @@ cli_getopt_ssl_flags(int ssl_flag, char *optarg, PostgresSetup *pgSetup)
 
 
 /*
+ * cli_common_get_set_pgdata_or_exit gets pgdata from either --pgdata or PGDATA
+ * in the environment, and when we have a value for it, then we set it in the
+ * environment.
+ */
+void
+cli_common_get_set_pgdata_or_exit(PostgresSetup *pgSetup)
+{
+	/* if --pgdata is not given, fetch PGDATA from the environment or exit */
+	if (IS_EMPTY_STRING_BUFFER(pgSetup->pgdata))
+	{
+		get_env_pgdata_or_exit(pgSetup->pgdata);
+	}
+	else
+	{
+		/* from now on on want PGDATA set in the environment */
+		setenv("PGDATA", pgSetup->pgdata, 1);
+	}
+}
+
+
+/*
  * keeper_cli_getopt_pgdata gets the PGDATA options or environment variable,
  * either of those must be set for all of pg_autoctl's commands. This parameter
  * allows to know which PostgreSQL instance we are the keeper of, and also
@@ -834,10 +852,7 @@ cli_getopt_pgdata(int argc, char **argv)
 void
 prepare_keeper_options(KeeperConfig *options)
 {
-	if (IS_EMPTY_STRING_BUFFER(options->pgSetup.pgdata))
-	{
-		get_env_pgdata_or_exit(options->pgSetup.pgdata);
-	}
+	cli_common_get_set_pgdata_or_exit(&(options->pgSetup));
 
 	log_debug("Managing PostgreSQL installation at \"%s\"",
 			  options->pgSetup.pgdata);

--- a/src/bin/pg_autoctl/cli_common.h
+++ b/src/bin/pg_autoctl/cli_common.h
@@ -143,6 +143,8 @@ int cli_print_version_getopts(int argc, char **argv);
 void keeper_cli_print_version(int argc, char **argv);
 void cli_pprint_json(JSON_Value *js);
 
+void cli_common_get_set_pgdata_or_exit(PostgresSetup *pgSetup);
+
 int cli_common_keeper_getopts(int argc, char **argv,
 							  struct option *long_options,
 							  const char *optstring,

--- a/src/bin/pg_autoctl/cli_create_drop_node.c
+++ b/src/bin/pg_autoctl/cli_create_drop_node.c
@@ -544,10 +544,7 @@ cli_create_monitor_getopts(int argc, char **argv)
 	 * here, we don't have to manage the whole life-time of that PostgreSQL
 	 * instance.
 	 */
-	if (IS_EMPTY_STRING_BUFFER(options.pgSetup.pgdata))
-	{
-		get_env_pgdata_or_exit(options.pgSetup.pgdata);
-	}
+	cli_common_get_set_pgdata_or_exit(&(options.pgSetup));
 
 	/*
 	 * We require the user to specify an authentication mechanism, or to use

--- a/src/bin/pg_autoctl/cli_do_service.c
+++ b/src/bin/pg_autoctl/cli_do_service.c
@@ -310,7 +310,7 @@ cli_do_service_restart(const char *serviceName)
 	log_info("Service \"%s\" has been restarted with pid %d",
 			 serviceName, newPid);
 
-	fformat(stdout, "%d\n", pid);
+	fformat(stdout, "%d\n", newPid);
 }
 
 

--- a/src/bin/pg_autoctl/cli_do_service.c
+++ b/src/bin/pg_autoctl/cli_do_service.c
@@ -30,7 +30,6 @@
 #include "signals.h"
 #include "supervisor.h"
 
-
 static void cli_do_service_postgres(int argc, char **argv);
 static void cli_do_service_pgcontroller(int argc, char **argv);
 static void cli_do_service_postgresctl_on(int argc, char **argv);
@@ -232,7 +231,7 @@ cli_do_service_getpid(const char *serviceName)
 static void
 cli_do_service_getpid_postgres(int argc, char **argv)
 {
-	(void) cli_do_service_getpid("postgres");
+	(void) cli_do_service_getpid(SERVICE_NAME_POSTGRES);
 }
 
 
@@ -242,7 +241,7 @@ cli_do_service_getpid_postgres(int argc, char **argv)
 static void
 cli_do_service_getpid_listener(int argc, char **argv)
 {
-	(void) cli_do_service_getpid("listener");
+	(void) cli_do_service_getpid(SERVICE_NAME_MONITOR);
 }
 
 
@@ -252,7 +251,7 @@ cli_do_service_getpid_listener(int argc, char **argv)
 static void
 cli_do_service_getpid_node_active(int argc, char **argv)
 {
-	(void) cli_do_service_getpid("node active");
+	(void) cli_do_service_getpid(SERVICE_NAME_KEEPER);
 }
 
 
@@ -323,7 +322,7 @@ cli_do_service_restart(const char *serviceName)
 static void
 cli_do_service_restart_postgres(int argc, char **argv)
 {
-	(void) cli_do_service_restart("postgres");
+	(void) cli_do_service_restart(SERVICE_NAME_POSTGRES);
 }
 
 
@@ -336,7 +335,7 @@ cli_do_service_restart_postgres(int argc, char **argv)
 static void
 cli_do_service_restart_listener(int argc, char **argv)
 {
-	(void) cli_do_service_restart("listener");
+	(void) cli_do_service_restart(SERVICE_NAME_MONITOR);
 }
 
 
@@ -349,7 +348,7 @@ cli_do_service_restart_listener(int argc, char **argv)
 static void
 cli_do_service_restart_node_active(int argc, char **argv)
 {
-	(void) cli_do_service_restart("node active");
+	(void) cli_do_service_restart(SERVICE_NAME_KEEPER);
 }
 
 
@@ -425,6 +424,13 @@ cli_do_service_postgres(int argc, char **argv)
 
 	/* display a user-friendly process name */
 	(void) set_ps_title("pg_autoctl: start/stop postgres");
+
+	/* create the service pidfile */
+	if (!create_service_pidfile(pathnames.pid, SERVICE_NAME_POSTGRES))
+	{
+		/* errors have already been logged */
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
 
 	(void) service_postgres_ctl_loop(&postgres);
 }
@@ -530,6 +536,14 @@ cli_do_service_monitor_listener(int argc, char **argv)
 	/* display a user-friendly process name */
 	(void) set_ps_title("pg_autoctl: monitor listener");
 
+	/* create the service pidfile */
+	if (!create_service_pidfile(monitor.config.pathnames.pid,
+								SERVICE_NAME_MONITOR))
+	{
+		/* errors have already been logged */
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+
 	/* Start the monitor service */
 	(void) monitor_service_run(&monitor);
 }
@@ -562,6 +576,14 @@ cli_do_service_node_active(int argc, char **argv)
 
 	/* display a user-friendly process name */
 	(void) set_ps_title("pg_autoctl: node active");
+
+	/* create the service pidfile */
+	if (!create_service_pidfile(keeper.config.pathnames.pid,
+								SERVICE_NAME_KEEPER))
+	{
+		/* errors have already been logged */
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
 
 	/* Start the node_active() protocol client */
 	(void) keeper_node_active_loop(&keeper, ppid);

--- a/src/bin/pg_autoctl/cli_enable_disable.c
+++ b/src/bin/pg_autoctl/cli_enable_disable.c
@@ -232,10 +232,7 @@ cli_secondary_getopts(int argc, char **argv)
 		exit(EXIT_CODE_BAD_ARGS);
 	}
 
-	if (IS_EMPTY_STRING_BUFFER(options.pgSetup.pgdata))
-	{
-		get_env_pgdata_or_exit(options.pgSetup.pgdata);
-	}
+	cli_common_get_set_pgdata_or_exit(&(options.pgSetup));
 
 	if (IS_EMPTY_STRING_BUFFER(options.formation))
 	{
@@ -752,10 +749,7 @@ cli_ssl_getopts(int argc, char **argv)
 	}
 
 	/* Initialize with given PGDATA */
-	if (IS_EMPTY_STRING_BUFFER(options.pgSetup.pgdata))
-	{
-		get_env_pgdata_or_exit(options.pgSetup.pgdata);
-	}
+	cli_common_get_set_pgdata_or_exit(&(options.pgSetup));
 
 	if (!keeper_config_set_pathnames_from_pgdata(&(options.pathnames),
 												 options.pgSetup.pgdata))

--- a/src/bin/pg_autoctl/cli_formation.c
+++ b/src/bin/pg_autoctl/cli_formation.c
@@ -157,10 +157,7 @@ keeper_cli_formation_getopts(int argc, char **argv)
 		exit(EXIT_CODE_BAD_ARGS);
 	}
 
-	if (IS_EMPTY_STRING_BUFFER(options.pgSetup.pgdata))
-	{
-		get_env_pgdata_or_exit(options.pgSetup.pgdata);
-	}
+	cli_common_get_set_pgdata_or_exit(&(options.pgSetup));
 
 	/* publish our option parsing in the global variable */
 	formationOptions = options;
@@ -319,10 +316,7 @@ keeper_cli_formation_create_getopts(int argc, char **argv)
 		}
 	}
 
-	if (IS_EMPTY_STRING_BUFFER(options.pgSetup.pgdata))
-	{
-		get_env_pgdata_or_exit(options.pgSetup.pgdata);
-	}
+	cli_common_get_set_pgdata_or_exit(&(options.pgSetup));
 
 	if (IS_EMPTY_STRING_BUFFER(options.formation) ||
 		IS_EMPTY_STRING_BUFFER(options.formationKind))

--- a/src/bin/pg_autoctl/cli_perform.c
+++ b/src/bin/pg_autoctl/cli_perform.c
@@ -178,10 +178,7 @@ cli_perform_failover_getopts(int argc, char **argv)
 		exit(EXIT_CODE_BAD_ARGS);
 	}
 
-	if (IS_EMPTY_STRING_BUFFER(options.pgSetup.pgdata))
-	{
-		get_env_pgdata_or_exit(options.pgSetup.pgdata);
-	}
+	cli_common_get_set_pgdata_or_exit(&(options.pgSetup));
 
 	keeperOptions = options;
 

--- a/src/bin/pg_autoctl/cli_show.c
+++ b/src/bin/pg_autoctl/cli_show.c
@@ -1504,6 +1504,13 @@ fprint_pidfile_as_json(const char *pidfile)
 			json_object_set_string(jsobj, "version", fileLines[lineNumber]);
 		}
 
+		/* extension version string */
+		if (pidLine == PIDFILE_LINE_EXTENSION_VERSION)
+		{
+			/* skip it, the supervisor does not connect to the monitor */
+			(void) 0;
+		}
+
 		/* semId */
 		if (pidLine == PIDFILE_LINE_SEM_ID)
 		{
@@ -1529,8 +1536,11 @@ fprint_pidfile_as_json(const char *pidfile)
 			{
 				int pidnum = 0;
 				char *serviceName = separator + 1;
-				char versionString[BUFSIZE] = { 0 };
+
 				char servicePidFile[BUFSIZE] = { 0 };
+
+				char versionString[BUFSIZE] = { 0 };
+				char extensionVersionString[BUFSIZE] = { 0 };
 
 				*separator = '\0';
 				stringToInt(fileLines[lineNumber], &pidnum);
@@ -1541,8 +1551,10 @@ fprint_pidfile_as_json(const char *pidfile)
 				/* grab version number of the service by parsing its pidfile */
 				get_service_pidfile(pidfile, serviceName, servicePidFile);
 
-				if (!read_service_pidfile_version_string(servicePidFile,
-														 versionString))
+				if (!read_service_pidfile_version_strings(
+						servicePidFile,
+						versionString,
+						extensionVersionString))
 				{
 					/* warn about it and continue */
 					log_warn("Failed to read version string for "
@@ -1552,7 +1564,11 @@ fprint_pidfile_as_json(const char *pidfile)
 				}
 				else
 				{
-					json_object_set_string(jsServiceObj, "version", versionString);
+					json_object_set_string(jsServiceObj,
+										   "version", versionString);
+					json_object_set_string(jsServiceObj,
+										   "pgautofailover",
+										   extensionVersionString);
 				}
 			}
 

--- a/src/bin/pg_autoctl/cli_show.c
+++ b/src/bin/pg_autoctl/cli_show.c
@@ -315,10 +315,7 @@ cli_show_state_getopts(int argc, char **argv)
 		exit(EXIT_CODE_BAD_ARGS);
 	}
 
-	if (IS_EMPTY_STRING_BUFFER(options.pgSetup.pgdata))
-	{
-		get_env_pgdata_or_exit(options.pgSetup.pgdata);
-	}
+	cli_common_get_set_pgdata_or_exit(&(options.pgSetup));
 
 	keeperOptions = options;
 
@@ -537,10 +534,7 @@ cli_show_nodes_getopts(int argc, char **argv)
 		exit(EXIT_CODE_BAD_ARGS);
 	}
 
-	if (IS_EMPTY_STRING_BUFFER(options.pgSetup.pgdata))
-	{
-		get_env_pgdata_or_exit(options.pgSetup.pgdata);
-	}
+	cli_common_get_set_pgdata_or_exit(&(options.pgSetup));
 
 	keeperOptions = options;
 
@@ -763,16 +757,14 @@ cli_show_uri_getopts(int argc, char **argv)
 		}
 	}
 
-	if (showUriOptions.monitorOnly && !IS_EMPTY_STRING_BUFFER(showUriOptions.formation))
+	if (showUriOptions.monitorOnly &&
+		!IS_EMPTY_STRING_BUFFER(showUriOptions.formation))
 	{
 		log_fatal("Please use either --monitor or --formation, not both");
 		exit(EXIT_CODE_BAD_ARGS);
 	}
 
-	if (IS_EMPTY_STRING_BUFFER(options.pgSetup.pgdata))
-	{
-		get_env_pgdata_or_exit(options.pgSetup.pgdata);
-	}
+	cli_common_get_set_pgdata_or_exit(&(options.pgSetup));
 
 	if (!keeper_config_set_pathnames_from_pgdata(&(options.pathnames),
 												 options.pgSetup.pgdata))
@@ -1157,10 +1149,7 @@ cli_show_file_getopts(int argc, char **argv)
 		}
 	}
 
-	if (IS_EMPTY_STRING_BUFFER(options.pgSetup.pgdata))
-	{
-		get_env_pgdata_or_exit(options.pgSetup.pgdata);
-	}
+	cli_common_get_set_pgdata_or_exit(&(options.pgSetup));
 
 	if (!keeper_config_set_pathnames_from_pgdata(&options.pathnames,
 												 options.pgSetup.pgdata))

--- a/src/bin/pg_autoctl/cli_show.c
+++ b/src/bin/pg_autoctl/cli_show.c
@@ -1475,7 +1475,7 @@ fprint_pidfile_as_json(const char *pidfile)
 		if (pidLine == PIDFILE_LINE_PID)
 		{
 			int pidnum = 0;
-			stringToInt(fileLines[0], &pidnum);
+			stringToInt(fileLines[lineNumber], &pidnum);
 			json_object_set_number(jsobj, "pid", (double) pidnum);
 
 			continue;
@@ -1504,8 +1504,15 @@ fprint_pidfile_as_json(const char *pidfile)
 		if (pidLine == PIDFILE_LINE_SEM_ID)
 		{
 			int semId = 0;
-			stringToInt(fileLines[1], &semId);
-			json_object_set_number(jsobj, "semId", (double) semId);
+
+			if (stringToInt(fileLines[lineNumber], &semId))
+			{
+				json_object_set_number(jsobj, "semId", (double) semId);
+			}
+			else
+			{
+				log_error("Failed to parse semId \"%s\"", fileLines[lineNumber]);
+			}
 
 			continue;
 		}

--- a/src/bin/pg_autoctl/cli_systemd.c
+++ b/src/bin/pg_autoctl/cli_systemd.c
@@ -135,10 +135,7 @@ cli_systemd_getopt(int argc, char **argv)
 		exit(EXIT_CODE_BAD_ARGS);
 	}
 
-	if (IS_EMPTY_STRING_BUFFER(options.pgSetup.pgdata))
-	{
-		get_env_pgdata_or_exit(options.pgSetup.pgdata);
-	}
+	cli_common_get_set_pgdata_or_exit(&(options.pgSetup));
 
 	if (!keeper_config_set_pathnames_from_pgdata(&options.pathnames,
 												 options.pgSetup.pgdata))

--- a/src/bin/pg_autoctl/keeper_config.c
+++ b/src/bin/pg_autoctl/keeper_config.c
@@ -234,6 +234,10 @@ keeper_config_set_pathnames_from_pgdata(ConfigFilePaths *pathnames,
 				  " see above for details.", pgdata);
 		return false;
 	}
+
+	/* set our own PGDATA environment for the rest of the program duration */
+	setenv("PGDATA", pgdata, 1);
+
 	return true;
 }
 

--- a/src/bin/pg_autoctl/keeper_config.c
+++ b/src/bin/pg_autoctl/keeper_config.c
@@ -235,9 +235,6 @@ keeper_config_set_pathnames_from_pgdata(ConfigFilePaths *pathnames,
 		return false;
 	}
 
-	/* set our own PGDATA environment for the rest of the program duration */
-	setenv("PGDATA", pgdata, 1);
-
 	return true;
 }
 

--- a/src/bin/pg_autoctl/pidfile.c
+++ b/src/bin/pg_autoctl/pidfile.c
@@ -63,6 +63,16 @@ create_pidfile(const char *pidfile, pid_t pid)
 	if (!prepare_pidfile_buffer(content, pid))
 	{
 		/* errors have already been logged */
+		destroyPQExpBuffer(content);
+		return false;
+	}
+
+
+	/* memory allocation could have failed while building string */
+	if (PQExpBufferBroken(content))
+	{
+		log_error("Failed to create pidfile \"%s\": out of memory", pidfile);
+		destroyPQExpBuffer(content);
 		return false;
 	}
 
@@ -231,7 +241,7 @@ remove_pidfile(const char *pidfile)
 {
 	if (remove(pidfile) != 0)
 	{
-		log_error("Failed to remove keeper's pid file \"%s\": %m", pidfile);
+		log_error("Failed to remove pid file \"%s\": %m", pidfile);
 		return false;
 	}
 	return true;

--- a/src/bin/pg_autoctl/pidfile.c
+++ b/src/bin/pg_autoctl/pidfile.c
@@ -14,8 +14,12 @@
 #include <time.h>
 #include <unistd.h>
 
+#include "postgres_fe.h"
+#include "pqexpbuffer.h"
+
 #include "cli_root.h"
 #include "defaults.h"
+#include "env_utils.h"
 #include "fsm.h"
 #include "keeper.h"
 #include "keeper_config.h"
@@ -29,6 +33,10 @@
 #include "signals.h"
 #include "string_utils.h"
 
+/* pidfile for this process */
+char service_pidfile[MAXPGPATH] = { 0 };
+
+static void remove_service_pidfile_atexit(void);
 
 /*
  * create_pidfile writes our pid in a file.
@@ -40,13 +48,86 @@
 bool
 create_pidfile(const char *pidfile, pid_t pid)
 {
-	char content[BUFSIZE];
+	char pgdata[MAXPGPATH] = { 0 };
+	PQExpBuffer content = createPQExpBuffer();
+
+	bool success = false;
 
 	log_trace("create_pidfile(%d): \"%s\"", pid, pidfile);
 
-	sformat(content, BUFSIZE, "%d\n%d\n", pid, log_semaphore.semId);
+	if (content == NULL)
+	{
+		log_fatal("Failed to allocate memory to update our PID file");
+		return false;
+	}
 
-	return write_file(content, strlen(content), pidfile);
+	/* we get PGDATA from the environment */
+	if (!get_env_pgdata(pgdata))
+	{
+		log_fatal("Failed to get PGDATA to create the PID file");
+		return false;
+	}
+
+	/*
+	 * line #
+	 *		1	supervisor PID
+	 *		2	data directory path
+	 *		3	version number (PG_AUTOCTL_VERSION)
+	 *		4	shared semaphore id (used to serialize log writes)
+	 */
+	appendPQExpBuffer(content, "%d\n", pid);
+	appendPQExpBuffer(content, "%s\n", pgdata);
+	appendPQExpBuffer(content, "%s\n", PG_AUTOCTL_VERSION);
+	appendPQExpBuffer(content, "%d\n", log_semaphore.semId);
+
+	success = write_file(content->data, content->len, pidfile);
+	destroyPQExpBuffer(content);
+
+	return success;
+}
+
+
+/*
+ * create_pidfile writes the given serviceName pidfile, using getpid().
+ */
+bool
+create_service_pidfile(const char *pidfile, const char *serviceName)
+{
+	pid_t pid = getpid();
+
+	/* compute the service pidfile and store it in our global variable */
+	(void) get_service_pidfile(pidfile, serviceName, service_pidfile);
+
+	/* register our service pidfile clean-up atexit */
+	atexit(remove_service_pidfile_atexit);
+
+	return create_pidfile(service_pidfile, pid);
+}
+
+
+/*
+ * get_service_pidfile computes the pidfile names for the given service.
+ */
+void
+get_service_pidfile(const char *pidfile,
+					const char *serviceName,
+					char *servicePidFilename)
+{
+	char filename[MAXPGPATH] = { 0 };
+
+	sformat(filename, sizeof(filename), "pg_autoctl_%s.pid", serviceName);
+	path_in_same_directory(pidfile, filename, servicePidFilename);
+}
+
+
+/*
+ * remove_service_pidfile_atexit is called atexit() to remove the service
+ * pidfile.
+ */
+static void
+remove_service_pidfile_atexit()
+{
+	(void) remove_pidfile(service_pidfile);
 }
 
 
@@ -178,4 +259,46 @@ check_pidfile(const char *pidfile, pid_t start_pid)
 		log_fatal("PID file not found at \"%s\", quitting.", pidfile);
 		exit(EXIT_CODE_QUIT);
 	}
+}
+
+
+/*
+ * read_service_pidfile_version_string reads a service pidfile and copies the
+ * version string found on line PIDFILE_LINE_VERSION_STRING into the
+ * pre-allocated buffer versionString.
+ */
+bool
+read_service_pidfile_version_string(const char *pidfile, char *versionString)
+{
+	long fileSize = 0L;
+	char *fileContents = NULL;
+	char *fileLines[BUFSIZE] = { 0 };
+	int lineCount = 0;
+	int lineNumber;
+
+	if (!file_exists(pidfile))
+	{
+		return false;
+	}
+
+	if (!read_file(pidfile, &fileContents, &fileSize))
+	{
+		return false;
+	}
+
+	lineCount = splitLines(fileContents, fileLines, BUFSIZE);
+
+	for (lineNumber = 0; lineNumber < lineCount; lineNumber++)
+	{
+		int pidLine = lineNumber + 1; /* zero-based, one-based */
+
+		/* version string */
+		if (pidLine == PIDFILE_LINE_VERSION_STRING)
+		{
+			strlcpy(versionString, fileLines[lineNumber], BUFSIZE);
+			return true;
+		}
+	}
+
+	return false;
 }

--- a/src/bin/pg_autoctl/pidfile.h
+++ b/src/bin/pg_autoctl/pidfile.h
@@ -27,9 +27,10 @@
  *		1	supervisor PID
  *		2	data directory path
  *		3	version number (PG_AUTOCTL_VERSION)
- *		4	shared semaphore id (used to serialize log writes)
- *		5	first supervised service pid line
- *		6	second supervised service pid line
+ *		4	extension version number (PG_AUTOCTL_EXTENSION_VERSION)
+ *		5	shared semaphore id (used to serialize log writes)
+ *		6	first supervised service pid line
+ *		7	second supervised service pid line
  *    ...
  *
  * The supervised service lines are added later, not the first tim we create
@@ -45,8 +46,9 @@
 #define PIDFILE_LINE_PID 1
 #define PIDFILE_LINE_DATA_DIR 2
 #define PIDFILE_LINE_VERSION_STRING 3
-#define PIDFILE_LINE_SEM_ID 4
-#define PIDFILE_LINE_FIRST_SERVICE 5
+#define PIDFILE_LINE_EXTENSION_VERSION 4
+#define PIDFILE_LINE_SEM_ID 5
+#define PIDFILE_LINE_FIRST_SERVICE 6
 
 bool create_pidfile(const char *pidfile, pid_t pid);
 
@@ -55,8 +57,9 @@ bool create_service_pidfile(const char *pidfile, const char *serviceName);
 void get_service_pidfile(const char *pidfile,
 						 const char *serviceName,
 						 char *filename);
-bool read_service_pidfile_version_string(const char *pidfile,
-										 char *versionString);
+bool read_service_pidfile_version_strings(const char *pidfile,
+										  char *versionString,
+										  char *extensionVersionString);
 
 bool read_pidfile(const char *pidfile, pid_t *pid);
 bool remove_pidfile(const char *pidfile);

--- a/src/bin/pg_autoctl/pidfile.h
+++ b/src/bin/pg_autoctl/pidfile.h
@@ -33,8 +33,8 @@
  *		7	second supervised service pid line
  *    ...
  *
- * The supervised service lines are added later, not the first tim we create
- * the pidfile. Each service line contains 3 bits of information, separated
+ * The supervised service lines are added later, not the first time we create
+ * the pidfile. Each service line contains 2 bits of information, separated
  * with spaces:
  *
  *   pid service-name

--- a/src/bin/pg_autoctl/pidfile.h
+++ b/src/bin/pg_autoctl/pidfile.h
@@ -17,7 +17,42 @@
 #include "monitor.h"
 #include "monitor_config.h"
 
+/*
+ * As of pg_autoctl 1.4, the contents of the pidfile is:
+ *
+ * line #
+ *		1	supervisor PID
+ *		2	data directory path
+ *		3	version number (PG_AUTOCTL_VERSION)
+ *		4	shared semaphore id (used to serialize log writes)
+ *		5	first supervised service pid line
+ *		6	second supervised service pid line
+ *    ...
+ *
+ * The supervised service lines are added later, not the first tim we create
+ * the pidfile. Each service line contains 3 bits of information, separated
+ * with spaces:
+ *
+ *   pid service-name
+ *
+ * Each service creates its own pidfile with its own version number. At
+ * pg_autoctl upgrade time, we might have a supervisor process that's running
+ * with a different version than one of the restarted pg_autoctl services.
+ */
+#define PIDFILE_LINE_PID 1
+#define PIDFILE_LINE_DATA_DIR 2
+#define PIDFILE_LINE_VERSION_STRING 3
+#define PIDFILE_LINE_SEM_ID 4
+#define PIDFILE_LINE_FIRST_SERVICE 5
+
 bool create_pidfile(const char *pidfile, pid_t pid);
+bool create_service_pidfile(const char *pidfile, const char *serviceName);
+void get_service_pidfile(const char *pidfile,
+						 const char *serviceName,
+						 char *filename);
+bool read_service_pidfile_version_string(const char *pidfile,
+										 char *versionString);
+
 bool read_pidfile(const char *pidfile, pid_t *pid);
 bool remove_pidfile(const char *pidfile);
 void check_pidfile(const char *pidfile, pid_t start_pid);

--- a/src/bin/pg_autoctl/pidfile.h
+++ b/src/bin/pg_autoctl/pidfile.h
@@ -12,6 +12,9 @@
 #include <inttypes.h>
 #include <signal.h>
 
+#include "postgres_fe.h"
+#include "pqexpbuffer.h"
+
 #include "keeper.h"
 #include "keeper_config.h"
 #include "monitor.h"
@@ -46,6 +49,8 @@
 #define PIDFILE_LINE_FIRST_SERVICE 5
 
 bool create_pidfile(const char *pidfile, pid_t pid);
+
+bool prepare_pidfile_buffer(PQExpBuffer content, pid_t pid);
 bool create_service_pidfile(const char *pidfile, const char *serviceName);
 void get_service_pidfile(const char *pidfile,
 						 const char *serviceName,

--- a/src/bin/pg_autoctl/service_keeper.c
+++ b/src/bin/pg_autoctl/service_keeper.c
@@ -54,13 +54,13 @@ start_keeper(Keeper *keeper)
 
 	Service subprocesses[] = {
 		{
-			"postgres",
+			SERVICE_NAME_POSTGRES,
 			RP_PERMANENT,
 			-1,
 			&service_postgres_ctl_start
 		},
 		{
-			"node active",
+			SERVICE_NAME_KEEPER,
 			RP_PERMANENT,
 			-1,
 			&service_keeper_start,

--- a/src/bin/pg_autoctl/service_keeper_init.c
+++ b/src/bin/pg_autoctl/service_keeper_init.c
@@ -46,13 +46,13 @@ service_keeper_init(Keeper *keeper)
 
 	Service subprocesses[] = {
 		{
-			"postgres",
+			SERVICE_NAME_POSTGRES,
 			RP_PERMANENT,
 			-1,
 			&service_postgres_ctl_start,
 		},
 		{
-			"keeper init",
+			SERVICE_NAME_KEEPER_INIT,
 			createAndRun ? RP_PERMANENT : RP_TRANSIENT,
 			-1,
 			&service_keeper_init_start,
@@ -62,10 +62,10 @@ service_keeper_init(Keeper *keeper)
 
 	int subprocessesCount = sizeof(subprocesses) / sizeof(subprocesses[0]);
 
-	/* when using pg_autoctl create monitor --run, use "node active" */
+	/* when using pg_autoctl create monitor --run, use "node-active" */
 	if (createAndRun)
 	{
-		strlcpy(subprocesses[1].name, "node active", NAMEDATALEN);
+		strlcpy(subprocesses[1].name, SERVICE_NAME_KEEPER, NAMEDATALEN);
 	}
 
 	return supervisor_start(subprocesses, subprocessesCount, pidfile);

--- a/src/bin/pg_autoctl/service_monitor.c
+++ b/src/bin/pg_autoctl/service_monitor.c
@@ -47,13 +47,13 @@ start_monitor(Monitor *monitor)
 
 	Service subprocesses[] = {
 		{
-			"postgres",
+			SERVICE_NAME_POSTGRES,
 			RP_PERMANENT,
 			-1,
 			&service_postgres_ctl_start
 		},
 		{
-			"listener",
+			SERVICE_NAME_MONITOR,
 			RP_PERMANENT,
 			-1,
 			&service_monitor_start,

--- a/src/bin/pg_autoctl/service_monitor_init.c
+++ b/src/bin/pg_autoctl/service_monitor_init.c
@@ -48,13 +48,13 @@ service_monitor_init(Monitor *monitor)
 
 	Service subprocesses[] = {
 		{
-			"postgres",
+			SERVICE_NAME_POSTGRES,
 			RP_PERMANENT,
 			-1,
 			&service_postgres_ctl_start
 		},
 		{
-			"installer",
+			SERVICE_NAME_MONITOR_INIT,
 			createAndRun ? RP_PERMANENT : RP_TRANSIENT,
 			-1,
 			&service_monitor_init_start,
@@ -67,7 +67,7 @@ service_monitor_init(Monitor *monitor)
 	/* when using pg_autoctl create monitor --run, use "listener" */
 	if (createAndRun)
 	{
-		strlcpy(subprocesses[1].name, "listener", NAMEDATALEN);
+		strlcpy(subprocesses[1].name, SERVICE_NAME_MONITOR, NAMEDATALEN);
 	}
 
 	/* We didn't create our target username/dbname yet */

--- a/src/bin/pg_autoctl/service_postgres_ctl.c
+++ b/src/bin/pg_autoctl/service_postgres_ctl.c
@@ -178,7 +178,7 @@ service_postgres_ctl_loop(LocalPostgresServer *postgres)
 	 * split-brain situations.
 	 */
 	Service postgresService = {
-		"postgres",
+		SERVICE_NAME_POSTGRES,
 		RP_PERMANENT,           /* actually micro-managed in this loop */
 		-1,
 		&service_postgres_start,

--- a/src/bin/pg_autoctl/supervisor.h
+++ b/src/bin/pg_autoctl/supervisor.h
@@ -13,6 +13,26 @@
 #include <signal.h>
 
 /*
+ * pg_autoctl runs sub-processes as "services", and we need to use the same
+ * service names in several places:
+ *
+ *  - the main pidfile,
+ *  - the per-service name for the pidfile is derived from this,
+ *  - the pg_autoctl do service getpid|restart commands
+ */
+#define SERVICE_NAME_POSTGRES "postgres"
+#define SERVICE_NAME_KEEPER "node-active"
+#define SERVICE_NAME_MONITOR "listener"
+
+/*
+ * At pg_autoctl create time we use a transient service to initialize our local
+ * node. When using the --run option, the transient service is terminated and
+ * we start the permanent service with the name defined above.
+ */
+#define SERVICE_NAME_KEEPER_INIT "node-active"
+#define SERVICE_NAME_MONITOR_INIT "node-active"
+
+/*
  * Our supervisor process may retart a service sub-process when it quits,
  * depending on the exit status and the restart policy that has been choosen:
  *

--- a/src/bin/pg_autoctl/supervisor.h
+++ b/src/bin/pg_autoctl/supervisor.h
@@ -29,8 +29,8 @@
  * node. When using the --run option, the transient service is terminated and
  * we start the permanent service with the name defined above.
  */
-#define SERVICE_NAME_KEEPER_INIT "node-active"
-#define SERVICE_NAME_MONITOR_INIT "node-active"
+#define SERVICE_NAME_KEEPER_INIT "node-init"
+#define SERVICE_NAME_MONITOR_INIT "monitor-init"
 
 /*
  * Our supervisor process may retart a service sub-process when it quits,


### PR DESCRIPTION
Our new pg_autoctl upgrade procedure will make it possible to have a
supervisor process running with version 1.4 and the node-active process
being restarted from disk with version 1.5. It is then important that we are
able to provide this information to the users.

Currently, the information fits in our output for pg_autoctl version when
using the JSON format, so that's where it is available.

To be able to have that information, we need the services themselves to
publish it. For that, we invent per-service pidfiles and have a new pidfile
format that contains the version string.