### PR TITLE
Log and notify node health changes.

### DIFF
--- a/docs/ref/configuration.rst
+++ b/docs/ref/configuration.rst
@@ -26,7 +26,7 @@ operations:
     secondary at shutdown time, thus preventing data loss.::
 
       pgautofailover.primary_demote_timeout
-        
+
   - Preventing promotion of the secondary
 
     pg_auto_failover implements a trade-off where data availability trumps service
@@ -66,7 +66,7 @@ database where the extension has been deployed::
   short_desc | Maximum number of re-tries before marking a node as failed.
   -[ RECORD 3 ]----------------------------------------------------------------------------------------------------
   name       | pgautofailover.health_check_period
-  setting    | 20000
+  setting    | 5000
   unit       | ms
   short_desc | Duration between each check (in milliseconds).
   -[ RECORD 4 ]----------------------------------------------------------------------------------------------------
@@ -119,19 +119,19 @@ An example configuration file looks like the following::
   group = 0
   nodename = node1.db
   nodekind = standalone
-  
+
   [postgresql]
   pgdata = /data/pgsql/
   pg_ctl = /usr/pgsql-10/bin/pg_ctl
   dbname = postgres
   host = /tmp
   port = 5000
-  
+
   [replication]
   slot = pgautofailover_standby
   maximum_backup_rate = 100M
   backup_directory = /data/backup/node1.db
-  
+
   [timeout]
   network_partition_timeout = 20
   postgresql_restart_failure_timeout = 20
@@ -143,7 +143,7 @@ commands are provided::
   pg_autoctl config check [--pgdata <pgdata>]
   pg_autoctl config get [--pgdata <pgdata>] section.option
   pg_autoctl config set [--pgdata <pgdata>] section.option value
-  
+
 The ``[postgresql]`` section is discovered automatically by the ``pg_autoctl``
 command and is not intended to be changed manually.
 

--- a/src/bin/pg_autoctl/primary_standby.c
+++ b/src/bin/pg_autoctl/primary_standby.c
@@ -265,9 +265,6 @@ ensure_postgres_service_is_running(LocalPostgresServer *postgres)
 
 	if (!pgIsRunning)
 	{
-		log_info("Waiting until Postgres is ready to serve \"%s\"",
-				 pgSetup->pgdata);
-
 		/* main logging is done in the Postgres controller sub-process */
 		pgIsRunning = pg_setup_wait_until_is_ready(pgSetup, timeout, LOG_DEBUG);
 

--- a/src/monitor/health_check.h
+++ b/src/monitor/health_check.h
@@ -57,5 +57,7 @@ extern void HealthCheckWorkerLauncherMain(Datum arg);
 extern List * LoadNodeHealthList(void);
 extern NodeHealth * TupleToNodeHealth(HeapTuple heapTuple,
 									  TupleDesc tupleDescriptor);
-extern void SetNodeHealthState(char *nodeName, uint16 nodePort, int healthStatus);
+extern void SetNodeHealthState(char *nodeName, uint16 nodePort,
+							   int previousHealthState,
+							   int healthState);
 extern void StopHealthCheckWorker(Oid databaseId);

--- a/src/monitor/health_check_worker.c
+++ b/src/monitor/health_check_worker.c
@@ -148,7 +148,7 @@ static volatile sig_atomic_t got_sighup = false;
 static volatile sig_atomic_t got_sigterm = false;
 
 /* GUC variables */
-int HealthCheckPeriod = 20 * 1000;
+int HealthCheckPeriod = 5 * 1000;
 int HealthCheckTimeout = 5 * 1000;
 int HealthCheckMaxRetries = 2;
 int HealthCheckRetryDelay = 2 * 1000;
@@ -773,15 +773,9 @@ ManageHealthCheck(HealthCheck *healthCheck, struct timeval currentTime)
 		{
 			if (healthCheck->numTries >= HealthCheckMaxRetries + 1)
 			{
-				if (nodeHealth->healthState != NODE_HEALTH_BAD)
-				{
-					elog(LOG, "pg_auto_failover monitor marking node %s:%d as unhealthy",
-						 nodeHealth->nodeName,
-						 nodeHealth->nodePort);
-				}
-
 				SetNodeHealthState(healthCheck->node->nodeName,
 								   healthCheck->node->nodePort,
+								   nodeHealth->healthState,
 								   NODE_HEALTH_BAD);
 
 				healthCheck->state = HEALTH_CHECK_DEAD;
@@ -890,15 +884,9 @@ ManageHealthCheck(HealthCheck *healthCheck, struct timeval currentTime)
 			{
 				PQfinish(connection);
 
-				if (nodeHealth->healthState != NODE_HEALTH_GOOD)
-				{
-					elog(LOG, "pg_auto_failover monitor marking node %s:%d as healthy",
-						 nodeHealth->nodeName,
-						 nodeHealth->nodePort);
-				}
-
 				SetNodeHealthState(healthCheck->node->nodeName,
 								   healthCheck->node->nodePort,
+								   nodeHealth->healthState,
 								   NODE_HEALTH_GOOD);
 
 				healthCheck->connection = NULL;

--- a/src/monitor/pg_auto_failover.c
+++ b/src/monitor/pg_auto_failover.c
@@ -91,7 +91,7 @@ StartMonitorNode(void)
 
 	DefineCustomIntVariable("pgautofailover.health_check_period",
 							"Duration between each check (in milliseconds).",
-							NULL, &HealthCheckPeriod, 20 * 1000, 1, INT_MAX, PGC_SIGHUP,
+							NULL, &HealthCheckPeriod, 5 * 1000, 1, INT_MAX, PGC_SIGHUP,
 							GUC_UNIT_MS, NULL, NULL, NULL);
 
 	DefineCustomIntVariable("pgautofailover.health_check_timeout",


### PR DESCRIPTION
Also remove a misleading log line saying that we're waiting for Postgres to
start (serve) when actually we are waiting for the monitor to have done at
least one health check with the node.

Also change the default HealthCheckPeriod from 20s down to 5s.

See #332.
Fixed #329.