### PR TITLE
When secondary, don't ensure current state before a transition.

### DIFF
--- a/src/bin/pg_autoctl/keeper.c
+++ b/src/bin/pg_autoctl/keeper.c
@@ -171,6 +171,17 @@ keeper_should_ensure_current_state_before_transition(Keeper *keeper)
 		return false;
 	}
 
+	if (keeperState->current_role == SECONDARY_STATE &&
+		keeperState->assigned_role != SECONDARY_STATE)
+	{
+		/*
+		 * We might have a different primary server to reconnect to, or be
+		 * asked to report lsn, etc. Ensuring the secondary state does not
+		 * sound productive there.
+		 */
+		return false;
+	}
+
 	/* in all other cases, yes please ensure the current state */
 	return true;
 }

--- a/src/bin/pg_autoctl/primary_standby.c
+++ b/src/bin/pg_autoctl/primary_standby.c
@@ -1132,6 +1132,13 @@ standby_follow_new_primary(LocalPostgresServer *postgres)
 
 	log_info("Follow new primary %s:%d", primaryNode->host, primaryNode->port);
 
+	if (!pgctl_identify_system(replicationSource))
+	{
+		log_error("Failed to establish a replication connection "
+				  "to the new primary, see above for details");
+		return false;
+	}
+
 	/* cleanup our existing standby setup, including postgresql.auto.conf */
 	if (!pg_cleanup_standby_mode(pgSetup->control.pg_control_version,
 								 pgSetup->pg_ctl,
@@ -1284,6 +1291,13 @@ standby_restart_with_current_replication_source(LocalPostgresServer *postgres)
 	PGSQL *pgsql = &(postgres->sqlClient);
 	PostgresSetup *pgSetup = &(postgres->postgresSetup);
 	ReplicationSource *replicationSource = &(postgres->replicationSource);
+
+	if (!pgctl_identify_system(replicationSource))
+	{
+		log_error("Failed to establish a replication connection "
+				  "to the primary node, see above for details");
+		return false;
+	}
 
 	/* cleanup our existing standby setup, including postgresql.auto.conf */
 	if (!pg_cleanup_standby_mode(pgSetup->control.pg_control_version,


### PR DESCRIPTION
Getting out of the secondary state means we should not ensure the secondary
state anymore, it's already too late. We had cases of Postgres being
restarted because of that, and if that happens when we don't have a recovery
setup in place, then Postgres restarts as a primary. Then it can't be a
secondary again anymore, WAL are "corrupted".