### PR TITLE
Fix some problems in make cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,8 @@ FIRST_PGPORT ?= 5500
 
 TMUX_EXTRA_COMMANDS ?= ""
 TMUX_LAYOUT ?= even-vertical	# could be "tiled"
-TMUX_TOP_DIR = ./tmux
-TMUX_SCRIPT = ./tmux/script-$(FIRST_PGPORT).tmux
+TMUX_TOP_DIR = $(PWD)/tmux
+TMUX_SCRIPT = $(TMUX_TOP_DIR)/script-$(FIRST_PGPORT).tmux
 
 all: monitor bin ;
 

--- a/src/bin/pg_autoctl/cli_do_tmux.c
+++ b/src/bin/pg_autoctl/cli_do_tmux.c
@@ -316,11 +316,12 @@ tmux_pg_autoctl_create(PQExpBuffer script,
 								   name);
 
 		tmux_add_send_keys_command(script,
-								   "%s create %s %s --monitor %s --run",
+								   "%s create %s %s --monitor %s --name %s --run",
 								   pg_autoctl_argv0,
 								   role,
 								   pg_ctl_opts,
-								   monitor);
+								   monitor,
+								   name);
 	}
 }
 
@@ -371,7 +372,7 @@ cli_do_tmux_script(int argc, char **argv)
 			/* on the primary, wait until the monitor is ready */
 			tmux_add_send_keys_command(script, "sleep 2");
 			tmux_add_send_keys_command(script,
-									   "%s do pgsetup wait --pgdata %s/monitor",
+									   "PG_AUTOCTL_DEBUG=1 %s do pgsetup wait --pgdata %s/monitor",
 									   pg_autoctl_argv0,
 									   options.root);
 		}
@@ -380,7 +381,7 @@ cli_do_tmux_script(int argc, char **argv)
 			/* on the other nodes, wait until the primary is ready */
 			tmux_add_send_keys_command(script, "sleep 2");
 			tmux_add_send_keys_command(script,
-									   "%s do pgsetup wait --pgdata %s/node1",
+									   "PG_AUTOCTL_DEBUG=1 %s do pgsetup wait --pgdata %s/node1",
 									   pg_autoctl_argv0,
 									   options.root);
 		}
@@ -405,6 +406,7 @@ cli_do_tmux_script(int argc, char **argv)
 
 	tmux_add_xdg_environment(script, root);
 	tmux_add_send_keys_command(script, "export PGDATA=\"%s/monitor\"", root);
+	tmux_add_send_keys_command(script, "cd \"%s\"", root);
 
 	/* now select our target layout */
 	tmux_add_command(script, "select-layout %s", options.layout);

--- a/src/bin/pg_autoctl/monitor.c
+++ b/src/bin/pg_autoctl/monitor.c
@@ -1641,7 +1641,7 @@ monitor_print_state(Monitor *monitor, char *formation, int group)
 		{
 			sql =
 				"SELECT * FROM pgautofailover.current_state($1) "
-				"ORDER BY node_id";
+				"ORDER BY nodename";
 
 			paramCount = 1;
 			paramTypes[0] = TEXTOID;
@@ -1654,7 +1654,7 @@ monitor_print_state(Monitor *monitor, char *formation, int group)
 		{
 			sql =
 				"SELECT * FROM pgautofailover.current_state($1,$2) "
-				"ORDER BY node_id";
+				"ORDER BY nodename";
 
 			groupStr = intToString(group);
 


### PR DESCRIPTION
My main problems were with the fact that nodes were spawned at the same
time and the node with name `node_2` was not the node with directory
`node2`. This is fixed by doing three things:
1. Adding `--name` to the create commands
2. Make `show state` order by name instead of nodeid, so `node2` would
   actually be above `node3` in the table
3. Fix the `do wait` commands to use `PG_AUTOCTL_DEBUG`.

My other issue was that I could not use `--pgdata node2` in the
interactive shell. This had two reasons:
1. It did not actually `cd` to the `TMUX_ROOT` directory
2. The `XDG` paths were relative, so once I `cd`ed there the XDG paths
   were suddenly wrong.