### PR TITLE
Only use replication slots on standby nodes for good Postgres versions.

### DIFF
--- a/src/bin/pg_autoctl/cli_config.c
+++ b/src/bin/pg_autoctl/cli_config.c
@@ -334,6 +334,15 @@ cli_config_check_connections(PostgresSetup *pgSetup,
 				 "please review your Postgres configuration");
 	}
 
+	if (pg_setup_standby_slot_supported(pgSetup, LOG_WARN))
+	{
+		int major = pgSetup->control.pg_control_version / 100;
+		int minor = pgSetup->control.pg_control_version % 100;
+
+		log_info("Postgres version %d.%d allows using replication slots "
+				 "on the standby nodes", major, minor);
+	}
+
 	/*
 	 * Now, on Postgres nodes, check that the monitor uri is valid and that we
 	 * can connect to the monitor just fine. This requires having setup the

--- a/src/bin/pg_autoctl/config.c
+++ b/src/bin/pg_autoctl/config.c
@@ -105,7 +105,7 @@ build_xdg_path(char *dst,
 		 * yet, precluding the use of realpath(3) to get the absolute name
 		 * here.
 		 */
-		char currentWorkingDirectory[MAXPGPATH];
+		char currentWorkingDirectory[MAXPGPATH] = { 0 };
 
 		if (getcwd(currentWorkingDirectory, MAXPGPATH) == NULL)
 		{
@@ -127,15 +127,15 @@ build_xdg_path(char *dst,
 		return false;
 	}
 
-	/* and finally add the configuration file name */
-	join_path_components(filename, filename, name);
-
-	/* normalize the path to the configuration file, if it exists */
+	/* normalize the existing path to the configuration file */
 	if (!normalize_filename(filename, dst, MAXPGPATH))
 	{
 		/* errors have already been logged */
 		return false;
 	}
+
+	/* and finally add the configuration file name */
+	join_path_components(dst, dst, name);
 
 	return true;
 }

--- a/src/bin/pg_autoctl/keeper.c
+++ b/src/bin/pg_autoctl/keeper.c
@@ -973,15 +973,16 @@ keeper_maintain_replication_slots(Keeper *keeper)
 	 * replication slots in all versions of Postgres 11 and 12, so that we can
 	 * test our implementation.
 	 */
-	if (keeperState->current_role == PRIMARY_STATE ||
-		keeperState->current_role == WAIT_PRIMARY_STATE ||
-		!env_exists(PG_AUTOCTL_DEBUG))
+	if (!(keeperState->current_role == PRIMARY_STATE ||
+		  keeperState->current_role == WAIT_PRIMARY_STATE))
 	{
 		/*
 		 * Bypass replication slot maintenance unless Postgres has support for
-		 * replication slots on a standby.
+		 * replication slots on a standby, or unless PG_AUTOCTL_DEBUG is set in
+		 * the environment.
 		 */
-		bool bypass = !pg_setup_standby_slot_supported(pgSetup, LOG_TRACE);
+		bool bypass = !env_exists(PG_AUTOCTL_DEBUG) ||
+					  !pg_setup_standby_slot_supported(pgSetup, LOG_TRACE);
 
 		if (bypass)
 		{

--- a/src/bin/pg_autoctl/keeper.c
+++ b/src/bin/pg_autoctl/keeper.c
@@ -1134,7 +1134,9 @@ keeper_register_and_init(Keeper *keeper, NodeState initialState)
 	PostgresSetup *pgSetup = &(config->pgSetup);
 	KeeperStateInit *initState = &(keeper->initState);
 	Monitor *monitor = &(keeper->monitor);
+
 	MonitorAssignedState assignedState = { 0 };
+	char expectedSlotName[BUFSIZE] = { 0 };
 
 	/*
 	 * First try to create our state file. The keeper_state_create_file function
@@ -1212,6 +1214,14 @@ keeper_register_and_init(Keeper *keeper, NodeState initialState)
 
 		goto rollback;
 	}
+
+	/*
+	 * Also update the groupId and replication slot name in the
+	 * configuration file.
+	 */
+	(void) postgres_sprintf_replicationSlotName(assignedState.nodeId,
+												expectedSlotName,
+												sizeof(expectedSlotName));
 
 	/* also update the groupId in the configuration file. */
 	if (!keeper_config_set_groupId_and_slot_name(&(keeper->config),

--- a/src/bin/pg_autoctl/keeper_pg_init.c
+++ b/src/bin/pg_autoctl/keeper_pg_init.c
@@ -322,15 +322,18 @@ keeper_pg_init_and_register_primary(Keeper *keeper)
 bool
 keeper_pg_init_continue(Keeper *keeper)
 {
+	KeeperStateData *keeperState = &(keeper->state);
 	KeeperStateInit *initState = &(keeper->initState);
 	KeeperConfig *config = &(keeper->config);
 
+	/* initialize our keeper state and read the state file */
 	if (!keeper_init(keeper, config))
 	{
 		/* errors have already been logged */
 		return false;
 	}
 
+	/* also read the init state file */
 	if (!keeper_init_state_read(initState, config->pathnames.init))
 	{
 		log_fatal("Failed to restart from previous keeper init attempt");
@@ -346,6 +349,23 @@ keeper_pg_init_continue(Keeper *keeper)
 	 * TODO: verify the information in the state file against the information
 	 * in the monitor and decide if it's stale or not.
 	 */
+
+	/*
+	 * Also update the groupId and replication slot name in the configuration
+	 * file, from the keeper state file: we might not have reached a point
+	 * where the configuration changes have been saved to disk in the previous
+	 * attempt.
+	 */
+	if (!keeper_config_set_groupId_and_slot_name(&(keeper->config),
+												 keeperState->current_node_id,
+												 keeperState->current_group))
+	{
+		log_error("Failed to update the configuration file with the groupId %d "
+				  "and the nodeId %d",
+				  keeperState->current_group,
+				  keeperState->current_node_id);
+		return false;
+	}
 
 	/*
 	 * If we have an init file and the state file looks good, then the

--- a/src/bin/pg_autoctl/pgsetup.h
+++ b/src/bin/pg_autoctl/pgsetup.h
@@ -219,5 +219,7 @@ bool pgsetup_validate_ssl_settings(PostgresSetup *pgSetup);
 SSLMode pgsetup_parse_sslmode(const char *sslMode);
 char * pgsetup_sslmode_to_string(SSLMode sslMode);
 
+bool pg_setup_standby_slot_supported(PostgresSetup *pgSetup, int logLevel);
+
 
 #endif /* PGSETUP_H */

--- a/src/bin/pg_autoctl/primary_standby.c
+++ b/src/bin/pg_autoctl/primary_standby.c
@@ -151,6 +151,8 @@ local_postgres_unlink_status_file(LocalPostgresServer *postgres)
 {
 	LocalExpectedPostgresStatus *pgStatus = &(postgres->expectedPgStatus);
 
+	log_trace("local_postgres_unlink_status_file: %s", pgStatus->pgStatusPath);
+
 	return unlink_file(pgStatus->pgStatusPath);
 }
 
@@ -252,6 +254,9 @@ ensure_postgres_service_is_running(LocalPostgresServer *postgres)
 
 	if (!pgIsRunning)
 	{
+		log_info("Waiting until Postgres is ready to serve \"%s\"",
+				 pgSetup->pgdata);
+
 		/* main logging is done in the Postgres controller sub-process */
 		pgIsRunning = pg_setup_wait_until_is_ready(pgSetup, timeout, LOG_DEBUG);
 

--- a/src/bin/pg_autoctl/primary_standby.c
+++ b/src/bin/pg_autoctl/primary_standby.c
@@ -114,7 +114,16 @@ local_postgres_set_status_path(LocalPostgresServer *postgres, bool unlink)
 	PostgresSetup *pgSetup = &(postgres->postgresSetup);
 	LocalExpectedPostgresStatus *pgStatus = &(postgres->expectedPgStatus);
 
-	log_trace("local_postgres_set_status_path: %s", pgSetup->pgdata);
+	/* normalize our PGDATA path when it exists on-disk already */
+	if (directory_exists(pgSetup->pgdata))
+	{
+		/* normalize the existing path to PGDATA */
+		if (!normalize_filename(pgSetup->pgdata, pgSetup->pgdata, MAXPGPATH))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+	}
 
 	/* initialize our Postgres state file path */
 	if (!build_xdg_path(pgStatus->pgStatusPath,


### PR DESCRIPTION
A bug in Postgres prevents WAL recycling on standby nodes when we use the
function pg_replication_slot_advance() to maintain their LSN position. In
this patch we work around the bug to avoid it by just not installing our
replication slots on the standby nodes when we're running a Postgres version
with the bug. That's 11.0 to 11.8 included, and 12.0 to 12.3 included.

Fixes #283.