### PR TITLE
Allow registering multiple standbys concurrently

### DIFF
--- a/src/bin/pg_autoctl/fsm_transition.c
+++ b/src/bin/pg_autoctl/fsm_transition.c
@@ -366,7 +366,7 @@ fsm_init_primary(Keeper *keeper)
  * single.
  *
  *    disable_synchronous_replication
- * && keeper_drop_replication_slots_for_removed_nodes
+ * && keeper_create_and_drop_replication_slots
  *
  * TODO: We currently use a separate session for each step. We should use
  * a single connection.
@@ -403,7 +403,7 @@ fsm_disable_replication(Keeper *keeper)
  *
  *    start_postgres
  * && disable_synchronous_replication
- * && keeper_drop_replication_slots_for_removed_nodes
+ * && keeper_create_and_drop_replication_slots
  *
  * So we reuse fsm_disable_replication() here, rather than copy/pasting the same
  * bits code in the fsm_resume_as_primary() function body. If the definition of
@@ -1115,7 +1115,7 @@ fsm_restart_standby(Keeper *keeper)
  * && add_standby_to_hba
  * && create_replication_slot
  * && disable_synchronous_replication
- * && keeper_drop_replication_slots_for_removed_nodes
+ * && keeper_create_and_drop_replication_slots
  *
  * Note that the HBA and slot maintenance are done eagerly in the main keeper
  * loop as soon as a new node is added to the group, so we don't need to handle

--- a/src/bin/pg_autoctl/fsm_transition.c
+++ b/src/bin/pg_autoctl/fsm_transition.c
@@ -393,7 +393,7 @@ fsm_disable_replication(Keeper *keeper)
 	bzero((void *) postgres->standbyTargetLSN, PG_LSN_MAXLENGTH);
 
 	/* when a standby has been removed, remove its replication slot */
-	return keeper_drop_replication_slots_for_removed_nodes(keeper);
+	return keeper_create_and_drop_replication_slots(keeper);
 }
 
 

--- a/src/bin/pg_autoctl/keeper.c
+++ b/src/bin/pg_autoctl/keeper.c
@@ -955,7 +955,7 @@ keeper_create_and_drop_replication_slots(Keeper *keeper)
 	LocalPostgresServer *postgres = &(keeper->postgres);
 	NodeAddressArray *otherNodesArray = &(keeper->otherNodes);
 
-	log_trace("keeper_drop_replication_slots_for_removed_nodes");
+	log_trace("keeper_create_and_drop_replication_slots");
 
 	if (!postgres_replication_slot_create_and_drop(postgres, otherNodesArray))
 	{

--- a/src/bin/pg_autoctl/keeper.c
+++ b/src/bin/pg_autoctl/keeper.c
@@ -203,7 +203,11 @@ keeper_ensure_current_state(Keeper *keeper)
 		 *   timeout.postgresql_fails_to_start_timeout (default 20s)
 		 *   timeout.postgresql_fails_to_start_retries (default 3 times)
 		 */
+		case SINGLE_STATE:
 		case PRIMARY_STATE:
+		case WAIT_PRIMARY_STATE:
+		case JOIN_PRIMARY_STATE:
+		case APPLY_SETTINGS_STATE:
 		{
 			if (!keeper_ensure_postgres_is_running(keeper, true))
 			{
@@ -212,20 +216,7 @@ keeper_ensure_current_state(Keeper *keeper)
 			}
 
 			/* when a standby has been removed, remove its replication slot */
-			return keeper_drop_replication_slots_for_removed_nodes(keeper);
-		}
-
-		case SINGLE_STATE:
-		{
-			/* a single node does not need to maintain retries attempts */
-			if (!keeper_ensure_postgres_is_running(keeper, false))
-			{
-				/* errors have already been logged */
-				return false;
-			}
-
-			/* when a standby has been removed, remove its replication slot */
-			return keeper_drop_replication_slots_for_removed_nodes(keeper);
+			return keeper_create_and_drop_replication_slots(keeper);
 		}
 
 		/*
@@ -234,7 +225,6 @@ keeper_ensure_current_state(Keeper *keeper)
 		 * is taking care of that, or because we're in the middle of changing
 		 * the replication upstream node.
 		 */
-		case WAIT_PRIMARY_STATE:
 		case PREP_PROMOTION_STATE:
 		case STOP_REPLICATION_STATE:
 		{
@@ -952,20 +942,22 @@ keeper_ensure_configuration(Keeper *keeper, bool postgresNotRunningIsOk)
 
 
 /*
- * keeper_drop_replication_slots_for_removed_nodes drops replication slots that
- * we have on the local Postgres instance when the node is not registered on
- * the monitor anymore (after a pgautofailover.remove_node() has been issued,
- * maybe with the command `pg_autoctl drop node [ --destroy ]`).
+ * keeper_create_and_drop_replication_slots drops replication slots that we
+ * have on the local Postgres instance when the node is not registered on the
+ * monitor anymore (after a pgautofailover.remove_node() has been issued, maybe
+ * with the command `pg_autoctl drop node [ --destroy ]`); and creates
+ * replication slots for nodes that have been recently registered on the
+ * monitor.
  */
 bool
-keeper_drop_replication_slots_for_removed_nodes(Keeper *keeper)
+keeper_create_and_drop_replication_slots(Keeper *keeper)
 {
 	LocalPostgresServer *postgres = &(keeper->postgres);
 	NodeAddressArray *otherNodesArray = &(keeper->otherNodes);
 
 	log_trace("keeper_drop_replication_slots_for_removed_nodes");
 
-	if (!postgres_replication_slot_drop_removed(postgres, otherNodesArray))
+	if (!postgres_replication_slot_create_and_drop(postgres, otherNodesArray))
 	{
 		log_error("Failed to maintain replication slots on the local Postgres "
 				  "instance, see above for details");

--- a/src/bin/pg_autoctl/keeper.h
+++ b/src/bin/pg_autoctl/keeper.h
@@ -47,7 +47,7 @@ bool keeper_start_postgres(Keeper *keeper);
 bool keeper_restart_postgres(Keeper *keeper);
 bool keeper_should_ensure_current_state_before_transition(Keeper *keeper);
 bool keeper_ensure_postgres_is_running(Keeper *keeper, bool updateRetries);
-bool keeper_drop_replication_slots_for_removed_nodes(Keeper *keeper);
+bool keeper_create_and_drop_replication_slots(Keeper *keeper);
 bool keeper_maintain_replication_slots(Keeper *keeper);
 bool keeper_ensure_current_state(Keeper *keeper);
 bool keeper_create_self_signed_cert(Keeper *keeper);

--- a/src/bin/pg_autoctl/keeper_pg_init.c
+++ b/src/bin/pg_autoctl/keeper_pg_init.c
@@ -48,6 +48,9 @@ static bool keeper_pg_init_and_register_primary(Keeper *keeper);
 static bool reach_initial_state(Keeper *keeper);
 static bool wait_until_primary_is_ready(Keeper *config,
 										MonitorAssignedState *assignedState);
+static bool wait_until_primary_has_created_our_replication_slot(Keeper *keeper,
+																MonitorAssignedState *
+																assignedState);
 static bool keeper_pg_init_node_active(Keeper *keeper);
 
 /*
@@ -595,6 +598,100 @@ wait_until_primary_is_ready(Keeper *keeper,
 		log_error("Failed to update keepers's state");
 		return false;
 	}
+
+	/* Now make sure the replication slot has been created on the primary */
+	return wait_until_primary_has_created_our_replication_slot(keeper,
+															   assignedState);
+}
+
+
+/*
+ * wait_until_primary_has_created_our_replication_slot loops over querying the
+ * primary server until it has created our replication slot.
+ *
+ * When assigned CATCHINGUP_STATE, in some cases the primary might not be ready
+ * yet. That might happen when all the other standby nodes are in maintenance
+ * and the primary is already in the WAIT_PRIMARY state.
+ */
+static bool
+wait_until_primary_has_created_our_replication_slot(Keeper *keeper,
+													MonitorAssignedState *assignedState)
+{
+	int errors = 0, tries = 0;
+	bool firstLoop = true;
+
+	Monitor *monitor = &(keeper->monitor);
+	KeeperConfig *config = &(keeper->config);
+	LocalPostgresServer *postgres = &(keeper->postgres);
+	ReplicationSource *upstream = &(postgres->replicationSource);
+	NodeAddress *primaryNode = &(postgres->replicationSource.primaryNode);
+
+	bool hasReplicationSlot = false;
+
+	if (!monitor_get_primary(monitor,
+							 config->formation,
+							 assignedState->groupId,
+							 &(postgres->replicationSource.primaryNode)))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	if (!standby_init_replication_source(postgres,
+										 primaryNode,
+										 PG_AUTOCTL_REPLICA_USERNAME,
+										 config->replication_password,
+										 config->replication_slot_name,
+										 config->maximum_backup_rate,
+										 config->backupDirectory,
+										 NULL, /* no targetLSN */
+										 config->pgSetup.ssl,
+										 assignedState->nodeId))
+	{
+		/* can't happen at the moment */
+		return false;
+	}
+
+	do {
+		if (firstLoop)
+		{
+			firstLoop = false;
+		}
+		else
+		{
+			sleep(PG_AUTOCTL_KEEPER_SLEEP_TIME);
+		}
+
+		if (!upstream_has_replication_slot(upstream,
+										   &(config->pgSetup),
+										   &hasReplicationSlot))
+		{
+			++errors;
+
+			log_warn("Failed to contact the primary node %d \"%s\" (%s:%d)",
+					 primaryNode->nodeId,
+					 primaryNode->name,
+					 primaryNode->host,
+					 primaryNode->port);
+
+			if (errors > 5)
+			{
+				log_error("Failed to contact the primary 5 times in a row now, "
+						  "so we stop trying. You can do `pg_autoctl create` "
+						  "to retry and finish the local setup");
+				return false;
+			}
+		}
+
+		++tries;
+
+		if (!!hasReplicationSlot && tries == 3)
+		{
+			log_info("Still waiting for the to create our replication slot");
+			log_warn("Please make sure that the primary node is currently "
+					 "running `pg_autoctl run` and contacting the monitor.");
+		}
+	} while (!hasReplicationSlot);
 
 	return true;
 }

--- a/src/bin/pg_autoctl/keeper_pg_init.c
+++ b/src/bin/pg_autoctl/keeper_pg_init.c
@@ -685,7 +685,7 @@ wait_until_primary_has_created_our_replication_slot(Keeper *keeper,
 
 		++tries;
 
-		if (!!hasReplicationSlot && tries == 3)
+		if (!hasReplicationSlot && tries == 3)
 		{
 			log_info("Still waiting for the to create our replication slot");
 			log_warn("Please make sure that the primary node is currently "

--- a/src/bin/pg_autoctl/pgsql.c
+++ b/src/bin/pg_autoctl/pgsql.c
@@ -1117,7 +1117,7 @@ pgsql_replication_slot_exists(PGSQL *pgsql, const char *slotName,
 	SingleValueResultContext context = { { 0 }, PGSQL_RESULT_BOOL, false };
 	char *sql = "SELECT 1 FROM pg_replication_slots WHERE slot_name = $1";
 	int paramCount = 1;
-	Oid paramTypes[1] = { TEXTOID };
+	Oid paramTypes[1] = { NAMEOID };
 	const char *paramValues[1] = { slotName };
 
 	if (!pgsql_execute_with_params(pgsql, sql,

--- a/src/bin/pg_autoctl/pgsql.h
+++ b/src/bin/pg_autoctl/pgsql.h
@@ -56,7 +56,8 @@ typedef enum
 {
 	PGSQL_CONN_LOCAL = 0,
 	PGSQL_CONN_MONITOR,
-	PGSQL_CONN_COORDINATOR
+	PGSQL_CONN_COORDINATOR,
+	PGSQL_CONN_UPSTREAM
 } ConnectionType;
 
 
@@ -256,6 +257,8 @@ bool pgsql_check_postgresql_settings(PGSQL *pgsql, bool isCitusInstanceKind,
 bool pgsql_check_monitor_settings(PGSQL *pgsql, bool *settings_are_ok);
 bool pgsql_is_in_recovery(PGSQL *pgsql, bool *is_in_recovery);
 bool pgsql_reload_conf(PGSQL *pgsql);
+bool pgsql_replication_slot_exists(PGSQL *pgsql, const char *slotName,
+								   bool *slotExists);
 bool pgsql_create_replication_slot(PGSQL *pgsql, const char *slotName);
 bool pgsql_drop_replication_slot(PGSQL *pgsql, const char *slotName);
 bool postgres_sprintf_replicationSlotName(int nodeId, char *slotName, int size);

--- a/src/bin/pg_autoctl/pgsql.h
+++ b/src/bin/pg_autoctl/pgsql.h
@@ -248,6 +248,7 @@ void pgsql_set_init_retry_policy(PGSQL *pgsql);
 void pgsql_set_interactive_retry_policy(PGSQL *pgsql);
 void pgsql_finish(PGSQL *pgsql);
 void parseSingleValueResult(void *ctx, PGresult *result);
+void fetchedRows(void *ctx, PGresult *result);
 bool pgsql_execute(PGSQL *pgsql, const char *sql);
 bool pgsql_execute_with_params(PGSQL *pgsql, const char *sql, int paramCount,
 							   const Oid *paramTypes, const char **paramValues,
@@ -264,8 +265,8 @@ bool pgsql_drop_replication_slot(PGSQL *pgsql, const char *slotName);
 bool postgres_sprintf_replicationSlotName(int nodeId, char *slotName, int size);
 bool pgsql_set_synchronous_standby_names(PGSQL *pgsql,
 										 char *synchronous_standby_names);
-bool pgsql_replication_slot_drop_removed(PGSQL *pgsql,
-										 NodeAddressArray *nodeArray);
+bool pgsql_replication_slot_create_and_drop(PGSQL *pgsql,
+											NodeAddressArray *nodeArray);
 bool pgsql_replication_slot_maintain(PGSQL *pgsql, NodeAddressArray *nodeArray);
 bool postgres_sprintf_replicationSlotName(int nodeId, char *slotName, int size);
 bool pgsql_enable_synchronous_replication(PGSQL *pgsql);

--- a/src/bin/pg_autoctl/primary_standby.c
+++ b/src/bin/pg_autoctl/primary_standby.c
@@ -383,6 +383,10 @@ upstream_has_replication_slot(ReplicationSource *upstream,
 	upstreamSetup.pgport = primaryNode->port;
 	upstreamSetup.ssl = pgSetup->ssl;
 
+	/*
+	 * Build the connection string as if to a local node, but we tweaked the
+	 * pgsetup to target the primary node by changing its pghost and pgport.
+	 */
 	pg_setup_get_local_connection_string(&upstreamSetup, connectionString);
 
 	if (!pgsql_init(&upstreamClient, connectionString, PGSQL_CONN_UPSTREAM))

--- a/src/bin/pg_autoctl/primary_standby.h
+++ b/src/bin/pg_autoctl/primary_standby.h
@@ -62,6 +62,9 @@ bool ensure_postgres_service_is_stopped(LocalPostgresServer *postgres);
 
 bool primary_has_replica(LocalPostgresServer *postgres, char *userName,
 						 bool *hasStandby);
+bool upstream_has_replication_slot(ReplicationSource *upstream,
+								   PostgresSetup *pgSetup,
+								   bool *hasReplicationSlot);
 bool primary_create_replication_slot(LocalPostgresServer *postgres,
 									 char *replicationSlotName);
 bool primary_drop_replication_slot(LocalPostgresServer *postgres,

--- a/src/bin/pg_autoctl/primary_standby.h
+++ b/src/bin/pg_autoctl/primary_standby.h
@@ -71,8 +71,8 @@ bool primary_drop_replication_slot(LocalPostgresServer *postgres,
 								   char *replicationSlotName);
 bool primary_drop_replication_slots(LocalPostgresServer *postgres);
 bool primary_set_synchronous_standby_names(LocalPostgresServer *postgres);
-bool postgres_replication_slot_drop_removed(LocalPostgresServer *postgres,
-											NodeAddressArray *nodeArray);
+bool postgres_replication_slot_create_and_drop(LocalPostgresServer *postgres,
+											   NodeAddressArray *nodeArray);
 bool postgres_replication_slot_maintain(LocalPostgresServer *postgres,
 										NodeAddressArray *nodeArray);
 bool primary_enable_synchronous_replication(LocalPostgresServer *postgres);


### PR DESCRIPTION
A bug has been found where if we have a single standby and it's in maintenance, we can't add another standby. That's not nice, and to fix it, we need to allow registering a new standby node while the primary is in the WAIT_PRIMARY state. The reason for this state could either be that a standby is in maintenance, or that another standby is concurrently registering to the primary.

To fix, we now lift the limitation that only one standby can be registered at a single time. This way we can register a standby even when the primary is in the WAIT_PRIMARY state already, or even in the JOIN_PRIMARY or APPLY_SETTINGS state. For this to work, some responsibilities are added to the client side of things, where it's now necessary to check for the replication slot creation before moving on, even when the local node has been cleared with registration and assigned CATCHING-UP already.

Fixes #392.