### PR TITLE
Fix a corner case which leaves a node in JOIN_PRIMARY state.

### DIFF
--- a/src/bin/pg_autoctl/fsm_transition.c
+++ b/src/bin/pg_autoctl/fsm_transition.c
@@ -414,15 +414,6 @@ fsm_disable_replication(Keeper *keeper)
 bool
 fsm_resume_as_primary(Keeper *keeper)
 {
-	LocalPostgresServer *postgres = &(keeper->postgres);
-
-	if (!ensure_postgres_service_is_running(postgres))
-	{
-		log_error("Failed to promote postgres because the server could not "
-				  "be started before promotion, see above for details");
-		return false;
-	}
-
 	if (!fsm_disable_replication(keeper))
 	{
 		log_error("Failed to disable synchronous replication in order to "

--- a/src/bin/pg_autoctl/fsm_transition.c
+++ b/src/bin/pg_autoctl/fsm_transition.c
@@ -376,6 +376,12 @@ fsm_disable_replication(Keeper *keeper)
 {
 	LocalPostgresServer *postgres = &(keeper->postgres);
 
+	if (!ensure_postgres_service_is_running(postgres))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
 	if (!primary_disable_synchronous_replication(postgres))
 	{
 		log_error("Failed to disable replication because disabling synchronous "

--- a/src/monitor/group_state_machine.c
+++ b/src/monitor/group_state_machine.c
@@ -892,24 +892,25 @@ ProceedGroupStateForPrimaryNode(AutoFailoverNode *primaryNode)
 		IsCurrentState(primaryNode, REPLICATION_STATE_JOIN_PRIMARY))
 	{
 		ListCell *nodeCell = NULL;
-		bool allSecondariesAreGood = true;
+		bool allSecondariesAreHealthy = true;
 
 		foreach(nodeCell, otherNodesGroupList)
 		{
 			AutoFailoverNode *otherNode = (AutoFailoverNode *) lfirst(nodeCell);
 
-			allSecondariesAreGood = allSecondariesAreGood &&
-									IsCurrentState(otherNode,
-												   REPLICATION_STATE_SECONDARY) &&
-									IsHealthy(otherNode);
+			allSecondariesAreHealthy =
+				allSecondariesAreHealthy &&
+				IsCurrentState(otherNode,
+							   REPLICATION_STATE_SECONDARY) &&
+				IsHealthy(otherNode);
 
-			if (!allSecondariesAreGood)
+			if (!allSecondariesAreHealthy)
 			{
 				break;
 			}
 		}
 
-		if (allSecondariesAreGood)
+		if (allSecondariesAreHealthy)
 		{
 			char message[BUFSIZE] = { 0 };
 

--- a/src/monitor/node_active_protocol.c
+++ b/src/monitor/node_active_protocol.c
@@ -1046,6 +1046,8 @@ RemoveNode(AutoFailoverNode *currentNode)
 	ListCell *nodeCell = NULL;
 	AutoFailoverNode *firstStandbyNode = NULL;
 
+	char message[BUFSIZE] = { 0 };
+
 	if (currentNode == NULL)
 	{
 		return false;
@@ -1096,6 +1098,16 @@ RemoveNode(AutoFailoverNode *currentNode)
 
 	/* time to actually remove the current node */
 	RemoveAutoFailoverNode(currentNode);
+
+	LogAndNotifyMessage(
+		message, BUFSIZE,
+		"Removing node %d \"%s\" (%s:%d) from formation \"%s\" and group %d",
+		currentNode->nodeId,
+		currentNode->nodeName,
+		currentNode->nodeHost,
+		currentNode->nodePort,
+		currentNode->formationId,
+		currentNode->groupId);
 
 	/* now proceed with the failover, starting with the first standby */
 	if (currentNodeIsPrimary)


### PR DESCRIPTION
When removing a standby node just after creating it, and before running its
pg_autoctl service, then it's still in the CATCHINGUP state, and the primary
is waiting in the JOIN_PRIMARY state. At removal of the standby, the primary
should feel free to set itself back to PRIMARY again.

Fixes #393.