### PR TITLE
Fix/fatal auth pgautofailover monitor

### DIFF
--- a/src/bin/pg_autoctl/cli_do_misc.c
+++ b/src/bin/pg_autoctl/cli_do_misc.c
@@ -159,12 +159,7 @@ keeper_cli_create_monitor_user(int argc, char **argv)
 	int urlLength = 0;
 	char monitorHostname[_POSIX_HOST_NAME_MAX];
 	int monitorPort = 0;
-
-	/*
-	 * Monitor does not use a password, we expect it to login and immediately
-	 * disconnect.
-	 */
-	char *password = NULL;
+	int connlimit = 1;
 
 	keeper_config_init(&config, missingPgdataOk, postgresNotRunningOk);
 	local_postgres_init(&postgres, &(config.pgSetup));
@@ -187,9 +182,11 @@ keeper_cli_create_monitor_user(int argc, char **argv)
 	}
 
 	if (!primary_create_user_with_hba(&postgres,
-									  PG_AUTOCTL_HEALTH_USERNAME, password,
+									  PG_AUTOCTL_HEALTH_USERNAME,
+									  PG_AUTOCTL_HEALTH_PASSWORD,
 									  monitorHostname,
-									  pg_setup_get_auth_method(&(config.pgSetup))))
+									  "trust",
+									  connlimit))
 	{
 		log_fatal("Failed to create the database user that the pg_auto_failover "
 				  " monitor uses for health checks, see above for details");

--- a/src/bin/pg_autoctl/cli_do_root.c
+++ b/src/bin/pg_autoctl/cli_do_root.c
@@ -30,6 +30,14 @@
 #include "primary_standby.h"
 
 
+CommandLine do_primary_adduser_monitor =
+	make_command("monitor",
+				 "add a local user for queries from the monitor",
+				 "",
+				 KEEPER_CLI_WORKER_SETUP_OPTIONS,
+				 keeper_cli_keeper_setup_getopts,
+				 keeper_cli_create_monitor_user);
+
 CommandLine do_primary_adduser_replica =
 	make_command("replica",
 				 "add a local user with replication privileges",
@@ -39,6 +47,7 @@ CommandLine do_primary_adduser_replica =
 				 keeper_cli_create_replication_user);
 
 CommandLine *do_primary_adduser_subcommands[] = {
+	&do_primary_adduser_monitor,
 	&do_primary_adduser_replica,
 	NULL
 };

--- a/src/bin/pg_autoctl/cli_do_root.h
+++ b/src/bin/pg_autoctl/cli_do_root.h
@@ -29,6 +29,7 @@ extern CommandLine do_show_commands;
 /* src/bin/pg_autoctl/cli_do_root.c */
 extern CommandLine do_primary_adduser;
 extern CommandLine *do_primary_adduser_subcommands[];
+extern CommandLine do_primary_adduser_monitor;
 extern CommandLine do_primary_adduser_replica;
 
 extern CommandLine do_primary_syncrep_;
@@ -77,6 +78,7 @@ void keeper_cli_pgsetup_startup_logs(int argc, char **argv);
 void keeper_cli_pgsetup_tune(int argc, char **argv);
 
 void keeper_cli_add_default_settings(int argc, char **argv);
+void keeper_cli_create_monitor_user(int argc, char **argv);
 void keeper_cli_create_replication_user(int argc, char **argv);
 void keeper_cli_add_standby_to_hba(int argc, char **argv);
 void keeper_cli_init_standby(int argc, char **argv);

--- a/src/bin/pg_autoctl/defaults.h
+++ b/src/bin/pg_autoctl/defaults.h
@@ -112,6 +112,7 @@
 
 /* pg_auto_failover monitor related constants */
 #define PG_AUTOCTL_HEALTH_USERNAME "pgautofailover_monitor"
+#define PG_AUTOCTL_HEALTH_PASSWORD "pgautofailover_monitor"
 #define PG_AUTOCTL_REPLICA_USERNAME "pgautofailover_replicator"
 
 #define PG_AUTOCTL_MONITOR_DBNAME "pg_auto_failover"

--- a/src/bin/pg_autoctl/fsm_transition.c
+++ b/src/bin/pg_autoctl/fsm_transition.c
@@ -241,6 +241,8 @@ fsm_init_primary(Keeper *keeper)
 	{
 		char monitorHostname[_POSIX_HOST_NAME_MAX];
 		int monitorPort = 0;
+		char *password = NULL;
+		char *authMethod = NULL;
 
 		if (!hostname_from_uri(config->monitor_pguri,
 							   monitorHostname, _POSIX_HOST_NAME_MAX,
@@ -249,6 +251,23 @@ fsm_init_primary(Keeper *keeper)
 			/* developer error, this should never happen */
 			log_fatal("BUG: monitor_pguri should be validated before calling "
 					  "fsm_init_primary");
+			return false;
+		}
+
+		authMethod = pg_setup_get_auth_method(&(config->pgSetup));
+
+		/*
+		 * We need to add the monitor host:port in the HBA settings for the
+		 * node to enable the health checks.
+		 */
+		if (!primary_create_user_with_hba(postgres,
+										  PG_AUTOCTL_HEALTH_USERNAME, password,
+										  monitorHostname, authMethod))
+		{
+			log_error(
+				"Failed to initialise postgres as primary because "
+				"creating the database user that the pg_auto_failover monitor "
+				"uses for health checks failed, see above for details");
 			return false;
 		}
 	}

--- a/src/bin/pg_autoctl/keeper_pg_init.c
+++ b/src/bin/pg_autoctl/keeper_pg_init.c
@@ -738,8 +738,8 @@ create_database_and_extension(Keeper *keeper)
 	{
 		if (!pgsql_create_user(&initPostgres.sqlClient, pgSetup->username,
 
-		                       /* password, login, superuser, replication */
-							   NULL, true, true, false))
+		                       /* password, login, superuser, replication, connlimit */
+							   NULL, true, true, false, -1))
 		{
 			log_fatal("Failed to create role \"%s\""
 					  ", see above for details", pgSetup->username);

--- a/src/bin/pg_autoctl/monitor_pg_init.c
+++ b/src/bin/pg_autoctl/monitor_pg_init.c
@@ -163,8 +163,8 @@ monitor_install(const char *hostname,
 
 	if (!pgsql_create_user(&postgres.sqlClient, PG_AUTOCTL_MONITOR_DBOWNER,
 
-	                       /* password, login, superuser, replication */
-						   NULL, true, false, false))
+	                       /* password, login, superuser, replication, connlimit */
+						   NULL, true, false, false, -1))
 	{
 		log_error("Failed to create user \"%s\" on local postgres server",
 				  PG_AUTOCTL_MONITOR_DBOWNER);

--- a/src/bin/pg_autoctl/pgsql.c
+++ b/src/bin/pg_autoctl/pgsql.c
@@ -1762,7 +1762,7 @@ pgsql_create_extension(PGSQL *pgsql, const char *name)
  */
 bool
 pgsql_create_user(PGSQL *pgsql, const char *userName, const char *password,
-				  bool login, bool superuser, bool replication)
+				  bool login, bool superuser, bool replication, int connlimit)
 {
 	PGconn *connection = NULL;
 	PGresult *result = NULL;
@@ -1807,6 +1807,10 @@ pgsql_create_user(PGSQL *pgsql, const char *userName, const char *password,
 	if (replication)
 	{
 		appendPQExpBufferStr(query, " REPLICATION");
+	}
+	if (connlimit > -1)
+	{
+		appendPQExpBuffer(query, " CONNECTION LIMIT %d", connlimit);
 	}
 	if (password)
 	{

--- a/src/bin/pg_autoctl/pgsql.h
+++ b/src/bin/pg_autoctl/pgsql.h
@@ -269,7 +269,8 @@ bool pgsql_get_hba_file_path(PGSQL *pgsql, char *hbaFilePath, int maxPathLength)
 bool pgsql_create_database(PGSQL *pgsql, const char *dbname, const char *owner);
 bool pgsql_create_extension(PGSQL *pgsql, const char *name);
 bool pgsql_create_user(PGSQL *pgsql, const char *userName, const char *password,
-					   bool login, bool superuser, bool replication);
+					   bool login, bool superuser, bool replication,
+					   int connlimit);
 bool pgsql_has_replica(PGSQL *pgsql, char *userName, bool *hasReplica);
 bool hostname_from_uri(const char *pguri,
 					   char *hostname, int maxHostLength, int *port);

--- a/src/bin/pg_autoctl/primary_standby.c
+++ b/src/bin/pg_autoctl/primary_standby.c
@@ -528,7 +528,8 @@ postgres_add_default_settings(LocalPostgresServer *postgres)
  */
 bool
 primary_create_user_with_hba(LocalPostgresServer *postgres, char *userName,
-							 char *password, char *hostname, char *authMethod)
+							 char *password, char *hostname, char *authMethod,
+							 int connlimit)
 {
 	PGSQL *pgsql = &(postgres->sqlClient);
 	bool login = true;
@@ -539,7 +540,7 @@ primary_create_user_with_hba(LocalPostgresServer *postgres, char *userName,
 	log_trace("primary_create_user_with_hba");
 
 	if (!pgsql_create_user(pgsql, userName, password,
-						   login, superuser, replication))
+						   login, superuser, replication, connlimit))
 	{
 		log_error("Failed to create user \"%s\" on local postgres server",
 				  userName);
@@ -591,11 +592,12 @@ primary_create_replication_user(LocalPostgresServer *postgres,
 	bool login = true;
 	bool superuser = true;
 	bool replication = true;
+	int connlimit = -1;
 
 	log_trace("primary_create_replication_user");
 
 	result = pgsql_create_user(pgsql, replicationUsername, replicationPassword,
-							   login, superuser, replication);
+							   login, superuser, replication, connlimit);
 
 	pgsql_finish(pgsql);
 

--- a/src/bin/pg_autoctl/primary_standby.h
+++ b/src/bin/pg_autoctl/primary_standby.h
@@ -76,7 +76,8 @@ bool primary_enable_synchronous_replication(LocalPostgresServer *postgres);
 bool primary_disable_synchronous_replication(LocalPostgresServer *postgres);
 bool postgres_add_default_settings(LocalPostgresServer *postgres);
 bool primary_create_user_with_hba(LocalPostgresServer *postgres, char *userName,
-								  char *password, char *hostname, char *authMethod);
+								  char *password, char *hostname,
+								  char *authMethod, int connlimit);
 bool primary_create_replication_user(LocalPostgresServer *postgres,
 									 char *replicationUser,
 									 char *replicationPassword);

--- a/src/bin/pg_autoctl/primary_standby.h
+++ b/src/bin/pg_autoctl/primary_standby.h
@@ -75,6 +75,8 @@ bool postgres_replication_slot_maintain(LocalPostgresServer *postgres,
 bool primary_enable_synchronous_replication(LocalPostgresServer *postgres);
 bool primary_disable_synchronous_replication(LocalPostgresServer *postgres);
 bool postgres_add_default_settings(LocalPostgresServer *postgres);
+bool primary_create_user_with_hba(LocalPostgresServer *postgres, char *userName,
+								  char *password, char *hostname, char *authMethod);
 bool primary_create_replication_user(LocalPostgresServer *postgres,
 									 char *replicationUser,
 									 char *replicationPassword);

--- a/src/monitor/health_check_worker.c
+++ b/src/monitor/health_check_worker.c
@@ -47,7 +47,7 @@
 
 #define CONN_INFO_TEMPLATE \
 	"host=%s port=%u user=pgautofailover_monitor " \
-	"password=user=pgautofailover_monitor dbname=postgres " \
+	"password=pgautofailover_monitor dbname=postgres " \
 	"connect_timeout=%u"
 #define MAX_CONN_INFO_SIZE 1024
 

--- a/src/monitor/health_check_worker.c
+++ b/src/monitor/health_check_worker.c
@@ -46,7 +46,8 @@
 #include "tcop/utility.h"
 
 #define CONN_INFO_TEMPLATE \
-	"host=%s port=%u user=pgautofailover_monitor dbname=postgres " \
+	"host=%s port=%u user=pgautofailover_monitor " \
+	"password=user=pgautofailover_monitor dbname=postgres " \
 	"connect_timeout=%u"
 #define MAX_CONN_INFO_SIZE 1024
 

--- a/src/monitor/health_check_worker.c
+++ b/src/monitor/health_check_worker.c
@@ -45,16 +45,8 @@
 #include "utils/memutils.h"
 #include "tcop/utility.h"
 
-/*
- * The healthcheck only checks if it gets a response back from postgres. So
- * both user and password are actually useless, because we do not need to
- * authenticate. They are provided though to override any settings set through
- * PGPASSWORD environment variable or .pgpass file. This way it does not matter
- * that TLS is not necessarily used, because no secret information is sent.
- */
 #define CONN_INFO_TEMPLATE \
 	"host=%s port=%u user=pgautofailover_monitor dbname=postgres " \
-	"password=pgautofailover_monitor" \
 	"connect_timeout=%u"
 #define MAX_CONN_INFO_SIZE 1024
 

--- a/src/monitor/health_check_worker.c
+++ b/src/monitor/health_check_worker.c
@@ -45,6 +45,13 @@
 #include "utils/memutils.h"
 #include "tcop/utility.h"
 
+/*
+ * The healthcheck only checks if it gets a response back from postgres. So
+ * both user and password are actually useless, because we do not need to
+ * authenticate. They are provided though to override any settings set through
+ * PGPASSWORD environment variable or .pgpass file. This way it does not matter
+ * that TLS is not necessarily used, because no secret information is sent.
+ */
 #define CONN_INFO_TEMPLATE \
 	"host=%s port=%u user=pgautofailover_monitor " \
 	"password=pgautofailover_monitor dbname=postgres " \

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -28,6 +28,7 @@ def test_001_init_primary():
     node1.run()
 
     node1.wait_until_pg_is_running()
+    node1.set_user_password("pgautofailover_monitor", "monitor_password")
     node1.set_user_password("pgautofailover_replicator", "streaming_password")
 
     assert node1.wait_until_state(target_state="single")

--- a/tests/test_create_run.py
+++ b/tests/test_create_run.py
@@ -72,6 +72,7 @@ def test_010_drop_secondary():
     node1.run()
     assert node1.wait_until_state(target_state="secondary")
     node1.drop()
+    sleep(2)                    # avoid timing issue
     assert not node1.pg_is_running()
     assert node2.wait_until_pg_is_running()
     assert node2.wait_until_state(target_state="single")

--- a/tests/test_create_run.py
+++ b/tests/test_create_run.py
@@ -72,7 +72,7 @@ def test_010_drop_secondary():
     node1.run()
     assert node1.wait_until_state(target_state="secondary")
     node1.drop()
-    sleep(2)                    # avoid timing issue
+    time.sleep(2)                    # avoid timing issue
     assert not node1.pg_is_running()
     assert node2.wait_until_pg_is_running()
     assert node2.wait_until_state(target_state="single")


### PR DESCRIPTION
Create the pgautofailover_monitor user on the Postgres nodes to avoid FATAL errors in the logs.

As we want to avoid using a password that we could leak when not using SSL connections, we hardcode the password (to the same string as the username). We don't actually authenticate at all, let alone use the password send, so we also hard code the authentication method for the health checks to trust.

Fixes https://github.com/citusdata/pg_auto_failover/issues/277