### PR TITLE
Feature/default node names for citus formations

### DIFF
--- a/src/monitor/Makefile
+++ b/src/monitor/Makefile
@@ -14,7 +14,7 @@ MODULE_big = $(EXTENSION)
 OBJS = $(patsubst ${SRC_DIR}%.c,%.o,$(wildcard ${SRC_DIR}*.c))
 PG_CPPFLAGS = -std=c99 -Wall -Werror -Wno-unused-parameter -Iinclude -I$(libpq_srcdir) -g
 SHLIB_LINK = $(libpq)
-REGRESS = create_extension monitor dummy_update drop_extension upgrade
+REGRESS = create_extension monitor workers dummy_update drop_extension upgrade
 
 PG_CONFIG ?= pg_config
 PGXS = $(shell $(PG_CONFIG) --pgxs)

--- a/src/monitor/expected/monitor.out
+++ b/src/monitor/expected/monitor.out
@@ -9,11 +9,8 @@ assigned_group_id           | 0
 assigned_group_state        | single
 assigned_candidate_priority | 100
 assigned_replication_quorum | t
+assigned_node_name          | node_1
 
-select *
-  from pgautofailover.register_node('default', 'localhost', 9877, 'postgres');
-ERROR:  primary node is still initializing
-HINT:  Retry registering in a moment
 select *
   from pgautofailover.set_node_system_identifier(1, 6852685710417058800);
 -[ RECORD 1 ]--------
@@ -22,8 +19,10 @@ node_name | node_1
 node_host | localhost
 node_port | 9876
 
+-- node_1 reports single
 select *
-  from pgautofailover.node_active('default', 1, 0, current_group_role => 'single');
+  from pgautofailover.node_active('default', 1, 0,
+                                  current_group_role => 'single');
 -[ RECORD 1 ]---------------+-------
 assigned_node_id            | 1
 assigned_group_id           | 0
@@ -31,6 +30,7 @@ assigned_group_state        | single
 assigned_candidate_priority | 100
 assigned_replication_quorum | t
 
+-- register node_2
 select *
   from pgautofailover.register_node('default', 'localhost', 9877, 'postgres');
 -[ RECORD 1 ]---------------+-------------
@@ -39,6 +39,69 @@ assigned_group_id           | 0
 assigned_group_state        | wait_standby
 assigned_candidate_priority | 100
 assigned_replication_quorum | t
+assigned_node_name          | node_2
+
+-- node_2 reports wait_standby already
+select *
+  from pgautofailover.node_active('default', 2, 0,
+                                  current_group_role => 'wait_standby');
+-[ RECORD 1 ]---------------+-------------
+assigned_node_id            | 2
+assigned_group_id           | 0
+assigned_group_state        | wait_standby
+assigned_candidate_priority | 100
+assigned_replication_quorum | t
+
+-- node_1 reports single again, and gets assigned wait_primary
+select *
+  from pgautofailover.node_active('default', 1, 0,
+                                  current_group_role => 'single');
+-[ RECORD 1 ]---------------+-------------
+assigned_node_id            | 1
+assigned_group_id           | 0
+assigned_group_state        | wait_primary
+assigned_candidate_priority | 100
+assigned_replication_quorum | t
+
+-- node_1 now reports wait_primary
+select *
+  from pgautofailover.node_active('default', 1, 0,
+                                  current_group_role => 'wait_primary');
+-[ RECORD 1 ]---------------+-------------
+assigned_node_id            | 1
+assigned_group_id           | 0
+assigned_group_state        | wait_primary
+assigned_candidate_priority | 100
+assigned_replication_quorum | t
+
+-- node_2 now reports wait_standby, gets assigned catchingup
+select *
+  from pgautofailover.node_active('default', 2, 0,
+                                  current_group_role => 'wait_standby');
+-[ RECORD 1 ]---------------+-----------
+assigned_node_id            | 2
+assigned_group_id           | 0
+assigned_group_state        | catchingup
+assigned_candidate_priority | 100
+assigned_replication_quorum | t
+
+-- attempt to register node_3 now fails because node_1 is still in wait_primary
+select *
+  from pgautofailover.register_node('default', 'localhost', 9879, 'postgres');
+ERROR:  primary node localhost:9876 is already in state wait_primary
+HINT:  Retry registering in a moment
+select formationid, nodename, goalstate, reportedstate
+  from pgautofailover.node;
+-[ RECORD 1 ]-+-------------
+formationid   | default
+nodename      | node_1
+goalstate     | wait_primary
+reportedstate | wait_primary
+-[ RECORD 2 ]-+-------------
+formationid   | default
+nodename      | node_2
+goalstate     | catchingup
+reportedstate | wait_standby
 
 table pgautofailover.formation;
 -[ RECORD 1 ]--------+---------
@@ -46,7 +109,7 @@ formationid          | default
 kind                 | pgsql
 dbname               | postgres
 opt_secondary        | t
-number_sync_standbys | 1
+number_sync_standbys | 0
 
 -- dump the pgautofailover.node table, omitting the timely columns
 select formationid, nodeid, groupid, nodehost, nodeport,
@@ -58,8 +121,8 @@ nodeid              | 1
 groupid             | 0
 nodehost            | localhost
 nodeport            | 9876
-goalstate           | single
-reportedstate       | single
+goalstate           | wait_primary
+reportedstate       | wait_primary
 reportedpgisrunning | t
 reportedrepstate    | unknown
 -[ RECORD 2 ]-------+-------------
@@ -68,10 +131,10 @@ nodeid              | 2
 groupid             | 0
 nodehost            | localhost
 nodeport            | 9877
-goalstate           | wait_standby
-reportedstate       | init
+goalstate           | catchingup
+reportedstate       | wait_standby
 reportedpgisrunning | t
-reportedrepstate    | async
+reportedrepstate    | unknown
 
 select * from pgautofailover.get_primary('unknown formation');
 ERROR:  group has no writable node right now
@@ -91,7 +154,7 @@ primary_name    | node_1
 primary_host    | localhost
 primary_port    | 9876
 
-select * from pgautofailover.get_other_nodes('localhost', 9876);
+select * from pgautofailover.get_other_nodes(1);
 -[ RECORD 1 ]---+----------
 node_id         | 2
 node_name       | node_2
@@ -100,7 +163,7 @@ node_port       | 9877
 node_lsn        | 0/0
 node_is_primary | f
 
-select pgautofailover.remove_node('localhost', 9876);
+select pgautofailover.remove_node(1);
 -[ RECORD 1 ]--
 remove_node | t
 
@@ -110,22 +173,22 @@ formationid          | default
 kind                 | pgsql
 dbname               | postgres
 opt_secondary        | t
-number_sync_standbys | 1
+number_sync_standbys | 0
 
 -- dump the pgautofailover.node table, omitting the timely columns
 select formationid, nodeid, groupid, nodehost, nodeport,
        goalstate, reportedstate, reportedpgisrunning, reportedrepstate
   from pgautofailover.node;
--[ RECORD 1 ]-------+----------
+-[ RECORD 1 ]-------+-------------
 formationid         | default
 nodeid              | 2
 groupid             | 0
 nodehost            | localhost
 nodeport            | 9877
 goalstate           | single
-reportedstate       | init
+reportedstate       | wait_standby
 reportedpgisrunning | t
-reportedrepstate    | async
+reportedrepstate    | unknown
 
 select *
   from pgautofailover.set_node_system_identifier(2, 6852685710417058800);
@@ -134,6 +197,17 @@ node_id   | 2
 node_name | node_2
 node_host | localhost
 node_port | 9877
+
+-- node_2 reports catchingup and gets assigned single, now alone
+select *
+  from pgautofailover.node_active('default', 2, 0,
+                                  current_group_role => 'catchingup');
+-[ RECORD 1 ]---------------+-------
+assigned_node_id            | 2
+assigned_group_id           | 0
+assigned_group_state        | single
+assigned_candidate_priority | 100
+assigned_replication_quorum | t
 
 select * from pgautofailover.node_active('default', 2, 0);
 -[ RECORD 1 ]---------------+-------
@@ -145,5 +219,5 @@ assigned_replication_quorum | t
 
 -- should fail as there's no primary at this point
 select pgautofailover.perform_failover();
-ERROR:  cannot fail over: group 0 in formation default currently has 0 node registered
+ERROR:  cannot fail over: group 0 in formation default currently has 1 node registered
 DETAIL:  At least 2 nodes are required to implement a failover

--- a/src/monitor/expected/workers.out
+++ b/src/monitor/expected/workers.out
@@ -1,0 +1,61 @@
+-- Copyright (c) Microsoft Corporation. All rights reserved.
+-- Licensed under the PostgreSQL License.
+-- This only tests that names are assigned properly
+\x on
+-- create a citus formation
+select *
+  from pgautofailover.create_formation('citus', 'citus', 'citus', true, 0);
+-[ RECORD 1 ]--------+------
+formation_id         | citus
+kind                 | citus
+dbname               | citus
+opt_secondary        | t
+number_sync_standbys | 0
+
+-- register the first coordinator
+select *
+  from pgautofailover.register_node('citus', 'localhost', 9876,
+                                    dbname => 'citus',
+                                    desired_group_id => 0,
+                                    node_kind => 'coordinator');
+-[ RECORD 1 ]---------------+--------------
+assigned_node_id            | 3
+assigned_group_id           | 0
+assigned_group_state        | single
+assigned_candidate_priority | 100
+assigned_replication_quorum | t
+assigned_node_name          | coordinator_3
+
+select *
+  from pgautofailover.set_node_system_identifier(3, 6862008014275870855);
+-[ RECORD 1 ]------------
+node_id   | 3
+node_name | coordinator_3
+node_host | localhost
+node_port | 9876
+
+-- coordinator_1 reports single
+select *
+  from pgautofailover.node_active('citus', 3, 0,
+                                  current_group_role => 'single');
+-[ RECORD 1 ]---------------+-------
+assigned_node_id            | 3
+assigned_group_id           | 0
+assigned_group_state        | single
+assigned_candidate_priority | 100
+assigned_replication_quorum | t
+
+-- register first worker
+select *
+  from pgautofailover.register_node('citus', 'localhost', 9878,
+                                    dbname => 'citus',
+                                    desired_group_id => 1,
+                                    node_kind => 'worker');
+-[ RECORD 1 ]---------------+---------
+assigned_node_id            | 4
+assigned_group_id           | 1
+assigned_group_state        | single
+assigned_candidate_priority | 100
+assigned_replication_quorum | t
+assigned_node_name          | worker_4
+

--- a/src/monitor/formation_metadata.h
+++ b/src/monitor/formation_metadata.h
@@ -30,15 +30,6 @@
 #define Anum_pgautofailover_formation_number_sync_standbys 5
 
 
-/* formation.kind: "pgsql" or "citus" */
-typedef enum FormationKind
-{
-	FORMATION_KIND_UNKNOWN = 0,
-	FORMATION_KIND_PGSQL,
-	FORMATION_KIND_CITUS
-} FormationKind;
-
-
 /*
  * AutoFailoverFormation represents a formation that is being managed by the
  * pg_auto_failover monitor.

--- a/src/monitor/node_active_protocol.c
+++ b/src/monitor/node_active_protocol.c
@@ -646,6 +646,7 @@ JoinAutoFailoverFormation(AutoFailoverFormation *formation,
 	}
 
 	AddAutoFailoverNode(formation->formationId,
+						formation->kind,
 						groupId,
 						nodeName,
 						nodeHost,

--- a/src/monitor/node_metadata.h
+++ b/src/monitor/node_metadata.h
@@ -109,6 +109,20 @@ typedef struct AutoFailoverNode
 } AutoFailoverNode;
 
 
+/*
+ * Formation.kind: "pgsql" or "citus"
+ *
+ * We define the formation kind here to avoid cyclic dependency between the
+ * formation_metadata.h and node_metadata.h headers.
+ */
+typedef enum FormationKind
+{
+	FORMATION_KIND_UNKNOWN = 0,
+	FORMATION_KIND_PGSQL,
+	FORMATION_KIND_CITUS
+} FormationKind;
+
+
 /* public function declarations */
 extern List * AllAutoFailoverNodes(char *formationId);
 extern List * AutoFailoverNodeGroup(char *formationId, int groupId);
@@ -138,6 +152,7 @@ extern AutoFailoverNode * GetWritableNodeInGroup(char *formationId, int32 groupI
 extern AutoFailoverNode * TupleToAutoFailoverNode(TupleDesc tupleDescriptor,
 												  HeapTuple heapTuple);
 extern int AddAutoFailoverNode(char *formationId,
+							   FormationKind formationKind,
 							   int groupId,
 							   char *nodeName,
 							   char *nodeHost,

--- a/src/monitor/pgautofailover.sql
+++ b/src/monitor/pgautofailover.sql
@@ -138,7 +138,9 @@ CREATE TABLE pgautofailover.node
                    AND reportedstate in ('init', 'wait_standby', 'catchingup') )
                 OR sysidentifier IS NOT NULL),
     CONSTRAINT same_system_identifier_within_group
-       EXCLUDE USING gist(groupid with =, sysidentifier with <>),
+       EXCLUDE USING gist(formationid with =,
+                          groupid with =,
+                          sysidentifier with <>),
     PRIMARY KEY (nodeid),
     FOREIGN KEY (formationid) REFERENCES pgautofailover.formation(formationid)
  )

--- a/src/monitor/sql/monitor.sql
+++ b/src/monitor/sql/monitor.sql
@@ -7,16 +7,43 @@ select *
   from pgautofailover.register_node('default', 'localhost', 9876, 'postgres');
 
 select *
-  from pgautofailover.register_node('default', 'localhost', 9877, 'postgres');
-
-select *
   from pgautofailover.set_node_system_identifier(1, 6852685710417058800);
 
+-- node_1 reports single
 select *
-  from pgautofailover.node_active('default', 1, 0, current_group_role => 'single');
+  from pgautofailover.node_active('default', 1, 0,
+                                  current_group_role => 'single');
 
+-- register node_2
 select *
   from pgautofailover.register_node('default', 'localhost', 9877, 'postgres');
+
+-- node_2 reports wait_standby already
+select *
+  from pgautofailover.node_active('default', 2, 0,
+                                  current_group_role => 'wait_standby');
+
+-- node_1 reports single again, and gets assigned wait_primary
+select *
+  from pgautofailover.node_active('default', 1, 0,
+                                  current_group_role => 'single');
+
+-- node_1 now reports wait_primary
+select *
+  from pgautofailover.node_active('default', 1, 0,
+                                  current_group_role => 'wait_primary');
+
+-- node_2 now reports wait_standby, gets assigned catchingup
+select *
+  from pgautofailover.node_active('default', 2, 0,
+                                  current_group_role => 'wait_standby');
+
+-- attempt to register node_3 now fails because node_1 is still in wait_primary
+select *
+  from pgautofailover.register_node('default', 'localhost', 9879, 'postgres');
+
+select formationid, nodename, goalstate, reportedstate
+  from pgautofailover.node;
 
 table pgautofailover.formation;
 
@@ -30,9 +57,9 @@ select * from pgautofailover.get_primary(group_id => -10);
 select * from pgautofailover.get_primary();
 
 select * from pgautofailover.get_primary('default', 0);
-select * from pgautofailover.get_other_nodes('localhost', 9876);
+select * from pgautofailover.get_other_nodes(1);
 
-select pgautofailover.remove_node('localhost', 9876);
+select pgautofailover.remove_node(1);
 
 table pgautofailover.formation;
 
@@ -43,6 +70,11 @@ select formationid, nodeid, groupid, nodehost, nodeport,
 
 select *
   from pgautofailover.set_node_system_identifier(2, 6852685710417058800);
+
+-- node_2 reports catchingup and gets assigned single, now alone
+select *
+  from pgautofailover.node_active('default', 2, 0,
+                                  current_group_role => 'catchingup');
 
 select * from pgautofailover.node_active('default', 2, 0);
 

--- a/src/monitor/sql/workers.sql
+++ b/src/monitor/sql/workers.sql
@@ -1,0 +1,32 @@
+-- Copyright (c) Microsoft Corporation. All rights reserved.
+-- Licensed under the PostgreSQL License.
+
+-- This only tests that names are assigned properly
+
+\x on
+
+-- create a citus formation
+select *
+  from pgautofailover.create_formation('citus', 'citus', 'citus', true, 0);
+
+-- register the first coordinator
+select *
+  from pgautofailover.register_node('citus', 'localhost', 9876,
+                                    dbname => 'citus',
+                                    desired_group_id => 0,
+                                    node_kind => 'coordinator');
+
+select *
+  from pgautofailover.set_node_system_identifier(3, 6862008014275870855);
+
+-- coordinator_1 reports single
+select *
+  from pgautofailover.node_active('citus', 3, 0,
+                                  current_group_role => 'single');
+
+-- register first worker
+select *
+  from pgautofailover.register_node('citus', 'localhost', 9878,
+                                    dbname => 'citus',
+                                    desired_group_id => 1,
+                                    node_kind => 'worker');


### PR DESCRIPTION
In Citus formation, use "coordinator" or "worker" as a prefix for nodes registered without `--name` option.

In passing, fix several problems in the extension regression tests, and also fix the system identifier exclusion constraint to allow different groups with the same groupId in different formations to have different system identifiers.