### PR TITLE
pg_autoctl get|set formation number-sync-standbys from the monitor.

### DIFF
--- a/src/bin/pg_autoctl/cli_common.c
+++ b/src/bin/pg_autoctl/cli_common.c
@@ -1010,6 +1010,13 @@ monitor_init_from_pgsetup(Monitor *monitor, PostgresSetup *pgSetup)
 				return false;
 			}
 
+			if (config.monitorDisabled)
+			{
+				log_error("This node has disabled monitor, "
+						  "pg_autoctl get and set commands are not available.");
+				return false;
+			}
+
 			if (!monitor_init(&(keeper.monitor), config.monitor_pguri))
 			{
 				return false;

--- a/src/bin/pg_autoctl/cli_get_set_properties.c
+++ b/src/bin/pg_autoctl/cli_get_set_properties.c
@@ -215,6 +215,16 @@ cli_get_set_properties_getopts(int argc, char **argv)
 
 	optind = 0;
 
+	/*
+	 * The only command lines that are using keeper_cli_getopt_pgdata are
+	 * terminal ones: they don't accept subcommands. In that case our option
+	 * parsing can happen in any order and we don't need getopt_long to behave
+	 * in a POSIXLY_CORRECT way.
+	 *
+	 * The unsetenv() call allows getopt_long() to reorder arguments for us.
+	 */
+	unsetenv("POSIXLY_CORRECT");
+
 	while ((c = getopt_long(argc, argv, "D:f:g:n:Vvqh",
 							long_options, &option_index)) != -1)
 	{

--- a/src/bin/pg_autoctl/cli_get_set_properties.c
+++ b/src/bin/pg_autoctl/cli_get_set_properties.c
@@ -35,8 +35,9 @@ static bool set_formation_number_sync_standbys(Monitor *monitor,
 CommandLine get_node_replication_quorum =
 	make_command("replication-quorum",
 				 "get replication-quorum property from the monitor",
-				 " [ --pgdata ] [ --json ] [ --name ]",
+				 " [ --pgdata ] [ --json ] [ --formation ] [ --name ]",
 				 "  --pgdata      path to data directory\n"
+				 "  --formation   pg_auto_failover formation\n"
 				 "  --name        pg_auto_failover node name\n"
 				 "  --json        output data in the JSON format\n",
 				 cli_get_set_properties_getopts,
@@ -45,8 +46,9 @@ CommandLine get_node_replication_quorum =
 CommandLine get_node_candidate_priority =
 	make_command("candidate-priority",
 				 "get candidate property from the monitor",
-				 " [ --pgdata ] [ --json ] [ --name ]",
+				 " [ --pgdata ] [ --json ] [ --formation ] [ --name ]",
 				 "  --pgdata      path to data directory\n"
+				 "  --formation   pg_auto_failover formation\n"
 				 "  --name        pg_auto_failover node name\n"
 				 "  --json        output data in the JSON format\n",
 				 cli_get_set_properties_getopts,
@@ -68,9 +70,8 @@ static CommandLine get_node_command =
 static CommandLine get_formation_number_sync_standbys =
 	make_command("number-sync-standbys",
 				 "get number_sync_standbys for a formation from the monitor",
-				 " [ --pgdata ] [ --json ] [ --formation ] [ --name ]",
+				 " [ --pgdata ] [ --json ] [ --formation ] ",
 				 "  --pgdata      path to data directory\n"
-				 "  --name        pg_auto_failover node name\n"
 				 "  --json        output data in the JSON format\n"
 				 "  --formation   pg_auto_failover formation\n",
 				 cli_get_set_properties_getopts,
@@ -102,8 +103,10 @@ CommandLine get_commands =
 static CommandLine set_node_replication_quorum_command =
 	make_command("replication-quorum",
 				 "set replication-quorum property on the monitor",
-				 " [ --pgdata ] [ --json ] [ --name ] <true|false>",
+				 " [ --pgdata ] [ --json ] [ --formation ] [ --name ] "
+				 "<true|false>",
 				 "  --pgdata      path to data directory\n"
+				 "  --formation   pg_auto_failover formation\n"
 				 "  --name        pg_auto_failover node name\n"
 				 "  --json        output data in the JSON format\n",
 				 cli_get_set_properties_getopts,
@@ -112,8 +115,10 @@ static CommandLine set_node_replication_quorum_command =
 static CommandLine set_node_candidate_priority_command =
 	make_command("candidate-priority",
 				 "set candidate property on the monitor",
-				 " [ --pgdata ] [ --json ] [ --name ] <priority: 0..100>",
+				 " [ --pgdata ] [ --json ] [ --formation ] [ --name ] "
+				 "<priority: 0..100>",
 				 "  --pgdata      path to data directory\n"
+				 "  --formation   pg_auto_failover formation\n"
 				 "  --name        pg_auto_failover node name\n"
 				 "  --json        output data in the JSON format\n",
 				 cli_get_set_properties_getopts,
@@ -147,12 +152,11 @@ CommandLine set_node_command =
 static CommandLine set_formation_number_sync_standby_command =
 	make_command("number-sync-standbys",
 				 "set number-sync-standbys for a formation on the monitor",
-				 " [ --pgdata ] [ --json ] [ --formation ] [ --name ] "
+				 " [ --pgdata ] [ --json ] [ --formation ] "
 				 "<number_sync_standbys>",
 				 "  --pgdata      path to data directory\n"
-				 "  --name        pg_auto_failover node name\n"
-				 "  --json        output data in the JSON format\n"
-				 "  --formation   pg_auto_failover formation\n",
+				 "  --formation   pg_auto_failover formation\n"
+				 "  --json        output data in the JSON format\n",
 				 cli_get_set_properties_getopts,
 				 cli_set_formation_number_sync_standbys);
 

--- a/src/bin/pg_autoctl/monitor.c
+++ b/src/bin/pg_autoctl/monitor.c
@@ -780,30 +780,29 @@ monitor_node_active(Monitor *monitor,
  */
 bool
 monitor_set_node_candidate_priority(Monitor *monitor,
-									int nodeid, char *hostName, int nodePort,
+									char *formation, char *name,
 									int candidate_priority)
 {
 	PGSQL *pgsql = &monitor->pgsql;
 	const char *sql =
-		"SELECT pgautofailover.set_node_candidate_priority($1, $2, $3, $4)";
-	int paramCount = 4;
-	Oid paramTypes[4] = { INT4OID, TEXTOID, INT4OID, INT4OID };
-	const char *paramValues[4];
+		"SELECT pgautofailover.set_node_candidate_priority($1, $2, $3)";
+	int paramCount = 3;
+	Oid paramTypes[3] = { TEXTOID, TEXTOID, INT4OID };
+	const char *paramValues[3];
 	char *candidatePriorityText = intToString(candidate_priority).strValue;
 	bool success = true;
 
-	paramValues[0] = intToString(nodeid).strValue;
-	paramValues[1] = hostName,
-	paramValues[2] = intToString(nodePort).strValue;
-	paramValues[3] = candidatePriorityText;
+	paramValues[0] = formation;
+	paramValues[1] = name,
+	paramValues[2] = candidatePriorityText;
 
 	if (!pgsql_execute_with_params(pgsql, sql,
 								   paramCount, paramTypes, paramValues,
 								   NULL, NULL))
 	{
-		log_error("Failed to update node candidate priority on node %d"
-				  " for candidate_priority: \"%s\"",
-				  nodeid, candidatePriorityText);
+		log_error("Failed to update node candidate priority on node \"%s\""
+				  "in formation \"%s\" for candidate_priority: \"%s\"",
+				  name, formation, candidatePriorityText);
 
 		success = false;
 	}
@@ -817,30 +816,29 @@ monitor_set_node_candidate_priority(Monitor *monitor,
  * in the node replication quorum.
  */
 bool
-monitor_set_node_replication_quorum(Monitor *monitor, int nodeid,
-									char *hostName, int nodePort,
+monitor_set_node_replication_quorum(Monitor *monitor,
+									char *formation, char *name,
 									bool replicationQuorum)
 {
 	PGSQL *pgsql = &monitor->pgsql;
 	const char *sql =
-		"SELECT pgautofailover.set_node_replication_quorum($1, $2, $3, $4)";
-	int paramCount = 4;
-	Oid paramTypes[4] = { INT4OID, TEXTOID, INT4OID, BOOLOID };
-	const char *paramValues[4];
+		"SELECT pgautofailover.set_node_replication_quorum($1, $2, $3)";
+	int paramCount = 3;
+	Oid paramTypes[3] = { TEXTOID, TEXTOID, BOOLOID };
+	const char *paramValues[3];
 	char *replicationQuorumText = replicationQuorum ? "true" : "false";
 	bool success = true;
 
-	paramValues[0] = intToString(nodeid).strValue;
-	paramValues[1] = hostName;
-	paramValues[2] = intToString(nodePort).strValue;
-	paramValues[3] = replicationQuorumText;
+	paramValues[0] = formation;
+	paramValues[1] = name,
+	paramValues[2] = replicationQuorumText;
 
 	if (!pgsql_execute_with_params(pgsql, sql, paramCount, paramTypes,
 								   paramValues, NULL, NULL))
 	{
-		log_error("Failed to update node replication quorum on node %d"
-				  " and replication_quorum: \"%s\"",
-				  nodeid, replicationQuorumText);
+		log_error("Failed to update node replication quorum on node \"%s\""
+				  "in formation \"%s\" for replication_quorum: \"%s\"",
+				  name, formation, replicationQuorumText);
 
 		success = false;
 	}

--- a/src/bin/pg_autoctl/monitor.h
+++ b/src/bin/pg_autoctl/monitor.h
@@ -98,7 +98,7 @@ bool monitor_node_active(Monitor *monitor,
 						 bool pgIsRunning,
 						 char *currentLSN, char *pgsrSyncState,
 						 MonitorAssignedState *assignedState);
-bool monitor_get_node_replication_settings(Monitor *monitor, int nodeid,
+bool monitor_get_node_replication_settings(Monitor *monitor,
 										   NodeReplicationSettings *settings);
 bool monitor_set_node_candidate_priority(Monitor *monitor, int nodeid,
 										 char *hostName, int nodePort,

--- a/src/bin/pg_autoctl/monitor.h
+++ b/src/bin/pg_autoctl/monitor.h
@@ -100,11 +100,11 @@ bool monitor_node_active(Monitor *monitor,
 						 MonitorAssignedState *assignedState);
 bool monitor_get_node_replication_settings(Monitor *monitor,
 										   NodeReplicationSettings *settings);
-bool monitor_set_node_candidate_priority(Monitor *monitor, int nodeid,
-										 char *hostName, int nodePort,
+bool monitor_set_node_candidate_priority(Monitor *monitor,
+										 char *formation, char *name,
 										 int candidatePriority);
-bool monitor_set_node_replication_quorum(Monitor *monitor, int nodeid,
-										 char *hostName, int nodePort,
+bool monitor_set_node_replication_quorum(Monitor *monitor,
+										 char *formation, char *name,
 										 bool replicationQuorum);
 bool monitor_get_formation_number_sync_standbys(Monitor *monitor, char *formation,
 												int *numberSyncStandbys);

--- a/src/bin/pg_autoctl/pgsetup.c
+++ b/src/bin/pg_autoctl/pgsetup.c
@@ -436,7 +436,7 @@ get_pgpid(PostgresSetup *pgSetup, bool pgIsNotRunningIsOk)
 	int pid = -1;
 
 	/* when !pgIsNotRunningIsOk then log_error(), otherwise log_debug() */
-	int logLevel = pgIsNotRunningIsOk ? LOG_DEBUG : LOG_ERROR;
+	int logLevel = pgIsNotRunningIsOk ? LOG_TRACE : LOG_ERROR;
 
 	join_path_components(pidfile, pgSetup->pgdata, "postmaster.pid");
 

--- a/src/bin/pg_autoctl/pgsetup.h
+++ b/src/bin/pg_autoctl/pgsetup.h
@@ -112,6 +112,7 @@ typedef enum PgInstanceKind
  */
 typedef struct NodeReplicationSettings
 {
+	char name[_POSIX_HOST_NAME_MAX];
 	int candidatePriority;      /* promotion candidate priority */
 	bool replicationQuorum;     /* true if participates in write quorum */
 } NodeReplicationSettings;

--- a/src/monitor/node_active_protocol.c
+++ b/src/monitor/node_active_protocol.c
@@ -112,8 +112,8 @@ register_node(PG_FUNCTION_ARGS)
 	TypeFuncClass resultTypeClass = 0;
 	Datum resultDatum = 0;
 	HeapTuple resultTuple = NULL;
-	Datum values[5];
-	bool isNulls[5];
+	Datum values[6];
+	bool isNulls[6];
 
 	checkPgAutoFailoverVersion();
 
@@ -298,6 +298,7 @@ register_node(PG_FUNCTION_ARGS)
 		ReplicationStateGetEnum(pgAutoFailoverNode->goalState));
 	values[3] = Int32GetDatum(assignedNodeState->candidatePriority);
 	values[4] = BoolGetDatum(assignedNodeState->replicationQuorum);
+	values[5] = CStringGetTextDatum(pgAutoFailoverNode->nodeName);
 
 	resultTypeClass = get_call_result_type(fcinfo, NULL, &resultDescriptor);
 	if (resultTypeClass != TYPEFUNC_COMPOSITE)

--- a/src/monitor/node_metadata.c
+++ b/src/monitor/node_metadata.c
@@ -913,28 +913,26 @@ GetAutoFailoverNodeById(int nodeId)
  * identified by node id, node name and node port.
  */
 AutoFailoverNode *
-GetAutoFailoverNodeWithId(int nodeid, char *nodeHost, int nodePort)
+GetAutoFailoverNodeByName(char *formationId, char *nodeName)
 {
 	AutoFailoverNode *pgAutoFailoverNode = NULL;
 	MemoryContext callerContext = CurrentMemoryContext;
 
 	Oid argTypes[] = {
-		INT4OID, /* nodeport */
-		TEXTOID, /* nodehost */
-		INT4OID  /* nodeport */
+		TEXTOID,                    /* formationId */
+		TEXTOID                     /* nodename */
 	};
 
 	Datum argValues[] = {
-		Int32GetDatum(nodeid),         /* nodeid */
-		CStringGetTextDatum(nodeHost), /* nodehost */
-		Int32GetDatum(nodePort)        /* nodeport */
+		CStringGetTextDatum(formationId), /* formationId */
+		CStringGetTextDatum(nodeName)     /* nodename */
 	};
 	const int argCount = sizeof(argValues) / sizeof(argValues[0]);
 	int spiStatus = 0;
 
 	const char *selectQuery =
 		SELECT_ALL_FROM_AUTO_FAILOVER_NODE_TABLE
-		" WHERE nodeid = $1 and nodehost = $2 AND nodeport = $3";
+		" WHERE formationid = $1 and nodename = $2";
 
 	SPI_connect();
 

--- a/src/monitor/node_metadata.h
+++ b/src/monitor/node_metadata.h
@@ -132,8 +132,8 @@ extern AutoFailoverNode * FindCandidateNodeBeingPromoted(List *groupNodeList);
 
 extern AutoFailoverNode * GetAutoFailoverNode(char *nodeHost, int nodePort);
 extern AutoFailoverNode * GetAutoFailoverNodeById(int nodeId);
-extern AutoFailoverNode * GetAutoFailoverNodeWithId(int nodeid, char *nodeHost, int
-													nodePort);
+extern AutoFailoverNode * GetAutoFailoverNodeByName(char *formationId,
+													char *nodeName);
 extern AutoFailoverNode * OtherNodeInGroup(AutoFailoverNode *pgAutoFailoverNode);
 extern AutoFailoverNode * GetWritableNodeInGroup(char *formationId, int32 groupId);
 extern AutoFailoverNode * TupleToAutoFailoverNode(TupleDesc tupleDescriptor,

--- a/src/monitor/pgautofailover.sql
+++ b/src/monitor/pgautofailover.sql
@@ -665,36 +665,34 @@ CREATE TRIGGER disable_secondary_check
 
 CREATE FUNCTION pgautofailover.set_node_candidate_priority
  (
-    IN nodeid				int,
-	IN nodehost             text,
-	IN nodeport             int,
+    IN formation_id         text,
+    IN node_name            text,
     IN candidate_priority	int
  )
 RETURNS bool LANGUAGE C STRICT SECURITY DEFINER
 AS 'MODULE_PATHNAME', $$set_node_candidate_priority$$;
 
-comment on function pgautofailover.set_node_candidate_priority(int, text, int, int)
+comment on function pgautofailover.set_node_candidate_priority(text, text, int)
         is 'sets the candidate priority value for a node. Expects a priority value between 0 and 100. 0 if the node is not a candidate to be promoted to be primary.';
 
 grant execute on function
-      pgautofailover.set_node_candidate_priority(int, text, int, int)
+      pgautofailover.set_node_candidate_priority(text, text, int)
    to autoctl_node;
 
 CREATE FUNCTION pgautofailover.set_node_replication_quorum
  (
-    IN nodeid             int,
-    IN nodehost           text,
-    IN nodeport           int,
+    IN formation_id       text,
+    IN node_name          text,
     IN replication_quorum bool
  )
 RETURNS bool LANGUAGE C STRICT SECURITY DEFINER
 AS 'MODULE_PATHNAME', $$set_node_replication_quorum$$;
 
-comment on function pgautofailover.set_node_replication_quorum(int, text, int, bool)
+comment on function pgautofailover.set_node_replication_quorum(text, text, bool)
         is 'sets the replication quorum value for a node. true if the node participates in write quorum';
 
 grant execute on function
-      pgautofailover.set_node_replication_quorum(int, text, int, bool)
+      pgautofailover.set_node_replication_quorum(text, text, bool)
    to autoctl_node;
 
 

--- a/src/monitor/pgautofailover.sql
+++ b/src/monitor/pgautofailover.sql
@@ -216,7 +216,8 @@ CREATE FUNCTION pgautofailover.register_node
    OUT assigned_group_id    int,
    OUT assigned_group_state pgautofailover.replication_state,
    OUT assigned_candidate_priority 	int,
-   OUT assigned_replication_quorum  bool
+   OUT assigned_replication_quorum  bool,
+   OUT assigned_node_name   text
  )
 RETURNS record LANGUAGE C STRICT SECURITY DEFINER
 AS 'MODULE_PATHNAME', $$register_node$$;


### PR DESCRIPTION
We add a new parameter --formation (defaults "default") to the commands so
that we now support running them from a monitor node.

Fixes #351.