### PR TITLE
Fix bug in pg_setup_controldata.

### DIFF
--- a/src/bin/pg_autoctl/pgctl.c
+++ b/src/bin/pg_autoctl/pgctl.c
@@ -111,7 +111,7 @@ pg_controldata(PostgresSetup *pgSetup, bool missing_ok)
 
 	if (pgSetup->pgdata[0] == '\0' || pgSetup->pg_ctl[0] == '\0')
 	{
-		log_debug("Failed to run pg_control_data on an empty pgSetup");
+		log_error("BUG: pg_controldata: missing pgSetup pgdata or pg_ctl");
 		return false;
 	}
 

--- a/src/bin/pg_autoctl/pgsetup.c
+++ b/src/bin/pg_autoctl/pgsetup.c
@@ -451,6 +451,9 @@ pg_setup_controldata(PostgresSetup *pgSetup, bool missingPgDataIsOk)
 	/*
 	 * Now fetch new control values from running pg_controldata on PGDATA.
 	 */
+	strlcpy(newPgSetup.pgdata, pgSetup->pgdata, MAXPGPATH);
+	strlcpy(newPgSetup.pg_ctl, pgSetup->pg_ctl, MAXPGPATH);
+
 	if (!pg_controldata(&newPgSetup, missingPgDataIsOk))
 	{
 		/* errors have already been logged */


### PR DESCRIPTION
We need to copy over at pgSetup.pgdata and pgSetup.pg_ctl before calling
into the pg_controldata binary.