### PR TITLE
Implement a retry policy for deadlocks and other transient failures.

### DIFF
--- a/src/bin/pg_autoctl/cli_enable_disable.c
+++ b/src/bin/pg_autoctl/cli_enable_disable.c
@@ -437,14 +437,11 @@ cli_enable_maintenance(int argc, char **argv)
 
 	char *channels[] = { "state", NULL };
 
-	ConnectionRetryPolicy retryPolicy = {
-		POSTGRES_PING_RETRY_TIMEOUT,
-		-1, /* unbounded number of attempts */
-		5 * 1000,               /* sleep up to 5s between attempts */
-		1 * 1000                /* first retry happens after 1 second */
-	};
+	ConnectionRetryPolicy retryPolicy = { 0 };
 
 	keeper.config = keeperOptions;
+
+	(void) pgsql_set_monitor_interactive_retry_policy(&retryPolicy);
 
 	(void) exit_unless_role_is_keeper(&(keeper.config));
 
@@ -538,14 +535,11 @@ cli_disable_maintenance(int argc, char **argv)
 
 	char *channels[] = { "state", NULL };
 
-	ConnectionRetryPolicy retryPolicy = {
-		POSTGRES_PING_RETRY_TIMEOUT,
-		-1, /* unbounded number of attempts */
-		5 * 1000,               /* sleep up to 5s between attempts */
-		1 * 1000                /* first retry happens after 1 second */
-	};
+	ConnectionRetryPolicy retryPolicy = { 0 };
 
 	keeper.config = keeperOptions;
+
+	(void) pgsql_set_monitor_interactive_retry_policy(&retryPolicy);
 
 	(void) exit_unless_role_is_keeper(&(keeper.config));
 

--- a/src/bin/pg_autoctl/keeper.c
+++ b/src/bin/pg_autoctl/keeper.c
@@ -1250,7 +1250,7 @@ keeper_register_and_init(Keeper *keeper, NodeState initialState)
 	/*
 	 * We implement a specific retry policy for cases where we have a transient
 	 * error on the monitor, such as OBJECT_IN_USE which indicates that another
-	 * standby is concurfrently being added to the same group.
+	 * standby is concurrently being added to the same group.
 	 */
 	(void) pgsql_set_init_retry_policy(&(keeper->monitor.pgsql.retryPolicy));
 

--- a/src/bin/pg_autoctl/keeper.c
+++ b/src/bin/pg_autoctl/keeper.c
@@ -1223,12 +1223,9 @@ keeper_register_and_init(Keeper *keeper, NodeState initialState)
 	MonitorAssignedState assignedState = { 0 };
 	char expectedSlotName[BUFSIZE] = { 0 };
 
-	ConnectionRetryPolicy retryPolicy = {
-		POSTGRES_PING_RETRY_TIMEOUT,
-		-1,                     /* unbounded number of attempts */
-		5 * 1000,               /* sleep up to 5s between attempts */
-		1 * 1000                /* first retry happens after 1 second */
-	};
+	ConnectionRetryPolicy retryPolicy = { 0 };
+
+	(void) pgsql_set_monitor_interactive_retry_policy(&retryPolicy);
 
 	/*
 	 * First try to create our state file. The keeper_state_create_file function
@@ -1250,7 +1247,7 @@ keeper_register_and_init(Keeper *keeper, NodeState initialState)
 	}
 
 	/* use a special connection retry policy for initialisation */
-	(void) pgsql_set_init_retry_policy(&(keeper->monitor.pgsql));
+	(void) pgsql_set_init_retry_policy(&(keeper->monitor.pgsql.retryPolicy));
 
 	/*
 	 * When registering to the monitor, we get assigned a nodeId, that we keep

--- a/src/bin/pg_autoctl/monitor.c
+++ b/src/bin/pg_autoctl/monitor.c
@@ -731,17 +731,18 @@ monitor_register_node(Monitor *monitor, char *formation,
 		if (strcmp(parseContext.sqlstate, STR_ERRCODE_OBJECT_IN_USE) == 0 &&
 			!pgsql_retry_policy_expired(retryPolicy))
 		{
-			int sleep = pgsql_compute_connection_retry_sleep_time(retryPolicy);
+			int sleepTimeMs =
+				pgsql_compute_connection_retry_sleep_time(retryPolicy);
 
 			log_warn("Failed to register node %s:%d in group %d of "
 					 "formation \"%s\" with initial state \"%s\" "
 					 "because the monitor is already registering another "
 					 "standby, retrying in %d ms",
 					 host, port, desiredGroupId, formation, nodeStateString,
-					 sleep);
+					 sleepTimeMs);
 
 			/* we have milliseconds, pg_usleep() wants microseconds */
-			(void) pg_usleep(sleep * 1000);
+			(void) pg_usleep(sleepTimeMs * 1000);
 
 			return monitor_register_node(monitor, formation, name, host, port,
 										 system_identifier,
@@ -3035,14 +3036,15 @@ monitor_start_maintenance(Monitor *monitor, int nodeId,
 		if (monitor_retryable_error(context.sqlstate) &&
 			!pgsql_retry_policy_expired(retryPolicy))
 		{
-			int sleep = pgsql_compute_connection_retry_sleep_time(retryPolicy);
+			int sleepTimeMs =
+				pgsql_compute_connection_retry_sleep_time(retryPolicy);
 
 			log_warn("Failed to start_maintenance of node %d on the monitor, "
 					 "retrying in %d ms.",
-					 nodeId, sleep);
+					 nodeId, sleepTimeMs);
 
 			/* we have milliseconds, pg_usleep() wants microseconds */
-			(void) pg_usleep(sleep * 1000);
+			(void) pg_usleep(sleepTimeMs * 1000);
 
 			return monitor_start_maintenance(monitor, nodeId, retryPolicy);
 		}
@@ -3089,16 +3091,17 @@ monitor_stop_maintenance(Monitor *monitor, int nodeId,
 		if (monitor_retryable_error(context.sqlstate) &&
 			!pgsql_retry_policy_expired(retryPolicy))
 		{
-			int sleep = pgsql_compute_connection_retry_sleep_time(retryPolicy);
+			int sleepTimeMs =
+				pgsql_compute_connection_retry_sleep_time(retryPolicy);
 
 			log_warn("Failed to start_maintenance of node %d on the monitor, "
 					 "retrying in %d ms.",
-					 nodeId, sleep);
+					 nodeId, sleepTimeMs);
 
 			/* we have milliseconds, pg_usleep() wants microseconds */
-			(void) pg_usleep(sleep * 1000);
+			(void) pg_usleep(sleepTimeMs * 1000);
 
-			return monitor_start_maintenance(monitor, nodeId, retryPolicy);
+			return monitor_stop_maintenance(monitor, nodeId, retryPolicy);
 		}
 
 		log_error("Failed to stop_maintenance of node %d from the monitor",

--- a/src/bin/pg_autoctl/monitor.c
+++ b/src/bin/pg_autoctl/monitor.c
@@ -3094,7 +3094,7 @@ monitor_stop_maintenance(Monitor *monitor, int nodeId,
 			int sleepTimeMs =
 				pgsql_compute_connection_retry_sleep_time(retryPolicy);
 
-			log_warn("Failed to start_maintenance of node %d on the monitor, "
+			log_warn("Failed to stop_maintenance of node %d on the monitor, "
 					 "retrying in %d ms.",
 					 nodeId, sleepTimeMs);
 

--- a/src/bin/pg_autoctl/monitor.c
+++ b/src/bin/pg_autoctl/monitor.c
@@ -728,7 +728,8 @@ monitor_register_node(Monitor *monitor, char *formation,
 								   paramCount, paramTypes, paramValues,
 								   &parseContext, parseNodeState))
 	{
-		if (strcmp(parseContext.sqlstate, STR_ERRCODE_OBJECT_IN_USE) == 0)
+		if (monitor_retryable_error(parseContext.sqlstate) ||
+			strcmp(parseContext.sqlstate, STR_ERRCODE_OBJECT_IN_USE) == 0)
 		{
 			*mayRetry = true;
 			return false;

--- a/src/bin/pg_autoctl/monitor.c
+++ b/src/bin/pg_autoctl/monitor.c
@@ -728,7 +728,8 @@ monitor_register_node(Monitor *monitor, char *formation,
 								   paramCount, paramTypes, paramValues,
 								   &parseContext, parseNodeState))
 	{
-		if (strcmp(parseContext.sqlstate, STR_ERRCODE_OBJECT_IN_USE) == 0)
+		if (strcmp(parseContext.sqlstate, STR_ERRCODE_OBJECT_IN_USE) == 0 &&
+			!pgsql_retry_policy_expired(retryPolicy))
 		{
 			int sleep = pgsql_compute_connection_retry_sleep_time(retryPolicy);
 
@@ -750,7 +751,8 @@ monitor_register_node(Monitor *monitor, char *formation,
 										 assignedState);
 		}
 		else if (strcmp(parseContext.sqlstate,
-						STR_ERRCODE_EXCLUSION_VIOLATION) == 0)
+						STR_ERRCODE_EXCLUSION_VIOLATION) == 0 &&
+				 !pgsql_retry_policy_expired(retryPolicy))
 		{
 			/* *INDENT-OFF* */
 			log_error("Failed to register node %s:%d in "
@@ -3030,7 +3032,8 @@ monitor_start_maintenance(Monitor *monitor, int nodeId,
 								   paramCount, paramTypes, paramValues,
 								   &context, &parseSingleValueResult))
 	{
-		if (monitor_retryable_error(context.sqlstate))
+		if (monitor_retryable_error(context.sqlstate) &&
+			!pgsql_retry_policy_expired(retryPolicy))
 		{
 			int sleep = pgsql_compute_connection_retry_sleep_time(retryPolicy);
 
@@ -3083,7 +3086,8 @@ monitor_stop_maintenance(Monitor *monitor, int nodeId,
 								   paramCount, paramTypes, paramValues,
 								   &context, &parseSingleValueResult))
 	{
-		if (monitor_retryable_error(context.sqlstate))
+		if (monitor_retryable_error(context.sqlstate) &&
+			!pgsql_retry_policy_expired(retryPolicy))
 		{
 			int sleep = pgsql_compute_connection_retry_sleep_time(retryPolicy);
 

--- a/src/bin/pg_autoctl/monitor.h
+++ b/src/bin/pg_autoctl/monitor.h
@@ -54,6 +54,8 @@ bool monitor_init(Monitor *monitor, char *url);
 bool monitor_local_init(Monitor *monitor);
 void monitor_finish(Monitor *monitor);
 
+bool monitor_retryable_error(const char *sqlstate);
+
 void printNodeHeader(int maxHostNameSize);
 void printNodeEntry(NodeAddress *node);
 

--- a/src/bin/pg_autoctl/monitor.h
+++ b/src/bin/pg_autoctl/monitor.h
@@ -93,6 +93,7 @@ bool monitor_register_node(Monitor *monitor,
 						   PgInstanceKind kind,
 						   int candidatePriority,
 						   bool quorum,
+						   ConnectionRetryPolicy *retryPolicy,
 						   MonitorAssignedState *assignedState);
 bool monitor_node_active(Monitor *monitor,
 						 char *formation, int nodeId,

--- a/src/bin/pg_autoctl/monitor.h
+++ b/src/bin/pg_autoctl/monitor.h
@@ -169,8 +169,10 @@ bool monitor_set_node_system_identifier(Monitor *monitor,
 										int nodeId,
 										uint64_t system_identifier);
 
-bool monitor_start_maintenance(Monitor *monitor, int nodeId);
-bool monitor_stop_maintenance(Monitor *monitor, int nodeId);
+bool monitor_start_maintenance(Monitor *monitor, int nodeId,
+							   ConnectionRetryPolicy *retryPolicy);
+bool monitor_stop_maintenance(Monitor *monitor, int nodeId,
+							  ConnectionRetryPolicy *retryPolicy);
 
 bool monitor_get_notifications(Monitor *monitor, int timeoutMs);
 bool monitor_wait_until_primary_applied_settings(Monitor *monitor,

--- a/src/bin/pg_autoctl/monitor.h
+++ b/src/bin/pg_autoctl/monitor.h
@@ -93,7 +93,7 @@ bool monitor_register_node(Monitor *monitor,
 						   PgInstanceKind kind,
 						   int candidatePriority,
 						   bool quorum,
-						   ConnectionRetryPolicy *retryPolicy,
+						   bool *mayRetry,
 						   MonitorAssignedState *assignedState);
 bool monitor_node_active(Monitor *monitor,
 						 char *formation, int nodeId,
@@ -170,10 +170,8 @@ bool monitor_set_node_system_identifier(Monitor *monitor,
 										int nodeId,
 										uint64_t system_identifier);
 
-bool monitor_start_maintenance(Monitor *monitor, int nodeId,
-							   ConnectionRetryPolicy *retryPolicy);
-bool monitor_stop_maintenance(Monitor *monitor, int nodeId,
-							  ConnectionRetryPolicy *retryPolicy);
+bool monitor_start_maintenance(Monitor *monitor, int nodeId, bool *mayRetry);
+bool monitor_stop_maintenance(Monitor *monitor, int nodeId, bool *mayRetry);
 
 bool monitor_get_notifications(Monitor *monitor, int timeoutMs);
 bool monitor_wait_until_primary_applied_settings(Monitor *monitor,

--- a/src/bin/pg_autoctl/pgsetup.c
+++ b/src/bin/pg_autoctl/pgsetup.c
@@ -442,9 +442,11 @@ get_pgpid(PostgresSetup *pgSetup, bool pgIsNotRunningIsOk)
 
 	if (!file_exists(pidfile))
 	{
-		log_level(logLevel,
-				  "Failed get postmaster pid, file \"%s\" does not exists",
-				  pidfile);
+		if (!pgIsNotRunningIsOk)
+		{
+			log_error("Failed get postmaster pid, file \"%s\" does not exists",
+					  pidfile);
+		}
 		return false;
 	}
 

--- a/src/bin/pg_autoctl/pgsql.c
+++ b/src/bin/pg_autoctl/pgsql.c
@@ -324,6 +324,12 @@ pgsql_retry_policy_expired(ConnectionRetryPolicy *retryPolicy)
 		return true;
 	}
 
+	/* set the first retry time when it's not been set previously */
+	if (retryPolicy->startTime == 0)
+	{
+		retryPolicy->startTime = now;
+	}
+
 	/*
 	 * We stop retrying as soon as we have spent all of our time budget or all
 	 * of our attempts count budget, whichever comes first.

--- a/src/bin/pg_autoctl/pgsql.h
+++ b/src/bin/pg_autoctl/pgsql.h
@@ -86,6 +86,8 @@ typedef struct ConnectionRetryPolicy
 	int maxSleepTime;           /* in millisecond, used to cap sleepTime */
 	int baseSleepTime;          /* in millisecond, base time to sleep for */
 	int sleepTime;              /* in millisecond, time waited for last round */
+
+	uint64_t startTime;         /* time of the first attempt */
 	int attempts;               /* how many attempts have been made so far */
 } ConnectionRetryPolicy;
 
@@ -238,6 +240,7 @@ typedef struct SingleValueResultContext
 	") as t(ok) "
 
 bool pgsql_init(PGSQL *pgsql, char *url, ConnectionType connectionType);
+
 void pgsql_set_retry_policy(PGSQL *pgsql,
 							int maxT,
 							int maxR,
@@ -247,6 +250,8 @@ void pgsql_set_main_loop_retry_policy(PGSQL *pgsql);
 void pgsql_set_init_retry_policy(PGSQL *pgsql);
 void pgsql_set_interactive_retry_policy(PGSQL *pgsql);
 int pgsql_compute_connection_retry_sleep_time(ConnectionRetryPolicy *retryPolicy);
+bool pgsql_retry_policy_expired(ConnectionRetryPolicy *retryPolicy);
+
 void pgsql_finish(PGSQL *pgsql);
 void parseSingleValueResult(void *ctx, PGresult *result);
 void fetchedRows(void *ctx, PGresult *result);

--- a/src/bin/pg_autoctl/pgsql.h
+++ b/src/bin/pg_autoctl/pgsql.h
@@ -246,6 +246,7 @@ void pgsql_set_retry_policy(PGSQL *pgsql,
 void pgsql_set_main_loop_retry_policy(PGSQL *pgsql);
 void pgsql_set_init_retry_policy(PGSQL *pgsql);
 void pgsql_set_interactive_retry_policy(PGSQL *pgsql);
+int pgsql_compute_connection_retry_sleep_time(ConnectionRetryPolicy *retryPolicy);
 void pgsql_finish(PGSQL *pgsql);
 void parseSingleValueResult(void *ctx, PGresult *result);
 void fetchedRows(void *ctx, PGresult *result);

--- a/src/bin/pg_autoctl/pgsql.h
+++ b/src/bin/pg_autoctl/pgsql.h
@@ -241,14 +241,15 @@ typedef struct SingleValueResultContext
 
 bool pgsql_init(PGSQL *pgsql, char *url, ConnectionType connectionType);
 
-void pgsql_set_retry_policy(PGSQL *pgsql,
+void pgsql_set_retry_policy(ConnectionRetryPolicy *retryPolicy,
 							int maxT,
 							int maxR,
 							int maxSleepTime,
 							int baseSleepTime);
-void pgsql_set_main_loop_retry_policy(PGSQL *pgsql);
-void pgsql_set_init_retry_policy(PGSQL *pgsql);
-void pgsql_set_interactive_retry_policy(PGSQL *pgsql);
+void pgsql_set_main_loop_retry_policy(ConnectionRetryPolicy *retryPolicy);
+void pgsql_set_init_retry_policy(ConnectionRetryPolicy *retryPolicy);
+void pgsql_set_interactive_retry_policy(ConnectionRetryPolicy *retryPolicy);
+void pgsql_set_monitor_interactive_retry_policy(ConnectionRetryPolicy *retryPolicy);
 int pgsql_compute_connection_retry_sleep_time(ConnectionRetryPolicy *retryPolicy);
 bool pgsql_retry_policy_expired(ConnectionRetryPolicy *retryPolicy);
 

--- a/src/bin/pg_autoctl/service_keeper.c
+++ b/src/bin/pg_autoctl/service_keeper.c
@@ -607,7 +607,7 @@ keeper_node_active(Keeper *keeper)
 
 
 	/* ensure we use the correct retry policy with the monitor */
-	(void) pgsql_set_main_loop_retry_policy(&(monitor->pgsql));
+	(void) pgsql_set_main_loop_retry_policy(&(monitor->pgsql.retryPolicy));
 
 	/*
 	 * Report the current state to the monitor and get the assigned state.


### PR DESCRIPTION
After seeing the following happen in Travis, we could process some error
conditions as transient and retry. It would be best for test stability, and
also for users who script around some pg_autoctl commands.

    ERROR Monitor ERROR:  deadlock detected
    ERROR Monitor DETAIL:  Process 21381 waits for ShareLock on transaction 532; blocked by process 21382.
    ERROR Monitor Process 21382 waits for ExclusiveLock on advisory lock [16385,822708183,0,11]; blocked by process 21381.
    ERROR Monitor HINT:  See server log for query details.
    ERROR Monitor CONTEXT:  while updating tuple (0,11) in relation "node"
    ERROR Monitor SQL statement "UPDATE pgautofailover.node SET goalstate = $1, statechangetime = now() WHERE nodeid = $2"
    ERROR SQL query: SELECT pgautofailover.stop_maintenance($1)
    ERROR SQL params: '2'
    ERROR Failed to stop_maintenance of node 2 from the monitor
    FATAL Failed to stop maintenance from the monitor, see above for details