### PR TITLE
Feature/pgtune

### DIFF
--- a/src/bin/pg_autoctl/cli_do_misc.c
+++ b/src/bin/pg_autoctl/cli_do_misc.c
@@ -27,6 +27,7 @@
 #include "monitor.h"
 #include "monitor_config.h"
 #include "pgctl.h"
+#include "pgtuning.h"
 #include "primary_standby.h"
 #include "string_utils.h"
 
@@ -271,6 +272,23 @@ keeper_cli_pgsetup_startup_logs(int argc, char **argv)
 	{
 		exit(EXIT_CODE_PGCTL);
 	}
+}
+
+
+/*
+ * keeper_cli_pgsetup_tune compute some Postgres tuning for the local system.
+ */
+void
+keeper_cli_pgsetup_tune(int argc, char **argv)
+{
+	char config[BUFSIZE] = { 0 };
+
+	if (!pgtuning_prepare_guc_settings(postgres_tuning, config, BUFSIZE))
+	{
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+
+	fformat(stdout, "%s\n", config);
 }
 
 

--- a/src/bin/pg_autoctl/cli_do_root.c
+++ b/src/bin/pg_autoctl/cli_do_root.c
@@ -199,11 +199,20 @@ CommandLine do_pgsetup_startup_logs =
 				 keeper_cli_keeper_setup_getopts,
 				 keeper_cli_pgsetup_startup_logs);
 
+CommandLine do_pgsetup_tune =
+	make_command("tune",
+				 "Compute and log some Postgres tuning options",
+				 "[option ...]",
+				 KEEPER_CLI_WORKER_SETUP_OPTIONS,
+				 keeper_cli_keeper_setup_getopts,
+				 keeper_cli_pgsetup_tune);
+
 CommandLine *do_pgsetup[] = {
 	&do_pgsetup_discover,
 	&do_pgsetup_is_ready,
 	&do_pgsetup_wait_until_ready,
 	&do_pgsetup_startup_logs,
+	&do_pgsetup_tune,
 	NULL
 };
 

--- a/src/bin/pg_autoctl/cli_do_root.h
+++ b/src/bin/pg_autoctl/cli_do_root.h
@@ -74,6 +74,7 @@ void keeper_cli_pgsetup_discover(int argc, char **argv);
 void keeper_cli_pgsetup_is_ready(int argc, char **argv);
 void keeper_cli_pgsetup_wait_until_ready(int argc, char **argv);
 void keeper_cli_pgsetup_startup_logs(int argc, char **argv);
+void keeper_cli_pgsetup_tune(int argc, char **argv);
 
 void keeper_cli_add_default_settings(int argc, char **argv);
 void keeper_cli_create_replication_user(int argc, char **argv);

--- a/src/bin/pg_autoctl/pgctl.c
+++ b/src/bin/pg_autoctl/pgctl.c
@@ -592,14 +592,18 @@ prepare_guc_settings_from_pgsetup(const char *configFilePath,
 	 * Postgres system on those targets.
 	 */
 #if defined(__linux__)
-	char tuning[BUFSIZE] = { 0 };
-
-	if (!pgtuning_prepare_guc_settings(postgres_tuning, tuning, sizeof(tuning)))
 	{
-		log_warn("Failed to compute Postgres basic tuning for this system");
-	}
+		char tuning[BUFSIZE] = { 0 };
 
-	appendPQExpBuffer(config, "\n%s\n", tuning);
+		if (!pgtuning_prepare_guc_settings(postgres_tuning,
+										   tuning,
+										   sizeof(tuning)))
+		{
+			log_warn("Failed to compute Postgres basic tuning for this system");
+		}
+
+		appendPQExpBuffer(config, "\n%s\n", tuning);
+	}
 #endif
 
 	/* memory allocation could have failed while building string */

--- a/src/bin/pg_autoctl/pgctl.c
+++ b/src/bin/pg_autoctl/pgctl.c
@@ -590,8 +590,11 @@ prepare_guc_settings_from_pgsetup(const char *configFilePath,
 	 * Only bother to apply settings on Linux, macOS and Windows are considered
 	 * development environment and we decide to refrain from tuning a dedicated
 	 * Postgres system on those targets.
+	 *
+	 * Also disable Postgres tuning when running the unit test suite.
 	 */
 #if defined(__linux__)
+	if (!(env_exists(PG_AUTOCTL_DEBUG) && env_exists("PG_REGRESS_SOCK_DIR")))
 	{
 		char tuning[BUFSIZE] = { 0 };
 

--- a/src/bin/pg_autoctl/pgtuning.c
+++ b/src/bin/pg_autoctl/pgtuning.c
@@ -1,0 +1,338 @@
+/*
+ * src/bin/pg_autoctl/pgtuning.c
+ *     Adjust some very basic Postgres tuning to the system properties.
+ *
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the PostgreSQL License.
+ *
+ */
+
+#include "postgres_fe.h"
+#include "pqexpbuffer.h"
+
+#include "config.h"
+#include "file_utils.h"
+#include "log.h"
+#include "pgctl.h"
+#include "pgtuning.h"
+#include "system_utils.h"
+
+/*
+ * In most cases we are going to initdb a Postgres instance for our users, we
+ * might as well introduce some naive Postgres tuning. In the static array are
+ * selected Postgres default values and static values we always set.
+ *
+ * Dynamic code is then used on the target systems to compute better values
+ * dynamically for some parameters: work_mem, maintenance_work_mem,
+ * effective_cache_size, autovacuum_max_workers.
+ */
+GUC postgres_tuning[] = {
+	{ "shared_preload_libraries", "'pg_stat_statements'" },
+	{ "track_io_timing", "on" },
+	{ "track_functions", "pl" },
+	{ "shared_buffers", "'128 MB'" },
+	{ "work_mem", "'4 MB'" },
+	{ "maintenance_work_mem", "'64MB'" },
+	{ "effective_cache_size", "'4 GB'" },
+	{ "autovacuum_max_workers", "3" },
+	{ "autovacuum_vacuum_scale_factor", "0.08" },
+	{ "autovacuum_analyze_scale_factor", "0.02" },
+	{ NULL, NULL }
+};
+
+
+typedef struct DynamicTuning
+{
+	int maxWorkers;
+	uint64_t shared_buffers;
+	uint64_t work_mem;
+	uint64_t maintenance_work_mem;
+	uint64_t effective_cache_size;
+} DynamicTuning;
+
+
+static bool pgtuning_compute_mem_settings(SystemInfo *sysInfo,
+										  DynamicTuning *tuning);
+
+void pgtuning_log_settings(DynamicTuning *tuning, int logLevel);
+
+static int pgtuning_compute_max_workers(SystemInfo *sysInfo);
+
+static bool pgtuning_edit_guc_settings(GUC *settings, DynamicTuning *tuning,
+									   char *config, size_t size);
+
+
+/*
+ * pgtuning_prepare_guc_settings probes the system information (nCPU and total
+ * RAM) and computes some better defaults for Postgres.
+ */
+bool
+pgtuning_prepare_guc_settings(GUC *settings, char *config, size_t size)
+{
+	SystemInfo sysInfo = { 0 };
+	DynamicTuning tuning = { 0 };
+	char totalram[BUFSIZE] = { 0 };
+
+	if (!get_system_info(&sysInfo))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	(void) pretty_print_bytes(totalram, sizeof(totalram), sysInfo.totalram);
+
+	log_info("Detected %d CPUs and %s total RAM on this server",
+			 sysInfo.ncpu,
+			 totalram);
+
+	tuning.maxWorkers = pgtuning_compute_max_workers(&sysInfo);
+
+	if (!pgtuning_compute_mem_settings(&sysInfo, &tuning))
+	{
+		log_error("Failed to compute memory settings, using defaults");
+		return false;
+	}
+
+	(void) pgtuning_log_settings(&tuning, LOG_INFO);
+
+	return pgtuning_edit_guc_settings(settings, &tuning, config, size);
+}
+
+
+/*
+ * pgtuning_compute_max_workers returns how many autovacuum max workers we can
+ * setup on the local system, depending on its number of CPUs.
+ *
+ * We could certainly cook a simple enough maths expression to compute the
+ * numbers assigned in this range based "grid" here, but that would be much
+ * harder to maintain and change our mind about, and not as easy to grasp on a
+ * quick reading.
+ */
+static int
+pgtuning_compute_max_workers(SystemInfo *sysInfo)
+{
+	/* use the default up to 16 cores (HT included) */
+	if (sysInfo->ncpu < 16)
+	{
+		return 3;
+	}
+	else if (sysInfo->ncpu < 24)
+	{
+		return 4;
+	}
+	else if (sysInfo->ncpu < 32)
+	{
+		return 6;
+	}
+	else if (sysInfo->ncpu < 48)
+	{
+		return 8;
+	}
+	else if (sysInfo->ncpu < 64)
+	{
+		return 12;
+	}
+	else
+	{
+		return 16;
+	}
+}
+
+
+/*
+ * pgtuning_compute_work_mem computes how much work mem to use on this system.
+ *
+ * Inspiration has been taken from http://pgconfigurator.cybertec.at
+ *
+ * Rather than trying to devise a good maths expression to compute values, we
+ * implement our decision making with a range based approach. Some values are
+ * still computed with an expression (shared_buffers is set to 25% of the total
+ * RAM up to 256 GB of RAM, for instance).
+ */
+static bool
+pgtuning_compute_mem_settings(SystemInfo *sysInfo, DynamicTuning *tuning)
+{
+	uint64_t oneGB = 2 << 30;
+
+	/*
+	 * <= 8 GB of RAM
+	 */
+	if (sysInfo->totalram <= (8 * oneGB))
+	{
+		tuning->shared_buffers = sysInfo->totalram / 4;
+		tuning->work_mem = 16 * 2 << 20;              /*  16 MB */
+		tuning->maintenance_work_mem = 256 * 2 << 20; /* 256 MB */
+	}
+
+	/*
+	 * > 8 GB up to 64 GB of RAM
+	 */
+	else if (sysInfo->totalram <= (64 * oneGB))
+	{
+		tuning->shared_buffers = sysInfo->totalram / 4;
+		tuning->work_mem = 24 * 2 << 20;              /*  24 MB */
+		tuning->maintenance_work_mem = 512 * 2 << 20; /* 512 MB */
+	}
+
+	/*
+	 * > 64 GB up to 256 GB of RAM
+	 */
+	else if (sysInfo->totalram <= (256 * oneGB))
+	{
+		tuning->shared_buffers = 16 * oneGB;        /* 16 GB */
+		tuning->work_mem = 32 * 2 << 20;              /* 32 MB */
+		tuning->maintenance_work_mem = oneGB;       /*  1 GB */
+	}
+
+	/*
+	 * > 256 GB of RAM
+	 */
+	else
+	{
+		tuning->shared_buffers = 32 * oneGB;        /* 32 GB */
+		tuning->work_mem = 64 * 2 << 20;              /* 64 MB */
+		tuning->maintenance_work_mem = 2 * oneGB;   /*  2 GB */
+	}
+
+	/*
+	 * What's not in shared buffers is expected to be mostly file system cache,
+	 * and then again effective_cache_size is a hint and does not need to be
+	 * the exact value as shown by the free(1) command.
+	 */
+	tuning->effective_cache_size = sysInfo->totalram - tuning->shared_buffers;
+
+	return true;
+}
+
+
+/*
+ * pgtuning_log_mem_settings logs the memory settings we computed.
+ */
+void
+pgtuning_log_settings(DynamicTuning *tuning, int logLevel)
+{
+	char buf[BUFSIZE] = { 0 };
+
+	log_level(logLevel,
+			  "Setting autovacuum_max_workers to %d", tuning->maxWorkers);
+
+	(void) pretty_print_bytes(buf, sizeof(buf), tuning->shared_buffers);
+	log_level(logLevel, "Setting shared_buffers to %s", buf);
+
+	(void) pretty_print_bytes(buf, sizeof(buf), tuning->work_mem);
+	log_level(logLevel, "Setting work_mem to %s", buf);
+
+	(void) pretty_print_bytes(buf, sizeof(buf),
+							  tuning->maintenance_work_mem);
+	log_level(logLevel, "Setting maintenance_work_mem to %s", buf);
+
+	(void) pretty_print_bytes(buf, sizeof(buf),
+							  tuning->effective_cache_size);
+	log_level(logLevel, "Setting effective_cache_size to %s", buf);
+}
+
+
+/*
+ * pgtuning_edit_guc_settings prepares a Postgres configuration file snippet
+ * from the given GUC settings and the dynamic tuning adjusted to the system
+ * and place the resulting snippet in the pre-allocated string buffer config of
+ * given size.
+ */
+#define streq(x, y) ((x != NULL) && (y != NULL) && (strcmp(x, y) == 0))
+
+static bool
+pgtuning_edit_guc_settings(GUC *settings, DynamicTuning *tuning,
+						   char *config, size_t size)
+{
+	/*
+	 * Only bother to apply settings on Linux, macOS and Windows are considered
+	 * development environment and we decide to refrain from tuning a dedicated
+	 * Postgres system on those targets.
+	 */
+	PQExpBuffer contents = createPQExpBuffer();
+	int settingIndex = 0;
+
+	if (contents == NULL)
+	{
+		log_error("Failed to allocate memory");
+		return false;
+	}
+
+	/* replace placeholder values with dynamic tuned values */
+	for (settingIndex = 0; settings[settingIndex].name != NULL; settingIndex++)
+	{
+		GUC *setting = &settings[settingIndex];
+
+		if (streq(setting->name, "autovacuum_max_workers"))
+		{
+			appendPQExpBuffer(contents, "%s = %d\n",
+							  setting->name,
+							  tuning->maxWorkers);
+		}
+		else if (streq(setting->name, "shared_buffers"))
+		{
+			char pretty[BUFSIZE] = { 0 };
+
+			(void) pretty_print_bytes(pretty, sizeof(pretty),
+									  tuning->shared_buffers);
+
+			appendPQExpBuffer(contents, "%s = '%s'\n", setting->name, pretty);
+		}
+		else if (streq(setting->name, "work_mem"))
+		{
+			char pretty[BUFSIZE] = { 0 };
+
+			(void) pretty_print_bytes(pretty, sizeof(pretty), tuning->work_mem);
+
+			appendPQExpBuffer(contents, "%s = '%s'\n", setting->name, pretty);
+		}
+		else if (streq(setting->name, "maintenance_work_mem"))
+		{
+			char pretty[BUFSIZE] = { 0 };
+
+			(void) pretty_print_bytes(pretty, sizeof(pretty),
+									  tuning->maintenance_work_mem);
+
+			appendPQExpBuffer(contents, "%s = '%s'\n", setting->name, pretty);
+		}
+		else if (streq(setting->name, "effective_cache_size"))
+		{
+			char pretty[BUFSIZE] = { 0 };
+
+			(void) pretty_print_bytes(pretty, sizeof(pretty),
+									  tuning->effective_cache_size);
+
+			appendPQExpBuffer(contents, "%s = '%s'\n", setting->name, pretty);
+		}
+		else
+		{
+			appendPQExpBuffer(contents, "%s = %s\n",
+							  setting->name, setting->value);
+		}
+	}
+
+	/* memory allocation could have failed while building string */
+	if (PQExpBufferBroken(contents))
+	{
+		log_error("Failed to allocate memory");
+		destroyPQExpBuffer(contents);
+		return false;
+	}
+
+	if (size < contents->len)
+	{
+		log_error("Failed to prepare Postgres tuning for the local system, "
+				  "the setup needs %ld bytes and pg_autoctl only support "
+				  "up to %ld bytes",
+				  contents->len,
+				  size);
+		destroyPQExpBuffer(contents);
+		return false;
+	}
+
+	strlcpy(config, contents->data, size);
+
+	destroyPQExpBuffer(contents);
+
+	return true;
+}

--- a/src/bin/pg_autoctl/pgtuning.c
+++ b/src/bin/pg_autoctl/pgtuning.c
@@ -42,7 +42,7 @@ GUC postgres_tuning[] = {
 
 typedef struct DynamicTuning
 {
-	int maxWorkers;
+	int autovacuum_max_workers;
 	uint64_t shared_buffers;
 	uint64_t work_mem;
 	uint64_t maintenance_work_mem;
@@ -84,7 +84,7 @@ pgtuning_prepare_guc_settings(GUC *settings, char *config, size_t size)
 			  sysInfo.ncpu,
 			  totalram);
 
-	tuning.maxWorkers = pgtuning_compute_max_workers(&sysInfo);
+	tuning.autovacuum_max_workers = pgtuning_compute_max_workers(&sysInfo);
 
 	if (!pgtuning_compute_mem_settings(&sysInfo, &tuning))
 	{
@@ -213,7 +213,7 @@ pgtuning_log_settings(DynamicTuning *tuning, int logLevel)
 	char buf[BUFSIZE] = { 0 };
 
 	log_level(logLevel,
-			  "Setting autovacuum_max_workers to %d", tuning->maxWorkers);
+			  "Setting autovacuum_max_workers to %d", tuning->autovacuum_max_workers);
 
 	(void) pretty_print_bytes(buf, sizeof(buf), tuning->shared_buffers);
 	log_level(logLevel, "Setting shared_buffers to %s", buf);
@@ -264,7 +264,7 @@ pgtuning_edit_guc_settings(GUC *settings, DynamicTuning *tuning,
 		{
 			appendPQExpBuffer(contents, "%s = %d\n",
 							  setting->name,
-							  tuning->maxWorkers);
+							  tuning->autovacuum_max_workers);
 		}
 		else if (streq(setting->name, "shared_buffers"))
 		{

--- a/src/bin/pg_autoctl/pgtuning.c
+++ b/src/bin/pg_autoctl/pgtuning.c
@@ -157,7 +157,6 @@ pgtuning_compute_mem_settings(SystemInfo *sysInfo, DynamicTuning *tuning)
 	 */
 	if (sysInfo->totalram <= (8 * oneGB))
 	{
-		log_error("less than 8 gigs");
 		tuning->shared_buffers = sysInfo->totalram / 4;
 		tuning->work_mem = 16 * 1 << 20;              /*  16 MB */
 		tuning->maintenance_work_mem = 256 * 1 << 20; /* 256 MB */

--- a/src/bin/pg_autoctl/pgtuning.c
+++ b/src/bin/pg_autoctl/pgtuning.c
@@ -150,16 +150,19 @@ pgtuning_compute_max_workers(SystemInfo *sysInfo)
 static bool
 pgtuning_compute_mem_settings(SystemInfo *sysInfo, DynamicTuning *tuning)
 {
-	uint64_t oneGB = 2 << 30;
+	uint64_t oneGB = ((uint64_t) 1) << 30;
+	log_error("total ram %ld", sysInfo->totalram);
+	log_error("shared bufferes %ld", sysInfo->totalram / 4);
 
 	/*
 	 * <= 8 GB of RAM
 	 */
 	if (sysInfo->totalram <= (8 * oneGB))
 	{
+		log_error("less than 8 gigs");
 		tuning->shared_buffers = sysInfo->totalram / 4;
-		tuning->work_mem = 16 * 2 << 20;              /*  16 MB */
-		tuning->maintenance_work_mem = 256 * 2 << 20; /* 256 MB */
+		tuning->work_mem = 16 * 1 << 20;              /*  16 MB */
+		tuning->maintenance_work_mem = 256 * 1 << 20; /* 256 MB */
 	}
 
 	/*
@@ -168,8 +171,8 @@ pgtuning_compute_mem_settings(SystemInfo *sysInfo, DynamicTuning *tuning)
 	else if (sysInfo->totalram <= (64 * oneGB))
 	{
 		tuning->shared_buffers = sysInfo->totalram / 4;
-		tuning->work_mem = 24 * 2 << 20;              /*  24 MB */
-		tuning->maintenance_work_mem = 512 * 2 << 20; /* 512 MB */
+		tuning->work_mem = 24 * 1 << 20;              /*  24 MB */
+		tuning->maintenance_work_mem = 512 * 1 << 20; /* 512 MB */
 	}
 
 	/*
@@ -178,7 +181,7 @@ pgtuning_compute_mem_settings(SystemInfo *sysInfo, DynamicTuning *tuning)
 	else if (sysInfo->totalram <= (256 * oneGB))
 	{
 		tuning->shared_buffers = 16 * oneGB;        /* 16 GB */
-		tuning->work_mem = 32 * 2 << 20;              /* 32 MB */
+		tuning->work_mem = 32 * 1 << 20;              /* 32 MB */
 		tuning->maintenance_work_mem = oneGB;       /*  1 GB */
 	}
 
@@ -188,7 +191,7 @@ pgtuning_compute_mem_settings(SystemInfo *sysInfo, DynamicTuning *tuning)
 	else
 	{
 		tuning->shared_buffers = 32 * oneGB;        /* 32 GB */
-		tuning->work_mem = 64 * 2 << 20;              /* 64 MB */
+		tuning->work_mem = 64 * 1 << 20;              /* 64 MB */
 		tuning->maintenance_work_mem = 2 * oneGB;   /*  2 GB */
 	}
 

--- a/src/bin/pg_autoctl/pgtuning.c
+++ b/src/bin/pg_autoctl/pgtuning.c
@@ -151,8 +151,6 @@ static bool
 pgtuning_compute_mem_settings(SystemInfo *sysInfo, DynamicTuning *tuning)
 {
 	uint64_t oneGB = ((uint64_t) 1) << 30;
-	log_error("total ram %ld", sysInfo->totalram);
-	log_error("shared bufferes %ld", sysInfo->totalram / 4);
 
 	/*
 	 * <= 8 GB of RAM
@@ -215,7 +213,8 @@ pgtuning_log_settings(DynamicTuning *tuning, int logLevel)
 	char buf[BUFSIZE] = { 0 };
 
 	log_level(logLevel,
-			  "Setting autovacuum_max_workers to %d", tuning->autovacuum_max_workers);
+			  "Setting autovacuum_max_workers to %d",
+			  tuning->autovacuum_max_workers);
 
 	(void) pretty_print_bytes(buf, sizeof(buf), tuning->shared_buffers);
 	log_level(logLevel, "Setting shared_buffers to %s", buf);

--- a/src/bin/pg_autoctl/pgtuning.c
+++ b/src/bin/pg_autoctl/pgtuning.c
@@ -27,7 +27,6 @@
  * effective_cache_size, autovacuum_max_workers.
  */
 GUC postgres_tuning[] = {
-	{ "track_io_timing", "on" },
 	{ "track_functions", "pl" },
 	{ "shared_buffers", "'128 MB'" },
 	{ "work_mem", "'4 MB'" },

--- a/src/bin/pg_autoctl/pgtuning.c
+++ b/src/bin/pg_autoctl/pgtuning.c
@@ -27,7 +27,6 @@
  * effective_cache_size, autovacuum_max_workers.
  */
 GUC postgres_tuning[] = {
-	{ "shared_preload_libraries", "'pg_stat_statements'" },
 	{ "track_io_timing", "on" },
 	{ "track_functions", "pl" },
 	{ "shared_buffers", "'128 MB'" },

--- a/src/bin/pg_autoctl/pgtuning.h
+++ b/src/bin/pg_autoctl/pgtuning.h
@@ -1,0 +1,19 @@
+/*
+ * src/bin/pg_autoctl/pgtuning.h
+ *     Adjust some very basic Postgres tuning to the system properties.
+ *
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the PostgreSQL License.
+ *
+ */
+
+#ifndef PGTUNING_H
+#define PGTUNING_H
+
+#include <stdbool.h>
+
+extern GUC postgres_tuning[];
+
+bool pgtuning_prepare_guc_settings(GUC *settings, char *config, size_t size);
+
+#endif /* PGTUNING_H */

--- a/src/bin/pg_autoctl/primary_standby.c
+++ b/src/bin/pg_autoctl/primary_standby.c
@@ -35,6 +35,7 @@ static void local_postgres_update_pg_failures_tracking(LocalPostgresServer *post
  * replaced with dynamic values from the setup when used.
  */
 #define DEFAULT_GUC_SETTINGS_FOR_PG_AUTO_FAILOVER \
+	{ "shared_preload_libraries", "pg_stat_statements" }, \
 	{ "listen_addresses", "'*'" }, \
 	{ "port", "5432" }, \
 	{ "max_wal_senders", "12" }, \
@@ -67,7 +68,7 @@ GUC postgres_default_settings[] = {
 
 GUC citus_default_settings[] = {
 	DEFAULT_GUC_SETTINGS_FOR_PG_AUTO_FAILOVER,
-	{ "shared_preload_libraries", "'citus'" },
+	{ "shared_preload_libraries", "'citus','pg_stat_statements'" },
 	{ "citus.node_conninfo", "'sslmode=prefer'" },
 	{ NULL, NULL }
 };

--- a/src/bin/pg_autoctl/primary_standby.c
+++ b/src/bin/pg_autoctl/primary_standby.c
@@ -41,7 +41,7 @@ static void local_postgres_update_pg_failures_tracking(LocalPostgresServer *post
 	{ "max_replication_slots", "12" }, \
 	{ "wal_level", "'replica'" }, \
 	{ "wal_log_hints", "on" }, \
-	{ "wal_keep_segments", "64" }, \
+	{ "wal_keep_segments", "512" }, \
 	{ "wal_sender_timeout", "'30s'" }, \
 	{ "hot_standby_feedback", "on" }, \
 	{ "hot_standby", "on" }, \

--- a/src/bin/pg_autoctl/system_utils.c
+++ b/src/bin/pg_autoctl/system_utils.c
@@ -124,7 +124,6 @@ pretty_print_bytes(char *buffer, size_t size, uint64_t bytes)
 
 	uint sIndex = 0;
 	long double count = bytes;
-	long double remainder = 0.0;
 
 	while (count >= 1024 && sIndex < 7)
 	{
@@ -132,16 +131,6 @@ pretty_print_bytes(char *buffer, size_t size, uint64_t bytes)
 		count /= 1024;
 	}
 
-	remainder = count - floorl(count);
-
-	if (remainder == 0.0)
-	{
-		sformat(buffer, size, "%d %s", (int) count, suffixes[sIndex]);
-	}
-	else
-	{
-		/* I can't seem to make %.1Lf work with pg_vsnprintf() */
-		sformat(buffer, size, "%d.%d %s",
-				(int) count, (int) (remainder * 10), suffixes[sIndex]);
-	}
+	/* forget about having more precision, Postgres wants integers here */
+	sformat(buffer, size, "%d %s", (int) count, suffixes[sIndex]);
 }

--- a/src/bin/pg_autoctl/system_utils.c
+++ b/src/bin/pg_autoctl/system_utils.c
@@ -125,7 +125,7 @@ pretty_print_bytes(char *buffer, size_t size, uint64_t bytes)
 	uint sIndex = 0;
 	long double count = bytes;
 
-	while (count >= 1024 && sIndex < 7)
+	while (count >= 10240 && sIndex < 7)
 	{
 		sIndex++;
 		count /= 1024;

--- a/src/bin/pg_autoctl/system_utils.c
+++ b/src/bin/pg_autoctl/system_utils.c
@@ -1,0 +1,147 @@
+/*
+ * src/bin/pg_autoctl/hardware_utils.c
+ *   Utility functions for getting CPU and Memory information.
+ *
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the PostgreSQL License.
+ *
+ */
+
+#if defined(__linux__)
+#include <sys/sysinfo.h>
+#else
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#endif
+
+#include <math.h>
+
+#include "log.h"
+#include "file_utils.h"
+#include "system_utils.h"
+
+#if defined(__linux__)
+static bool get_system_info_linux(SystemInfo *sysInfo);
+#endif
+
+#if defined(__APPLE__) || defined(BSD)
+static bool get_system_info_bsd(SystemInfo *sysInfo);
+#endif
+
+/*
+ * get_system_info probes for system information and fills the given SystemInfo
+ * structure with what we found: number of CPUs and total amount of memory.
+ */
+bool
+get_system_info(SystemInfo *sysInfo)
+{
+#if defined(__APPLE__) || defined(BSD)
+	return get_system_info_bsd(sysInfo);
+#elif defined(__linux__)
+	return get_system_info_linux(sysInfo);
+#else
+	log_error("Failed to get system information: "
+			  "Operating System not supported");
+	return false;
+#endif
+}
+
+
+/*
+ * On Linux, use sysinfo(2) and getnprocs(3)
+ */
+#if defined(__linux__)
+static bool
+get_system_info_linux(SystemInfo *sysInfo)
+{
+	struct sysinfo linuxSysInfo = { 0 };
+
+	if (sysinfo(&linuxSysInfo) != 0)
+	{
+		log_error("Failed to call sysinfo(): %m");
+		return false;
+	}
+
+	sysInfo->procs = get_nprocs();
+	sysInfo->totalram = linuxSysInfo.totalram;
+
+	return true;
+}
+
+
+#endif
+
+
+/*
+ * FreeBSD, OpenBSD, and darwin use the sysctlbyname(3) API.
+ */
+#if defined(__APPLE__) || defined(BSD)
+static bool
+get_system_info_bsd(SystemInfo *sysInfo)
+{
+	unsigned int ncpu = 0;      /* the API requires an integer here */
+
+	size_t cpuSize = sizeof(ncpu);
+	size_t memSize = sizeof(sysInfo->totalram);
+
+	if (sysctlbyname("hw.ncpu", &ncpu, &cpuSize, NULL, 0) != 0)
+	{
+		log_error("Failed to probe number of CPUs: %m");
+		return false;
+	}
+
+	sysInfo->procs = (unsigned short) ncpu;
+
+	if (sysctlbyname("hw.memsize", &(sysInfo->totalram), &memSize, NULL, 0) != 0)
+	{
+		log_error("Failed to probe Physical Memory: %m");
+		return false;
+	}
+
+	return true;
+}
+
+
+#endif
+
+
+/*
+ * pretty_print_bytes pretty prints bytes in a human readable form. Given
+ * 17179869184 it places the string "16 GB" in the given buffer.
+ */
+void
+pretty_print_bytes(char *buffer, size_t size, uint64_t bytes)
+{
+	const char *suffixes[7] = {
+		"B",                    /* Bytes */
+		"KB",                   /* Kilo */
+		"MB",                   /* Mega */
+		"GB",                   /* Giga */
+		"TB",                   /* Tera */
+		"PB",                   /* Peta */
+		"EB"                    /* Exa */
+	};
+
+	uint sIndex = 0;
+	long double count = bytes;
+	long double remainder = 0.0;
+
+	while (count >= 1024 && sIndex < 7)
+	{
+		sIndex++;
+		count /= 1024;
+	}
+
+	remainder = count - floorl(count);
+
+	if (remainder == 0.0)
+	{
+		sformat(buffer, size, "%d %s", (int) count, suffixes[sIndex]);
+	}
+	else
+	{
+		/* I can't seem to make %.1Lf work with pg_vsnprintf() */
+		sformat(buffer, size, "%d.%d %s",
+				(int) count, (int) (remainder * 10), suffixes[sIndex]);
+	}
+}

--- a/src/bin/pg_autoctl/system_utils.c
+++ b/src/bin/pg_autoctl/system_utils.c
@@ -62,7 +62,7 @@ get_system_info_linux(SystemInfo *sysInfo)
 		return false;
 	}
 
-	sysInfo->procs = get_nprocs();
+	sysInfo->ncpu = get_nprocs();
 	sysInfo->totalram = linuxSysInfo.totalram;
 
 	return true;
@@ -90,7 +90,7 @@ get_system_info_bsd(SystemInfo *sysInfo)
 		return false;
 	}
 
-	sysInfo->procs = (unsigned short) ncpu;
+	sysInfo->ncpu = (unsigned short) ncpu;
 
 	if (sysctlbyname("hw.memsize", &(sysInfo->totalram), &memSize, NULL, 0) != 0)
 	{

--- a/src/bin/pg_autoctl/system_utils.h
+++ b/src/bin/pg_autoctl/system_utils.h
@@ -1,0 +1,27 @@
+/*
+ * src/bin/pg_autoctl/hardware_utils.h
+ *   Utility functions for getting CPU and Memory information.
+ *
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the PostgreSQL License.
+ *
+ */
+
+#ifndef SYSTEM_UTILS_H
+#define SYSTEM_UTILS_H
+
+#include <stdbool.h>
+
+
+/* taken from sysinfo(2) on Linux */
+typedef struct SystemInfo
+{
+	uint64_t totalram;          /* Total usable main memory size */
+	unsigned short procs;    /* Number of current processes */
+} SystemInfo;
+
+bool get_system_info(SystemInfo *sysInfo);
+void pretty_print_bytes(char *buffer, size_t size, uint64_t bytes);
+
+
+#endif /* SYSTEM_UTILS_H */

--- a/src/bin/pg_autoctl/system_utils.h
+++ b/src/bin/pg_autoctl/system_utils.h
@@ -1,5 +1,5 @@
 /*
- * src/bin/pg_autoctl/hardware_utils.h
+ * src/bin/pg_autoctl/system_utils.h
  *   Utility functions for getting CPU and Memory information.
  *
  * Copyright (c) Microsoft Corporation. All rights reserved.
@@ -17,7 +17,7 @@
 typedef struct SystemInfo
 {
 	uint64_t totalram;          /* Total usable main memory size */
-	unsigned short procs;    /* Number of current processes */
+	unsigned short ncpu;        /* Number of current processes */
 } SystemInfo;
 
 bool get_system_info(SystemInfo *sysInfo);


### PR DESCRIPTION
In many cases `pg_autoctl` is going to do the `pg_ctl initdb` installation of a new Postgres database cluster.
We then have the opportunity to compute some dynamic Postgres tuning, and in this PR we do that for a couple
of easy to compute and highly rewarding settings, such as memory related settings.