### PR TITLE
Fix/number sync standby new async standby

### DIFF
--- a/src/monitor/formation_metadata.c
+++ b/src/monitor/formation_metadata.c
@@ -662,7 +662,8 @@ FormationNumSyncStandbyIsValid(AutoFailoverFormation *formation,
 
 	/*
 	 * number_sync_standbys = 0 is a special case in our FSM, because we have
-	 * special handling of a missing standby then.
+	 * special handling of a missing standby then, switching to wait_primary to
+	 * disable synchronous replication when the standby is not available.
 	 *
 	 * For other values (N) of number_sync_standbys, we require N+1 known
 	 * standby nodes, so that you can lose a standby at any point in time and

--- a/src/monitor/node_metadata.c
+++ b/src/monitor/node_metadata.c
@@ -758,7 +758,7 @@ CountSyncStandbys(List *groupNodeList)
 
 
 /*
- * allnodeshavesamecandidatepriority returns true when all the nodes in the
+ * AllNodesHaveSameCandidatePriority returns true when all the nodes in the
  * given list have the same candidate priority.
  */
 bool

--- a/src/monitor/node_metadata.c
+++ b/src/monitor/node_metadata.c
@@ -734,7 +734,31 @@ GroupListSyncStandbys(List *groupNodeList)
 
 
 /*
- * AllNodesHaveSameCandidatePriority returns true when all the nodes in the
+ * CountSyncStandbys returns how many standby nodes have their
+ * replicationQuorum property set to true in the given groupNodeList.
+ */
+int
+CountSyncStandbys(List *groupNodeList)
+{
+	int count = 0;
+	ListCell *nodeCell = NULL;
+
+	foreach(nodeCell, groupNodeList)
+	{
+		AutoFailoverNode *node = (AutoFailoverNode *) lfirst(nodeCell);
+
+		if (node->replicationQuorum)
+		{
+			++count;
+		}
+	}
+
+	return count;
+}
+
+
+/*
+ * allnodeshavesamecandidatepriority returns true when all the nodes in the
  * given list have the same candidate priority.
  */
 bool

--- a/src/monitor/node_metadata.c
+++ b/src/monitor/node_metadata.c
@@ -758,53 +758,6 @@ AllNodesHaveSameCandidatePriority(List *groupNodeList)
 
 
 /*
- * CountStandbyCandidates returns how many standby nodes are currently eligible
- * as failover candidates.
- */
-int
-CountStandbyCandidates(AutoFailoverNode *primaryNode, List *stateList)
-{
-	List *standbyNodesGroupList = AutoFailoverOtherNodesList(primaryNode);
-	ListCell *nodeCell = NULL;
-	int candidateCount = 0;
-
-	foreach(nodeCell, standbyNodesGroupList)
-	{
-		AutoFailoverNode *node = (AutoFailoverNode *) lfirst(nodeCell);
-
-		if (node == NULL)
-		{
-			/* shouldn't happen */
-			ereport(ERROR,
-					(errmsg("BUG in CountStandbyCandidates: node is NULL")));
-			continue;
-		}
-
-		/* if a promotion is already in progress, game over */
-		if (IsBeingPromoted(node))
-		{
-			ereport(ERROR,
-					(errmsg("node %d (%s:%d) is already being promoted",
-							node->nodeId,
-							node->nodeHost,
-							node->nodePort)));
-		}
-
-		/* skip nodes if they are not a failover candidate */
-		if (!(IsStateIn(node->reportedState, stateList) &&
-			  IsStateIn(node->goalState, stateList)))
-		{
-			continue;
-		}
-
-		++candidateCount;
-	}
-
-	return candidateCount;
-}
-
-
-/*
  * GetAutoFailoverNode returns a single AutoFailover node by hostname and port.
  */
 AutoFailoverNode *

--- a/src/monitor/node_metadata.h
+++ b/src/monitor/node_metadata.h
@@ -124,8 +124,6 @@ extern List * GroupListCandidates(List *groupNodeList);
 extern List * ListMostAdvancedStandbyNodes(List *groupNodeList);
 extern List * GroupListSyncStandbys(List *groupNodeList);
 extern bool AllNodesHaveSameCandidatePriority(List *groupNodeList);
-extern int CountStandbyCandidates(AutoFailoverNode *primaryNode,
-								  List *stateList);
 extern bool IsFailoverInProgress(List *groupNodeList);
 extern AutoFailoverNode * FindMostAdvancedStandby(List *groupNodeList);
 extern AutoFailoverNode * FindCandidateNodeBeingPromoted(List *groupNodeList);

--- a/src/monitor/node_metadata.h
+++ b/src/monitor/node_metadata.h
@@ -124,6 +124,7 @@ extern List * GroupListCandidates(List *groupNodeList);
 extern List * ListMostAdvancedStandbyNodes(List *groupNodeList);
 extern List * GroupListSyncStandbys(List *groupNodeList);
 extern bool AllNodesHaveSameCandidatePriority(List *groupNodeList);
+extern int CountSyncStandbys(List *groupNodeList);
 extern bool IsFailoverInProgress(List *groupNodeList);
 extern AutoFailoverNode * FindMostAdvancedStandby(List *groupNodeList);
 extern AutoFailoverNode * FindCandidateNodeBeingPromoted(List *groupNodeList);

--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -714,7 +714,8 @@ class DataNode(PGNode):
         self.listen_flag = listen_flag
         self.formation = formation
 
-    def create(self, run=False, level='-v', name=None, host=None, port=None):
+    def create(self, run=False, level='-v', name=None, host=None, port=None,
+               candidatePriority=None, replicationQuorum=None):
         """
         Runs "pg_autoctl create"
         """
@@ -770,8 +771,16 @@ class DataNode(PGNode):
         if port:
             create_args += ["--pgport", port]
 
+        if candidatePriority:
+            create_args += ["--candidate-priority", candidatePriority]
+
+        if replicationQuorum is not None:
+            create_args += ["--replication-quorum", str(replicationQuorum)]
+
         if run:
             create_args += ['--run']
+
+        print("pg_autoctl %s" % " ".join(create_args))
 
         # when run is requested pg_autoctl does not terminate
         # therefore we do not wait for process to complete

--- a/tests/test_multi_async.py
+++ b/tests/test_multi_async.py
@@ -49,7 +49,7 @@ def test_003_add_standby():
     global node3
 
     node3 = cluster.create_datanode("/tmp/multi_async/node3")
-    node3.create()
+    node3.create(level='-vv', replicationQuorum=False)
     node3.run()
 
     assert node3.wait_until_state(target_state="secondary")
@@ -60,8 +60,8 @@ def test_003_add_standby():
     assert node2.has_needed_replication_slots()
     assert node3.has_needed_replication_slots()
 
-    # the formation number_sync_standbys is expected to be set to 1 now
-    assert node1.get_number_sync_standbys() == 1
+    # the formation number_sync_standbys is expected to still be zero now
+    eq_(node1.get_number_sync_standbys(), 0)
 
     # make sure we reached primary on node1 before next tests
     assert node1.wait_until_state(target_state="primary")


### PR DESCRIPTION
Only raise number_sync_standbys from zero to one when adding a sync standby, that is when replication-quorum is set to true. That way, it still is possible to start with two nodes and then later add an async standby and keep the magic number_sync_standbys to zero.