### PR TITLE
Track connection status / failures.

### DIFF
--- a/src/bin/pg_autoctl/pgsql.c
+++ b/src/bin/pg_autoctl/pgsql.c
@@ -288,6 +288,13 @@ pgsql_finish(PGSQL *pgsql)
 		log_debug("Disconnecting from \"%s\"", pgsql->connectionString);
 		PQfinish(pgsql->connection);
 		pgsql->connection = NULL;
+
+		/*
+		 * When we fail to connect, on the way out we call pgsql_finish to
+		 * reset the connection to NULL. We still want the callers to be able
+		 * to inquire about our connection status, so refrain to reset the
+		 * status.
+		 */
 	}
 }
 
@@ -406,6 +413,8 @@ pgsql_open_connection(PGSQL *pgsql)
 					  connectionTypeToString(pgsql->connectionType),
 					  pgsql->connectionString);
 
+			pgsql->status = PG_CONNECTION_BAD;
+
 			pgsql_finish(pgsql);
 			return NULL;
 		}
@@ -420,6 +429,8 @@ pgsql_open_connection(PGSQL *pgsql)
 			return NULL;
 		}
 	}
+
+	pgsql->status = PG_CONNECTION_OK;
 
 	/* set the libpq notice receiver to integrate notifications as warnings. */
 	PQsetNoticeProcessor(pgsql->connection,
@@ -481,6 +492,7 @@ pgsql_retry_open_connection(PGSQL *pgsql, uint64_t startTime)
 			 pgsql->retryPolicy.attempts >= pgsql->retryPolicy.maxR))
 		{
 			(void) log_connection_error(pgsql->connection, LOG_ERROR);
+			pgsql->status = PG_CONNECTION_BAD;
 			pgsql_finish(pgsql);
 
 			log_error("Failed to connect to \"%s\" "
@@ -534,6 +546,7 @@ pgsql_retry_open_connection(PGSQL *pgsql, uint64_t startTime)
 					uint64_t now = time(NULL);
 
 					connectionOk = true;
+					pgsql->status = PG_CONNECTION_OK;
 
 					log_info("Successfully connected to \"%s\" "
 							 "after %d attempts in %d seconds.",
@@ -643,6 +656,7 @@ pgsql_retry_open_connection(PGSQL *pgsql, uint64_t startTime)
 	if (!connectionOk && pgsql->connection != NULL)
 	{
 		(void) log_connection_error(pgsql->connection, LOG_ERROR);
+		pgsql->status = PG_CONNECTION_BAD;
 		pgsql_finish(pgsql);
 
 		return false;

--- a/src/bin/pg_autoctl/pgsql.h
+++ b/src/bin/pg_autoctl/pgsql.h
@@ -95,12 +95,28 @@ typedef struct ConnectionRetryPolicy
 } ConnectionRetryPolicy;
 
 
+/*
+ * Allow higher level code to distinguish between failure to connect to the
+ * target Postgres service and failure to run a query or obtain the expected
+ * result. To that end we expose PQstatus() of the connection.
+ *
+ * We don't use the same enum values as in libpq because we want to have the
+ * unknown value when we didn't try to connect yet.
+ */
+typedef enum
+{
+	PG_CONNECTION_UNKNOWN = 0,
+	PG_CONNECTION_OK,
+	PG_CONNECTION_BAD
+} PGConnStatus;
+
 typedef struct PGSQL
 {
 	ConnectionType connectionType;
 	char connectionString[MAXCONNINFO];
 	PGconn *connection;
 	ConnectionRetryPolicy retryPolicy;
+	PGConnStatus status;
 } PGSQL;
 
 

--- a/src/bin/pg_autoctl/service_keeper.c
+++ b/src/bin/pg_autoctl/service_keeper.c
@@ -554,6 +554,22 @@ keeper_node_active(Keeper *keeper)
 	if (!keeper_check_monitor_extension_version(keeper))
 	{
 		/*
+		 * We could fail here for two different reasons:
+		 *
+		 * - if we failed to connect to the monitor (network split, monitor is
+		 *   in maintenance or being restarted, etc): in that case just return
+		 *   false and have the main loop handle the situation
+		 *
+		 * - if we could connect to the monitor and then failed to check that
+		 *   the version of the monitor is the one we expect, then we're not
+		 *   compatible with this monitor and that's a different story.
+		 */
+		if (monitor->pgsql.status != PG_CONNECTION_OK)
+		{
+			return false;
+		}
+
+		/*
 		 * Okay we're not compatible with the current version of the
 		 * pgautofailover extension on the monitor. The most plausible scenario
 		 * is that the monitor got update: we're still running e.g. 1.4 and the


### PR DESCRIPTION
Some parts of the code need to distinguish between failure to connect to a
(remote) Postgres instance and failure to execute a query, or retrieve the
expected result from the query. Make the information available in the PGSQL
structure.