### PR TITLE
Implement pg_autoctl perform promotion.

### DIFF
--- a/src/bin/pg_autoctl/cli_common.h
+++ b/src/bin/pg_autoctl/cli_common.h
@@ -182,5 +182,7 @@ bool cli_common_pgsetup_init(ConfigFilePaths *pathnames, PostgresSetup *pgSetup)
 bool cli_pg_autoctl_reload(const char *pidfile);
 
 int cli_node_metadata_getopts(int argc, char **argv);
+int cli_get_name_getopts(int argc, char **argv);
+void cli_ensure_node_name(Keeper *keeper);
 
 #endif  /* CLI_COMMON_H */

--- a/src/bin/pg_autoctl/cli_get_set_properties.c
+++ b/src/bin/pg_autoctl/cli_get_set_properties.c
@@ -13,9 +13,6 @@
 #include "parsing.h"
 #include "string_utils.h"
 
-static void cli_ensure_node_name(Keeper *keeper);
-static int cli_get_set_properties_getopts(int argc, char **argv);
-
 static bool get_node_replication_settings(NodeReplicationSettings *settings);
 static void cli_get_node_replication_quorum(int argc, char **argv);
 static void cli_get_node_candidate_priority(int argc, char **argv);
@@ -42,7 +39,7 @@ CommandLine get_node_replication_quorum =
 				 "  --formation   pg_auto_failover formation\n"
 				 "  --name        pg_auto_failover node name\n"
 				 "  --json        output data in the JSON format\n",
-				 cli_get_set_properties_getopts,
+				 cli_get_name_getopts,
 				 cli_get_node_replication_quorum);
 
 CommandLine get_node_candidate_priority =
@@ -53,7 +50,7 @@ CommandLine get_node_candidate_priority =
 				 "  --formation   pg_auto_failover formation\n"
 				 "  --name        pg_auto_failover node name\n"
 				 "  --json        output data in the JSON format\n",
-				 cli_get_set_properties_getopts,
+				 cli_get_name_getopts,
 				 cli_get_node_candidate_priority);
 
 
@@ -76,7 +73,7 @@ static CommandLine get_formation_settings =
 				 "  --pgdata      path to data directory\n"
 				 "  --json        output data in the JSON format\n"
 				 "  --formation   pg_auto_failover formation\n",
-				 cli_get_set_properties_getopts,
+				 cli_get_name_getopts,
 				 cli_get_formation_settings);
 
 static CommandLine get_formation_number_sync_standbys =
@@ -86,7 +83,7 @@ static CommandLine get_formation_number_sync_standbys =
 				 "  --pgdata      path to data directory\n"
 				 "  --json        output data in the JSON format\n"
 				 "  --formation   pg_auto_failover formation\n",
-				 cli_get_set_properties_getopts,
+				 cli_get_name_getopts,
 				 cli_get_formation_number_sync_standbys);
 
 static CommandLine *get_formation_subcommands[] = {
@@ -122,7 +119,7 @@ static CommandLine set_node_replication_quorum_command =
 				 "  --formation   pg_auto_failover formation\n"
 				 "  --name        pg_auto_failover node name\n"
 				 "  --json        output data in the JSON format\n",
-				 cli_get_set_properties_getopts,
+				 cli_get_name_getopts,
 				 cli_set_node_replication_quorum);
 
 static CommandLine set_node_candidate_priority_command =
@@ -134,7 +131,7 @@ static CommandLine set_node_candidate_priority_command =
 				 "  --formation   pg_auto_failover formation\n"
 				 "  --name        pg_auto_failover node name\n"
 				 "  --json        output data in the JSON format\n",
-				 cli_get_set_properties_getopts,
+				 cli_get_name_getopts,
 				 cli_set_node_candidate_priority);
 
 static CommandLine set_node_metadata_command =
@@ -170,7 +167,7 @@ static CommandLine set_formation_number_sync_standby_command =
 				 "  --pgdata      path to data directory\n"
 				 "  --formation   pg_auto_failover formation\n"
 				 "  --json        output data in the JSON format\n",
-				 cli_get_set_properties_getopts,
+				 cli_get_name_getopts,
 				 cli_set_formation_number_sync_standbys);
 
 static CommandLine *set_formation_subcommands[] = {
@@ -195,155 +192,6 @@ CommandLine set_commands =
 	make_command_set("set",
 					 "Set a pg_auto_failover node, or formation setting",
 					 NULL, NULL, NULL, set_subcommands);
-
-
-/*
- * cli_get_set_properties_getopts parses the command line options for the
- * command `pg_autoctl get|set` commands.
- */
-static int
-cli_get_set_properties_getopts(int argc, char **argv)
-{
-	KeeperConfig options = { 0 };
-	int c, option_index = 0, errors = 0;
-	int verboseCount = 0;
-
-	static struct option long_options[] = {
-		{ "pgdata", required_argument, NULL, 'D' },
-		{ "formation", required_argument, NULL, 'f' },
-		{ "name", required_argument, NULL, 'a' },
-		{ "json", no_argument, NULL, 'J' },
-		{ "version", no_argument, NULL, 'V' },
-		{ "verbose", no_argument, NULL, 'v' },
-		{ "quiet", no_argument, NULL, 'q' },
-		{ "help", no_argument, NULL, 'h' },
-		{ NULL, 0, NULL, 0 }
-	};
-
-	/* set default values for our options, when we have some */
-	options.groupId = -1;
-	options.network_partition_timeout = -1;
-	options.prepare_promotion_catchup = -1;
-	options.prepare_promotion_walreceiver = -1;
-	options.postgresql_restart_failure_timeout = -1;
-	options.postgresql_restart_failure_max_retries = -1;
-
-	strlcpy(options.formation, "default", NAMEDATALEN);
-
-	optind = 0;
-
-	/*
-	 * The only command lines that are using keeper_cli_getopt_pgdata are
-	 * terminal ones: they don't accept subcommands. In that case our option
-	 * parsing can happen in any order and we don't need getopt_long to behave
-	 * in a POSIXLY_CORRECT way.
-	 *
-	 * The unsetenv() call allows getopt_long() to reorder arguments for us.
-	 */
-	unsetenv("POSIXLY_CORRECT");
-
-	while ((c = getopt_long(argc, argv, "D:f:g:n:Vvqh",
-							long_options, &option_index)) != -1)
-	{
-		switch (c)
-		{
-			case 'D':
-			{
-				strlcpy(options.pgSetup.pgdata, optarg, MAXPGPATH);
-				log_trace("--pgdata %s", options.pgSetup.pgdata);
-				break;
-			}
-
-			case 'f':
-			{
-				strlcpy(options.formation, optarg, NAMEDATALEN);
-				log_trace("--formation %s", options.formation);
-				break;
-			}
-
-			case 'a':
-			{
-				/* { "name", required_argument, NULL, 'a' }, */
-				strlcpy(options.name, optarg, _POSIX_HOST_NAME_MAX);
-				log_trace("--name %s", options.name);
-				break;
-			}
-
-			case 'V':
-			{
-				/* keeper_cli_print_version prints version and exits. */
-				keeper_cli_print_version(argc, argv);
-				break;
-			}
-
-			case 'v':
-			{
-				++verboseCount;
-				switch (verboseCount)
-				{
-					case 1:
-					{
-						log_set_level(LOG_INFO);
-						break;
-					}
-
-					case 2:
-					{
-						log_set_level(LOG_DEBUG);
-						break;
-					}
-
-					default:
-					{
-						log_set_level(LOG_TRACE);
-						break;
-					}
-				}
-				break;
-			}
-
-			case 'q':
-			{
-				log_set_level(LOG_ERROR);
-				break;
-			}
-
-			case 'h':
-			{
-				commandline_help(stderr);
-				exit(EXIT_CODE_QUIT);
-				break;
-			}
-
-			case 'J':
-			{
-				outputJSON = true;
-				log_trace("--json");
-				break;
-			}
-
-			default:
-			{
-				/* getopt_long already wrote an error message */
-				errors++;
-			}
-		}
-	}
-
-	if (errors > 0)
-	{
-		commandline_help(stderr);
-		exit(EXIT_CODE_BAD_ARGS);
-	}
-
-	/* now that we have the command line parameters, prepare the options */
-	(void) prepare_keeper_options(&options);
-
-	/* publish our option parsing in the global variable */
-	keeperOptions = options;
-
-	return optind;
-}
 
 
 /*
@@ -1016,51 +864,4 @@ set_formation_number_sync_standbys(Monitor *monitor,
 	}
 
 	return true;
-}
-
-
-/*
- * cli_ensure_node_name ensures that we have a node name to continue with,
- * either from the command line itself, or from the configuration file when
- * we're dealing with a keeper node.
- */
-static void
-cli_ensure_node_name(Keeper *keeper)
-{
-	switch (ProbeConfigurationFileRole(keeper->config.pathnames.config))
-	{
-		case PG_AUTOCTL_ROLE_MONITOR:
-		{
-			if (IS_EMPTY_STRING_BUFFER(keeper->config.name))
-			{
-				log_fatal("Please use --name to target a specific node");
-				exit(EXIT_CODE_BAD_ARGS);
-			}
-			break;
-		}
-
-		case PG_AUTOCTL_ROLE_KEEPER:
-		{
-			/* when --name has not been used, fetch it from the config */
-			if (IS_EMPTY_STRING_BUFFER(keeper->config.name))
-			{
-				bool monitorDisabledIsOk = false;
-
-				if (!keeper_config_read_file_skip_pgsetup(&(keeper->config),
-														  monitorDisabledIsOk))
-				{
-					/* errors have already been logged */
-					exit(EXIT_CODE_BAD_CONFIG);
-				}
-			}
-			break;
-		}
-
-		default:
-		{
-			log_fatal("Unrecognized configuration file \"%s\"",
-					  keeper->config.pathnames.config);
-			exit(EXIT_CODE_INTERNAL_ERROR);
-		}
-	}
 }

--- a/src/bin/pg_autoctl/monitor.h
+++ b/src/bin/pg_autoctl/monitor.h
@@ -112,8 +112,14 @@ bool monitor_set_formation_number_sync_standbys(Monitor *monitor, char *formatio
 												int numberSyncStandbys);
 
 bool monitor_remove(Monitor *monitor, char *host, int port);
+
 bool monitor_count_groups(Monitor *monitor, char *formation, int *groupsCount);
+bool monitor_get_groupId_from_name(Monitor *monitor,
+								   char *formation, char *name,
+								   int *groupId);
+
 bool monitor_perform_failover(Monitor *monitor, char *formation, int group);
+bool monitor_perform_promotion(Monitor *monitor, char *formation, char *name);
 
 bool monitor_print_state(Monitor *monitor, char *formation, int group);
 bool monitor_print_last_events(Monitor *monitor,

--- a/src/monitor/group_state_machine.c
+++ b/src/monitor/group_state_machine.c
@@ -1397,11 +1397,11 @@ PromoteSelectedNode(AutoFailoverNode *selectedNode,
 	 * in the system then its candidate priority has been incremented by 100.
 	 * Now is the time to reset it.
 	 */
-	if (selectedNode->candidatePriority > 100)
+	if (selectedNode->candidatePriority > MAX_USER_DEFINED_CANDIDATE_PRIORITY)
 	{
 		char message[BUFSIZE] = { 0 };
 
-		selectedNode->candidatePriority -= 100;
+		selectedNode->candidatePriority -= MAX_USER_DEFINED_CANDIDATE_PRIORITY;
 
 		ReportAutoFailoverNodeReplicationSetting(
 			selectedNode->nodeId,

--- a/src/monitor/node_active_protocol.c
+++ b/src/monitor/node_active_protocol.c
@@ -1388,6 +1388,13 @@ perform_promotion(PG_FUNCTION_ARGS)
 
 		NotifyStateChange(currentNode, message);
 
+		/*
+		 * In case of errors in the perform_failover function, we ereport an
+		 * ERROR and that causes the transaction to fail (ROLLBACK). In that
+		 * case, the UPDATE of the candidate priority in the
+		 * pgautofailover.node table is also cancelled, and the notification
+		 * above is not sent either.
+		 */
 		DirectFunctionCall2(perform_failover,
 							CStringGetTextDatum(formationId),
 							Int32GetDatum(currentNode->groupId));

--- a/src/monitor/node_active_protocol.c
+++ b/src/monitor/node_active_protocol.c
@@ -61,6 +61,7 @@ PG_FUNCTION_INFO_V1(remove_node);
 PG_FUNCTION_INFO_V1(remove_node_by_nodeid);
 PG_FUNCTION_INFO_V1(remove_node_by_host);
 PG_FUNCTION_INFO_V1(perform_failover);
+PG_FUNCTION_INFO_V1(perform_promotion);
 PG_FUNCTION_INFO_V1(start_maintenance);
 PG_FUNCTION_INFO_V1(stop_maintenance);
 PG_FUNCTION_INFO_V1(set_node_candidate_priority);
@@ -1278,6 +1279,120 @@ perform_failover(PG_FUNCTION_ARGS)
 	}
 
 	PG_RETURN_VOID();
+}
+
+
+/*
+ * promote promotes a given target node in a group.
+ */
+Datum
+perform_promotion(PG_FUNCTION_ARGS)
+{
+	text *formationIdText = PG_GETARG_TEXT_P(0);
+	char *formationId = text_to_cstring(formationIdText);
+
+	text *nodeNameText = PG_GETARG_TEXT_P(1);
+	char *nodeName = text_to_cstring(nodeNameText);
+
+	List *groupNodesList = NULL;
+	int totalNodesCount = 0;
+
+	AutoFailoverNode *currentNode = NULL;
+
+	checkPgAutoFailoverVersion();
+
+	currentNode = GetAutoFailoverNodeByName(formationId, nodeName);
+
+	if (currentNode == NULL)
+	{
+		ereport(ERROR,
+				(errmsg("node \"%s\" is not registered in formation \"%s\"",
+						nodeName, formationId)));
+	}
+
+	LockFormation(formationId, ShareLock);
+	LockNodeGroup(formationId, currentNode->groupId, ExclusiveLock);
+
+	/*
+	 * If the current node is the primary, that's done.
+	 */
+	if (IsCurrentState(currentNode, REPLICATION_STATE_SINGLE) ||
+		IsCurrentState(currentNode, REPLICATION_STATE_PRIMARY))
+	{
+		/* return false: no promotion is happening */
+		PG_RETURN_BOOL(false);
+	}
+
+	/*
+	 * If we have only two nodes in the group, then perform a failover.
+	 */
+	groupNodesList =
+		AutoFailoverNodeGroup(currentNode->formationId, currentNode->groupId);
+
+	totalNodesCount = list_length(groupNodesList);
+
+	if (totalNodesCount <= 2)
+	{
+		DirectFunctionCall2(perform_failover,
+							CStringGetTextDatum(formationId),
+							Int32GetDatum(currentNode->groupId));
+
+		/* if we reach this point, then a failover is in progress */
+		PG_RETURN_BOOL(true);
+	}
+	else
+	{
+		char message[BUFSIZE] = { 0 };
+
+		/*
+		 * In the general case, we perform a little trick:
+		 *
+		 *  - first increment the node's candidate-priority by 100,
+		 *
+		 *  - then call perform_failover,
+		 *
+		 *  - when the node reaches WAIT_PRIMARY again, after promotion, reset
+		 *    its candidate priority.
+		 */
+		if (currentNode->candidatePriority == 0)
+		{
+			ereport(ERROR,
+					(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+					 errmsg("cannot perform promotion: node %s in formation %s "
+							"has a candidate priority of 0 (zero).",
+							nodeName, formationId)));
+		}
+
+		currentNode->candidatePriority += 100;
+
+		ReportAutoFailoverNodeReplicationSetting(
+			currentNode->nodeId,
+			currentNode->nodeHost,
+			currentNode->nodePort,
+			currentNode->candidatePriority,
+			currentNode->replicationQuorum);
+
+		LogAndNotifyMessage(
+			message, BUFSIZE,
+			"Updating candidate priority to %d for node %d \"%s\" (%s:%d)",
+			currentNode->candidatePriority,
+			currentNode->nodeId,
+			currentNode->nodeName,
+			currentNode->nodeHost,
+			currentNode->nodePort);
+
+		NotifyStateChange(currentNode, message);
+
+		DirectFunctionCall2(perform_failover,
+							CStringGetTextDatum(formationId),
+							Int32GetDatum(currentNode->groupId));
+
+		/* if we reach this point, then a failover is in progress */
+		PG_RETURN_BOOL(true);
+	}
+
+	/* can't happen, keep compiler happy */
+	PG_RETURN_BOOL(false);
 }
 
 

--- a/src/monitor/node_metadata.h
+++ b/src/monitor/node_metadata.h
@@ -82,6 +82,14 @@ typedef enum SyncState
 
 
 /*
+ * We restrict candidatePriority values in the range 0..100 to the users.
+ * Internally, we increment the candidatePriority (+= 100) when the
+ * perform_promotion API is used, in order to tweak the selection of the
+ * candidate.
+ */
+#define MAX_USER_DEFINED_CANDIDATE_PRIORITY 100
+
+/*
  * AutoFailoverNode represents a Postgres node that is being tracked by the
  * pg_auto_failover monitor.
  */

--- a/src/monitor/pgautofailover.sql
+++ b/src/monitor/pgautofailover.sql
@@ -421,6 +421,20 @@ comment on function pgautofailover.perform_failover(text,int)
 grant execute on function pgautofailover.perform_failover(text,int)
    to autoctl_node;
 
+CREATE FUNCTION pgautofailover.perform_promotion
+ (
+  formation_id text,
+  node_name    text
+ )
+RETURNS bool LANGUAGE C STRICT SECURITY DEFINER
+AS 'MODULE_PATHNAME', $$perform_promotion$$;
+
+comment on function pgautofailover.perform_promotion(text,text)
+        is 'manually failover from the primary to the given node';
+
+grant execute on function pgautofailover.perform_failover(text,int)
+   to autoctl_node;
+
 CREATE FUNCTION pgautofailover.start_maintenance(node_id int)
 RETURNS bool LANGUAGE C STRICT SECURITY DEFINER
 AS 'MODULE_PATHNAME', $$start_maintenance$$;

--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -940,6 +940,13 @@ SELECT reportedstate
         command = PGAutoCtl(self)
         command.execute("disable maintenance", 'disable', 'maintenance')
 
+    def perform_promotion(self):
+        """
+        Calls pg_autoctl perform promotion on a Postgres node
+        """
+        command = PGAutoCtl(self)
+        command.execute("perform promotion", 'perform', 'promotion')
+
     def drop(self):
         """
         Drops a pg_autoctl node from its formation

--- a/tests/test_basic_operation.py
+++ b/tests/test_basic_operation.py
@@ -183,8 +183,8 @@ def test_020_multiple_manual_failover_verify_replication_slots():
     assert node2.has_needed_replication_slots()
     assert node3.has_needed_replication_slots()
 
-    print("Calling pgautofailover.failover() on the monitor")
-    monitor.failover()
+    print("Calling pg_autoctl perform promotion on node 2")
+    node2.perform_promotion()
     assert node2.wait_until_state(target_state="primary")
     assert node3.wait_until_state(target_state="secondary")
 

--- a/tests/test_multi_async.py
+++ b/tests/test_multi_async.py
@@ -86,18 +86,7 @@ def test_004_set_async():
     assert node2.set_replication_quorum("false")    # secondary
     assert node3.set_replication_quorum("false")    # secondary
 
-def test_005_set_priorities():
-    # to make the tests consistent, we assign higher
-    # priorty to node1
-    assert node1.set_candidate_priority(90)      # current primary
-    assert node2.set_candidate_priority(100)     # next primary
-    assert node3.set_candidate_priority(90)      # secondary
-
-    # when we set candidate priority we go to join_primary then primary
-    print()
-    assert node1.wait_until_state(target_state="primary")
-
-def test_006_write_into_primary():
+def test_005_write_into_primary():
     node1.run_sql_query("CREATE TABLE t1(a int)")
     node1.run_sql_query("INSERT INTO t1 VALUES (1), (2), (3), (4)")
     node1.run_sql_query("CHECKPOINT")
@@ -105,16 +94,15 @@ def test_006_write_into_primary():
     results = node1.run_sql_query("SELECT * FROM t1")
     assert results == [(1,), (2,), (3,), (4,)]
 
-def test_007_async_failover():
+def test_006_async_failover():
     print()
     print("Calling pgautofailover.failover() on the monitor")
-    monitor.failover()
+    node2.perform_promotion()
 
-    assert node2.wait_until_state(target_state="wait_primary") # primary
     assert node1.wait_until_state(target_state="secondary")    # secondary
     assert node3.wait_until_state(target_state="secondary")    # secondary
     assert node2.wait_until_state(target_state="primary")      # primary
 
-def test_008_read_from_new_primary():
+def test_007_read_from_new_primary():
     results = node2.run_sql_query("SELECT * FROM t1")
     assert results == [(1,), (2,), (3,), (4,)]


### PR DESCRIPTION
This command allows to promote a given node (by name, or the current local
one) to being the primary on a group. When the node is already a primary, no
action is taken and the command returns true immediately.