### PR TITLE
Get rid of configuration setting for replication slot name.

### DIFF
--- a/src/bin/pg_autoctl/keeper.c
+++ b/src/bin/pg_autoctl/keeper.c
@@ -735,9 +735,9 @@ keeper_ensure_configuration(Keeper *keeper, bool postgresNotRunningIsOk)
 	 */
 	postgres->postgresSetup = config->pgSetup;
 
-	if (!keeper_config_set_groupId_and_slot_name(config,
-												 state->current_node_id,
-												 state->current_group))
+	if (!keeper_config_update(config,
+							  state->current_node_id,
+							  state->current_group))
 	{
 		log_error("Failed to update configuration");
 		return false;

--- a/src/bin/pg_autoctl/keeper.c
+++ b/src/bin/pg_autoctl/keeper.c
@@ -735,6 +735,14 @@ keeper_ensure_configuration(Keeper *keeper, bool postgresNotRunningIsOk)
 	 */
 	postgres->postgresSetup = config->pgSetup;
 
+	if (!keeper_config_set_groupId_and_slot_name(config,
+												 state->current_node_id,
+												 state->current_group))
+	{
+		log_error("Failed to update configuration");
+		return false;
+	}
+
 	if (!local_postgres_update(postgres, postgresNotRunningIsOk))
 	{
 		log_error("Failed to reload configuration, see above for details");

--- a/src/bin/pg_autoctl/keeper_config.h
+++ b/src/bin/pg_autoctl/keeper_config.h
@@ -38,8 +38,8 @@ typedef struct KeeperConfig
 	PostgresSetup pgSetup;
 
 	/* PostgreSQL replication / tooling setup */
-	char *replication_slot_name;
-	char *replication_password;
+	char replication_slot_name[MAXCONNINFO];
+	char replication_password[MAXCONNINFO];
 	char *maximum_backup_rate;
 	char backupDirectory[MAXPGPATH];
 


### PR DESCRIPTION
The code now expects the replication slot name to be set a certain way, same
as the application_name. As it's now enforced, make it so that our users
can't edit it the way they would prefer it. It's an implementation detail
now.