### PR TITLE
In some cases, we still need to call pg_controldata.

### DIFF
--- a/src/bin/pg_autoctl/keeper.c
+++ b/src/bin/pg_autoctl/keeper.c
@@ -485,8 +485,12 @@ keeper_update_pg_state(Keeper *keeper)
 		/* Postgres is not running. */
 		postgres->pgIsRunning = false;
 
-		/* keep the current values we have for the Postgres characteristics */
-		if (pgSetup->control.pg_control_version != 0)
+		/*
+		 * Cache invalidation: keep the current values we have for the Postgres
+		 * characteristics, when we already have them, or fetch them anew using
+		 * pg_controldata.
+		 */
+		if (keeperState->pg_control_version != 0)
 		{
 			pgSetup->control.pg_control_version = keeperState->pg_control_version;
 			pgSetup->control.catalog_version_no = keeperState->catalog_version_no;


### PR DESCRIPTION
As we renew the keeper->postgres.pgSetup cache on each round, we need to
manually make sure to re-install the current values we have in cache when
Postgres is not running. That said, we might also reach that code path at
pg_autoctl start-up when Postgres is not yet running.