### PR TITLE
Handle empty pgdata during creating monitor

### DIFF
--- a/src/bin/pg_autoctl/file_utils.h
+++ b/src/bin/pg_autoctl/file_utils.h
@@ -26,6 +26,7 @@
 
 bool file_exists(const char *filename);
 bool directory_exists(const char *path);
+bool directory_isempty(const char *path);
 bool ensure_empty_dir(const char *dirname, int mode);
 FILE * fopen_with_umask(const char *filePath, const char *modes, int flags, mode_t umask);
 FILE * fopen_read_only(const char *filePath);

--- a/src/bin/pg_autoctl/monitor_pg_init.c
+++ b/src/bin/pg_autoctl/monitor_pg_init.c
@@ -96,7 +96,13 @@ monitor_pg_init(Monitor *monitor)
 			return false;
 		}
 	}
-	else
+
+	/*
+	 * At this point we may have an env figured out, but not necessarily a
+	 * populated PGDATA directory in the case of an empty directory pointed
+	 * to by pgdata.
+	 */
+	if (!directory_exists(pgSetup->pgdata) || directory_isempty(pgSetup->pgdata))
 	{
 		if (!pg_ctl_initdb(pgSetup->pg_ctl, pgSetup->pgdata))
 		{


### PR DESCRIPTION
In case the --pgdata parameter to "create monitor" is an existing, but empty directory, the process would fail with a rather hard to interpret error message.  Make sure to properly support existing empty directories and initdb them just like how a non-existing directory is handled.