### PR TITLE
Fix name of config file in error message

### DIFF
--- a/src/bin/pg_autoctl/primary_standby.c
+++ b/src/bin/pg_autoctl/primary_standby.c
@@ -497,7 +497,7 @@ postgres_add_default_settings(LocalPostgresServer *postgres)
 											   configFilePath,
 											   default_settings))
 	{
-		log_error("Failed to add default settings to postgres.conf: couldn't "
+		log_error("Failed to add default settings to postgresql.conf: couldn't "
 				  "write the new postgresql.conf, see above for details");
 		return false;
 	}


### PR DESCRIPTION
The file in question is named postgresql.conf, make sure to reference it by its correct name to avoid user confusion.