### PR TITLE
Exit early with EXIT_CODE_QUIT in pg_autoctl create when possible.

### DIFF
--- a/src/bin/pg_autoctl/keeper_pg_init.c
+++ b/src/bin/pg_autoctl/keeper_pg_init.c
@@ -158,6 +158,7 @@ keeper_pg_init_and_register(Keeper *keeper)
 			log_fatal("The state file \"%s\" exists and "
 					  "there's no init in progress", config->pathnames.state);
 			log_info("HINT: use `pg_autoctl run` to start the service.");
+			exit(EXIT_CODE_QUIT);
 		}
 		return createAndRun;
 	}


### PR DESCRIPTION
When we return false from keeper_pg_init_and_register() the initialisation
process is then exited with an error code, and the supervisor is going to
try again to run the TRANSIENT service successfully. This makes sense when
we failed to contact to monitor or had another kind of intermitent failure.

When the problem is that it's all good and you should use --run or the
pg_autoctl run command, well, early exit with success code is better:
arguably we did our job.

Fixes #348.