### PR TITLE
Fix dropping the old-primary node.

### DIFF
--- a/src/monitor/node_active_protocol.c
+++ b/src/monitor/node_active_protocol.c
@@ -1030,7 +1030,7 @@ RemoveNode(AutoFailoverNode *currentNode)
 	LockFormation(currentNode->formationId, ExclusiveLock);
 
 	/* when removing the primary, initiate a failover */
-	currentNodeIsPrimary = StateBelongsToPrimary(currentNode->reportedState);
+	currentNodeIsPrimary = CanTakeWritesInState(currentNode->goalState);
 
 	/* get the list of the other nodes */
 	otherNodesGroupList = AutoFailoverOtherNodesList(currentNode);

--- a/tests/test_multi_standbys.py
+++ b/tests/test_multi_standbys.py
@@ -187,3 +187,17 @@ def test_011_write_into_new_primary():
 
     # generate more WAL trafic for replication
     node2.run_sql_query("CHECKPOINT")
+
+def test_012_fail_primary():
+    print()
+    print("Failing current primary node 2")
+    node2.fail()
+
+    assert node1.wait_until_state(target_state="primary")
+    assert node3.wait_until_state(target_state="secondary")
+
+def test_013_remove_old_primary():
+    node2.drop()
+
+    assert node1.wait_until_state(target_state="primary")
+    assert node3.wait_until_state(target_state="secondary")


### PR DESCRIPTION
When we remove the old primary, its reported state is still that of a
primary. We might have moved on to a new primary already though, and in that
case we want to process the old-primary the same way we would a secondary.

To fix, consider the goalState rather than the reportedState, and filter out
the DRAINING, DEMOTE, and DEMOTE_TIMEOUT as meaning that we have a primary,
by testing with CanTakeWritesInState() rather than StateBelongsToPrimary().

Fixes https://github.com/citusdata/pg_auto_failover/issues/353.