### PR TITLE
Reduce chatter when postmaster.pid is read empty.

### DIFF
--- a/src/bin/pg_autoctl/pgsetup.c
+++ b/src/bin/pg_autoctl/pgsetup.c
@@ -462,7 +462,7 @@ get_pgpid(PostgresSetup *pgSetup, bool pgIsNotRunningIsOk)
 	if (fileSize == 0)
 	{
 		/* yeah, that happens (race condition, kind of) */
-		log_warn("The PID file \"%s\" is empty", pidfile);
+		log_debug("The PID file \"%s\" is empty", pidfile);
 		return false;
 	}
 	else if (splitLines(contents, lines, 1) != 1 ||


### PR DESCRIPTION
That's not a very interesting race condition, really.