### PR TITLE
Fix when to allow for a failover in multiple standbys.

### DIFF
--- a/src/monitor/node_active_protocol.c
+++ b/src/monitor/node_active_protocol.c
@@ -1087,8 +1087,8 @@ RemoveNode(AutoFailoverNode *currentNode)
 	{
 		/* find the primary, if any, and have it realize a node has left */
 		AutoFailoverNode *primaryNode =
-			GetNodeToFailoverFromInGroup(currentNode->formationId,
-										 currentNode->groupId);
+			GetPrimaryNodeInGroup(currentNode->formationId,
+								  currentNode->groupId);
 
 		if (primaryNode)
 		{

--- a/src/monitor/node_metadata.c
+++ b/src/monitor/node_metadata.c
@@ -358,7 +358,8 @@ GetNodeToFailoverFromInGroup(char *formationId, int32 groupId)
 	{
 		AutoFailoverNode *currentNode = (AutoFailoverNode *) lfirst(nodeCell);
 
-		if (CanInitiateFailover(currentNode->goalState))
+		if (CanInitiateFailover(currentNode->goalState) &&
+			currentNode->reportedState == currentNode->goalState)
 		{
 			failoverNode = currentNode;
 			break;


### PR DESCRIPTION
We had re-opened the failover to unstable states where the current goal
state and reported state are not the same, and that led to problems as per
issue https://github.com/citusdata/pg_auto_failover/issues/369.

Fixes #369.