### PR TITLE
Feature/test primary conninfo

### DIFF
--- a/src/bin/pg_autoctl/cli_do_misc.c
+++ b/src/bin/pg_autoctl/cli_do_misc.c
@@ -447,7 +447,7 @@ keeper_cli_receiwal(int argc, char **argv)
 	{
 		log_fatal("Hostname \"%s\" given in command line is %d characters, "
 				  "the maximum supported by pg_autoctl is %d",
-				  argv[0], hostLength, MAXCONNINFO - 1);
+				  argv[0], hostLength, _POSIX_HOST_NAME_MAX - 1);
 		exit(EXIT_CODE_BAD_ARGS);
 	}
 

--- a/src/bin/pg_autoctl/cli_do_misc.c
+++ b/src/bin/pg_autoctl/cli_do_misc.c
@@ -412,3 +412,77 @@ keeper_cli_promote_standby(int argc, char **argv)
 		exit(EXIT_CODE_PGSQL);
 	}
 }
+
+
+/*
+ * keeper_cli_receiwal allows to run pg_receivewal targetting the current
+ * primary conninfo of a standby node, either to check that the connection
+ * makes sense, or to actually start a sub-process receiving WAL.
+ */
+void
+keeper_cli_receiwal(int argc, char **argv)
+{
+	const bool missing_pgdata_is_ok = true;
+	const bool pg_not_running_is_ok = true;
+
+	KeeperConfig config = keeperOptions;
+	LocalPostgresServer postgres = { 0 };
+	PostgresSetup *pgSetup = &(postgres.postgresSetup);
+	int hostLength = 0;
+
+	char *targetLSN = NULL;
+
+	if (argc != 3)
+	{
+		commandline_print_usage(&do_standby_init, stderr);
+		exit(EXIT_CODE_BAD_ARGS);
+	}
+
+	keeper_config_init(&config, missing_pgdata_is_ok, pg_not_running_is_ok);
+	local_postgres_init(&postgres, &(config.pgSetup));
+
+	hostLength = strlcpy(postgres.replicationSource.primaryNode.host, argv[0],
+						 _POSIX_HOST_NAME_MAX);
+	if (hostLength >= _POSIX_HOST_NAME_MAX)
+	{
+		log_fatal("Hostname \"%s\" given in command line is %d characters, "
+				  "the maximum supported by pg_autoctl is %d",
+				  argv[0], hostLength, MAXCONNINFO - 1);
+		exit(EXIT_CODE_BAD_ARGS);
+	}
+
+	if (!stringToInt(argv[1], &(postgres.replicationSource.primaryNode.port)))
+	{
+		log_fatal("Argument is not a valid port number: \"%s\"", argv[1]);
+		exit(EXIT_CODE_BAD_ARGS);
+	}
+
+	targetLSN = argv[2];
+
+	if (!standby_init_replication_source(&postgres,
+										 NULL, /* primaryNode is done */
+										 PG_AUTOCTL_REPLICA_USERNAME,
+										 config.replication_password,
+										 config.replication_slot_name,
+										 config.maximum_backup_rate,
+										 config.backupDirectory,
+										 config.pgSetup.ssl,
+										 0))
+	{
+		/* can't happen at the moment */
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+
+	if (!pg_receivewal(pgSetup->pgdata,
+					   pgSetup->pg_ctl,
+					   &(postgres.replicationSource),
+					   targetLSN,
+					   LOG_INFO))
+	{
+		log_fatal("Failed to connect to the upstream server %s:%d "
+				  "for replication, see above for details",
+				  postgres.replicationSource.primaryNode.host,
+				  postgres.replicationSource.primaryNode.port);
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+}

--- a/src/bin/pg_autoctl/cli_do_root.c
+++ b/src/bin/pg_autoctl/cli_do_root.c
@@ -146,10 +146,19 @@ CommandLine do_standby_promote =
 				 keeper_cli_keeper_setup_getopts,
 				 keeper_cli_promote_standby);
 
+CommandLine do_standby_receivewal =
+	make_command("receivewal",
+				 "Receivewal in the PGDATA/pg_wal directory",
+				 " host port endpos",
+				 KEEPER_CLI_WORKER_SETUP_OPTIONS,
+				 keeper_cli_keeper_setup_getopts,
+				 keeper_cli_receiwal);
+
 CommandLine *do_standby[] = {
 	&do_standby_init,
 	&do_standby_rewind,
 	&do_standby_promote,
+	&do_standby_receivewal,
 	NULL
 };
 

--- a/src/bin/pg_autoctl/cli_do_root.h
+++ b/src/bin/pg_autoctl/cli_do_root.h
@@ -81,6 +81,7 @@ void keeper_cli_add_standby_to_hba(int argc, char **argv);
 void keeper_cli_init_standby(int argc, char **argv);
 void keeper_cli_rewind_old_primary(int argc, char **argv);
 void keeper_cli_promote_standby(int argc, char **argv);
+void keeper_cli_receiwal(int argc, char **argv);
 
 
 #endif  /* CLI_DO_ROOT_H */

--- a/src/bin/pg_autoctl/fsm_transition.c
+++ b/src/bin/pg_autoctl/fsm_transition.c
@@ -749,6 +749,7 @@ fsm_stop_postgres_and_setup_standby(Keeper *keeper)
 	/* make the Postgres setup for a standby node before reaching maintenance */
 	if (!pg_setup_standby_mode(pgSetup->control.pg_control_version,
 							   pgSetup->pgdata,
+							   pgSetup->pg_ctl,
 							   upstream))
 	{
 		log_error("Failed to setup Postgres as a standby to go to maintenance");

--- a/src/bin/pg_autoctl/keeper.c
+++ b/src/bin/pg_autoctl/keeper.c
@@ -841,6 +841,7 @@ keeper_ensure_configuration(Keeper *keeper, bool postgresNotRunningIsOk)
 		/* now setup the replication configuration (primary_conninfo etc) */
 		if (!pg_setup_standby_mode(state->pg_control_version,
 								   pgSetup->pgdata,
+								   pgSetup->pg_ctl,
 								   upstream))
 		{
 			log_error("Failed to setup Postgres as a standby after primary "

--- a/src/bin/pg_autoctl/pgctl.c
+++ b/src/bin/pg_autoctl/pgctl.c
@@ -816,7 +816,7 @@ pg_receivewal(const char *pgdata,
 			  char *targetLSN,
 			  int logLevel)
 {
-	int returnCode;
+	bool success;
 	Program program;
 	char pg_receivewal[MAXPGPATH] = { 0 };
 	char pg_wal[MAXPGPATH] = { 0 };
@@ -898,22 +898,21 @@ pg_receivewal(const char *pgdata,
 
 	(void) execute_subprogram(&program);
 
-	returnCode = program.returnCode;
-	free_program(&program);
+	success = program.returnCode == 0;
 
-	if (returnCode != 0)
+	if (program.returnCode != 0)
 	{
 		(void) log_program_output(program, LOG_INFO, LOG_ERROR);
 
-		log_error("Failed to run pg_receivewal: exit code %d", returnCode);
-		return false;
+		log_error("Failed to run pg_receivewal: exit code %d", program.returnCode);
 	}
 	else
 	{
 		(void) log_program_output(program, LOG_DEBUG, LOG_DEBUG);
 	}
 
-	return true;
+	free_program(&program);
+	return success;
 }
 
 

--- a/src/bin/pg_autoctl/pgctl.c
+++ b/src/bin/pg_autoctl/pgctl.c
@@ -806,8 +806,8 @@ pg_rewind(const char *pgdata,
 
 
 /*
- * pg_rewind runs the pg_receivewal program to retrieve WAL files in the given
- * database directory. We need the ability to connect to the node.
+ * pg_receivewal runs the pg_receivewal program to retrieve WAL files in the
+ * given database directory. We need the ability to connect to the node.
  */
 bool
 pg_receivewal(const char *pgdata,

--- a/src/bin/pg_autoctl/pgctl.c
+++ b/src/bin/pg_autoctl/pgctl.c
@@ -1418,15 +1418,21 @@ pg_setup_standby_mode(uint32_t pg_control_version,
 	 *
 	 * Target LSN 0/1 (which we already have) to test the replication
 	 * connection without actually doing anything else.
+	 *
+	 * pg_receivewal --endpos feature was introduced in Postgres 11, so we skip
+	 * that connection string testing in Postgres 10.
 	 */
-	if (!pg_receivewal(pgdata, pg_ctl, replicationSource, "0/1", LOG_DEBUG))
+	if (pg_control_version >= 1100)
 	{
-		log_fatal("Failed to connect to the upstream server %d (%s:%d) "
-				  "for replication, see above for details",
-				  primaryNode->nodeId,
-				  primaryNode->host,
-				  primaryNode->port);
-		return false;
+		if (!pg_receivewal(pgdata, pg_ctl, replicationSource, "0/1", LOG_DEBUG))
+		{
+			log_fatal("Failed to connect to the upstream server %d (%s:%d) "
+					  "for replication, see above for details",
+					  primaryNode->nodeId,
+					  primaryNode->host,
+					  primaryNode->port);
+			return false;
+		}
 	}
 
 	if (pg_control_version < 1200)

--- a/src/bin/pg_autoctl/pgctl.c
+++ b/src/bin/pg_autoctl/pgctl.c
@@ -908,6 +908,10 @@ pg_receivewal(const char *pgdata,
 		log_error("Failed to run pg_receivewal: exit code %d", returnCode);
 		return false;
 	}
+	else
+	{
+		(void) log_program_output(program, LOG_DEBUG, LOG_DEBUG);
+	}
 
 	return true;
 }

--- a/src/bin/pg_autoctl/pgctl.c
+++ b/src/bin/pg_autoctl/pgctl.c
@@ -867,7 +867,6 @@ pg_receivewal(const char *pgdata,
 	args[argsIndex++] = (char *) replicationSource->slotName;
 	args[argsIndex++] = "--dbname";
 	args[argsIndex++] = primaryConnInfo;
-	args[argsIndex++] = "--synchronous";
 
 	if (targetLSN != NULL)
 	{

--- a/src/bin/pg_autoctl/pgctl.c
+++ b/src/bin/pg_autoctl/pgctl.c
@@ -908,10 +908,6 @@ pg_receivewal(const char *pgdata,
 		log_error("Failed to run pg_receivewal: exit code %d", returnCode);
 		return false;
 	}
-	else
-	{
-		(void) log_program_output(program, LOG_DEBUG, LOG_DEBUG);
-	}
 
 	return true;
 }

--- a/src/bin/pg_autoctl/pgctl.h
+++ b/src/bin/pg_autoctl/pgctl.h
@@ -44,6 +44,11 @@ bool pg_basebackup(const char *pgdata,
 bool pg_rewind(const char *pgdata,
 			   const char *pg_ctl,
 			   ReplicationSource *replicationSource);
+bool pg_receivewal(const char *pgdata,
+				   const char *pg_ctl,
+				   ReplicationSource *replicationSource,
+				   char *targetLSN,
+				   int logLevel);
 
 bool pg_ctl_initdb(const char *pg_ctl, const char *pgdata);
 bool pg_ctl_postgres(const char *pg_ctl, const char *pgdata, int pgport,

--- a/src/bin/pg_autoctl/pgctl.h
+++ b/src/bin/pg_autoctl/pgctl.h
@@ -59,6 +59,7 @@ int pg_ctl_status(const char *pg_ctl, const char *pgdata, bool log_output);
 bool pg_ctl_promote(const char *pg_ctl, const char *pgdata);
 
 bool pg_setup_standby_mode(uint32_t pg_control_version,
+						   const char *pg_ctl,
 						   const char *pgdata,
 						   ReplicationSource *replicationSource);
 

--- a/src/bin/pg_autoctl/primary_standby.c
+++ b/src/bin/pg_autoctl/primary_standby.c
@@ -659,6 +659,7 @@ standby_init_database(LocalPostgresServer *postgres,
 	/* now setup the replication configuration (primary_conninfo etc) */
 	if (!pg_setup_standby_mode(pgSetup->control.pg_control_version,
 							   pgSetup->pgdata,
+							   pgSetup->pg_ctl,
 							   upstream))
 	{
 		log_error("Failed to setup Postgres as a standby after pg_basebackup");
@@ -737,6 +738,7 @@ primary_rewind_to_standby(LocalPostgresServer *postgres)
 
 	if (!pg_setup_standby_mode(pgSetup->control.pg_control_version,
 							   pgSetup->pgdata,
+							   pgSetup->pg_ctl,
 							   replicationSource))
 	{
 		log_error("Failed to setup Postgres as a standby, after rewind");

--- a/tests/network.py
+++ b/tests/network.py
@@ -151,9 +151,7 @@ class VirtualNode:
         return managed_nspopen(self.namespace, sudo_command,
                                stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                                stderr=subprocess.PIPE,
-                               # the subprocess output isn't always UTF-8,
-                               # take it as binary
-                               #universal_newlines=True,
+                               universal_newlines=True,
                                start_new_session=True)
 
     def run_unmanaged(self, command, user=os.getenv("USER")):
@@ -169,8 +167,7 @@ class VirtualNode:
         return NSPopen(self.namespace, sudo_command,
                        stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                        stderr=subprocess.PIPE,
-                       # the subprocess output isn't always UTF-8, take binary
-                       #universal_newlines=True,
+                       universal_newlines=True,
                        start_new_session=True)
 
     def run_and_wait(self, command, name, timeout=COMMAND_TIMEOUT):

--- a/tests/network.py
+++ b/tests/network.py
@@ -150,7 +150,10 @@ class VirtualNode:
                         'env', 'PATH=' + os.getenv("PATH")] + command
         return managed_nspopen(self.namespace, sudo_command,
                                stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-                               stderr=subprocess.PIPE, universal_newlines=True,
+                               stderr=subprocess.PIPE,
+                               # the subprocess output isn't always UTF-8,
+                               # take it as binary
+                               #universal_newlines=True,
                                start_new_session=True)
 
     def run_unmanaged(self, command, user=os.getenv("USER")):
@@ -165,7 +168,9 @@ class VirtualNode:
                         'env', 'PATH=' + os.getenv("PATH")] + command
         return NSPopen(self.namespace, sudo_command,
                        stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-                       stderr=subprocess.PIPE, universal_newlines=True,
+                       stderr=subprocess.PIPE,
+                       # the subprocess output isn't always UTF-8, take binary
+                       #universal_newlines=True,
                        start_new_session=True)
 
     def run_and_wait(self, command, name, timeout=COMMAND_TIMEOUT):

--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -1337,6 +1337,9 @@ class PGAutoCtl():
 
             self.last_returncode = proc.returncode
             if proc.returncode > 0:
+                out = out.decode("utf-8", "backslashreplace")
+                err = err.decode("utf-8", "backslashreplace")
+
                 raise Exception("%s failed\n%s\n%s\n%s" %
                                 (name,
                                  " ".join(self.command),

--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -538,6 +538,10 @@ class PGNode:
         log_string = ""
         if self.running():
             out, err = self.stop_pg_autoctl()
+
+            out = out.decode("utf-8", "backslashreplace")
+            err = err.decode("utf-8", "backslashreplace")
+
             log_string += f"STDOUT OF PG_AUTOCTL FOR {self.datadir}:\n{out}\n"
             log_string += f"STDERR OF PG_AUTOCTL FOR {self.datadir}:\n{err}\n"
 
@@ -1165,6 +1169,9 @@ class MonitorNode(PGNode):
             out, err = self.pg_autoctl.stop()
 
             if out or err:
+                out = out.decode("utf-8", "backslashreplace")
+                err = err.decode("utf-8", "backslashreplace")
+
                 print()
                 print("Monitor logs:\n%s\n%s\n" % (out, err))
 

--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -538,10 +538,6 @@ class PGNode:
         log_string = ""
         if self.running():
             out, err = self.stop_pg_autoctl()
-
-            out = out.decode("utf-8", "backslashreplace")
-            err = err.decode("utf-8", "backslashreplace")
-
             log_string += f"STDOUT OF PG_AUTOCTL FOR {self.datadir}:\n{out}\n"
             log_string += f"STDERR OF PG_AUTOCTL FOR {self.datadir}:\n{err}\n"
 
@@ -1169,9 +1165,6 @@ class MonitorNode(PGNode):
             out, err = self.pg_autoctl.stop()
 
             if out or err:
-                out = out.decode("utf-8", "backslashreplace")
-                err = err.decode("utf-8", "backslashreplace")
-
                 print()
                 print("Monitor logs:\n%s\n%s\n" % (out, err))
 
@@ -1328,6 +1321,7 @@ class PGAutoCtl():
         with self.vnode.run(self.command) as proc:
             try:
                 out, err = self.pgnode.cluster.communicate(proc, timeout)
+
             except subprocess.TimeoutExpired:
                 string_command = " ".join(self.command)
                 self.pgnode.print_debug_logs()
@@ -1337,13 +1331,11 @@ class PGAutoCtl():
 
             self.last_returncode = proc.returncode
             if proc.returncode > 0:
-                out = out.decode("utf-8", "backslashreplace")
-                err = err.decode("utf-8", "backslashreplace")
-
                 raise Exception("%s failed\n%s\n%s\n%s" %
                                 (name,
                                  " ".join(self.command),
                                  out, err))
+
             return out, err, proc.returncode
 
     def stop(self):


### PR DESCRIPTION
Actually test the primary_conninfo that we setup, to have early error detection (HBA and other cases) in the pg_autoctl control and output rather than in the Postgres logs in the background with a retry loop.