### PR TITLE
Move the keeper reload_configuration into a hooks array.

### DIFF
--- a/src/bin/pg_autoctl/keeper.h
+++ b/src/bin/pg_autoctl/keeper.h
@@ -64,4 +64,23 @@ bool keeper_refresh_other_nodes(Keeper *keeper, bool forceCacheInvalidation);
 bool keeper_set_node_metadata(Keeper *keeper, KeeperConfig *oldConfig);
 bool keeper_config_accept_new(Keeper *keeper, KeeperConfig *newConfig);
 
+
+/*
+ * When receiving a SIGHUP signal, the keeper knows how to reload its current
+ * in-memory configuration from the on-disk configuration file, and then apply
+ * changes. For this we use an array of functions that we call in order each
+ * time we are asked to reload.
+ *
+ * Because it's possible to edit the configuration file while pg_autoctl is not
+ * running, we also call the ReloadHook functions when entering our main loop
+ * the first time.
+ */
+typedef bool (*KeeperReloadFunction)(Keeper *keeper, bool firstLoop);
+
+/* src/bin/pg_autoctl/service_keeper.c */
+extern KeeperReloadFunction KeeperReloadHooks[];
+
+void keeper_call_reload_hooks(Keeper *keeper, bool firstLoop);
+bool keeper_reload_configuration(Keeper *keeper, bool firstLoop);
+
 #endif /* KEEPER_H */

--- a/src/bin/pg_autoctl/keeper_pg_init.c
+++ b/src/bin/pg_autoctl/keeper_pg_init.c
@@ -710,13 +710,28 @@ create_database_and_extension(Keeper *keeper)
 	postgres->postgresSetup.ssl = initPostgres.postgresSetup.ssl;
 
 	/*
-	 * Ensure pg_stat_statements is installed in the server extension dir used
-	 * to create the Postgres instance
+	 * Ensure pg_stat_statements is available in the server extension dir used
+	 * to create the Postgres instance.
 	 */
-	if (!find_extension_control_file(config->pgSetup.pg_ctl, "pg_stat_statements"))
+	if (!find_extension_control_file(config->pgSetup.pg_ctl,
+									 "pg_stat_statements"))
 	{
-		log_error("Cannot proceed without pg_stat_statements");
+		log_error("Failed to find extension control file for "
+				  "\"pg_stat_statements\"");
 		exit(EXIT_CODE_EXTENSION_MISSING);
+	}
+
+	/*
+	 * Ensure citus extension is available in the server extension dir used to
+	 * create the Postgres instance.
+	 */
+	if (IS_CITUS_INSTANCE_KIND(postgres->pgKind))
+	{
+		if (!find_extension_control_file(config->pgSetup.pg_ctl, "citus"))
+		{
+			log_error("Failed to find extension control file for \"citus\"");
+			exit(EXIT_CODE_EXTENSION_MISSING);
+		}
 	}
 
 	/*

--- a/src/bin/pg_autoctl/primary_standby.c
+++ b/src/bin/pg_autoctl/primary_standby.c
@@ -81,14 +81,14 @@ GUC postgres_default_settings_13[] = {
 
 GUC citus_default_settings_pre_13[] = {
 	DEFAULT_GUC_SETTINGS_FOR_PG_AUTO_FAILOVER_PRE_13,
-	{ "shared_preload_libraries", "'citus','pg_stat_statements'" },
+	{ "shared_preload_libraries", "'citus,pg_stat_statements'" },
 	{ "citus.node_conninfo", "'sslmode=prefer'" },
 	{ NULL, NULL }
 };
 
 GUC citus_default_settings_13[] = {
 	DEFAULT_GUC_SETTINGS_FOR_PG_AUTO_FAILOVER_13,
-	{ "shared_preload_libraries", "'citus','pg_stat_statements'" },
+	{ "shared_preload_libraries", "'citus,pg_stat_statements'" },
 	{ "citus.node_conninfo", "'sslmode=prefer'" },
 	{ NULL, NULL }
 };


### PR DESCRIPTION
This allows more flexibility for extending the behavior at reload.