### PR TITLE
Feature/tmux session

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,6 @@ tmux-clean:
 	rm -rf $(TMUX_TOP_DIR)
 
 cluster: install
-	rm -rf $(TMUX_TOP_DIR)
 	$(PG_AUTOCTL) do tmux session        \
          --root $(TMUX_TOP_DIR)          \
          --first-pgport $(FIRST_PGPORT)  \

--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,7 @@ tmux-clean:
 	rm -rf $(TMUX_TOP_DIR)
 
 cluster: install
+	rm -rf $(TMUX_TOP_DIR)
 	$(PG_AUTOCTL) do tmux session        \
          --root $(TMUX_TOP_DIR)          \
          --first-pgport $(FIRST_PGPORT)  \

--- a/Makefile
+++ b/Makefile
@@ -117,11 +117,11 @@ tmux-clean:
 	rm -rf $(TMUX_TOP_DIR)
 
 cluster: install
-	$(MAKE) tmux-clean
-	$(MAKE) tmux-script
-	mkdir -p $(TMUX_TOP_DIR)/run
-	tmux start-server \; source-file $(TMUX_SCRIPT)
-	pkill pg_autoctl || true
+	$(PG_AUTOCTL) do tmux session        \
+         --root $(TMUX_TOP_DIR)          \
+         --first-pgport $(FIRST_PGPORT)  \
+         --nodes $(NODES)                \
+         --layout $(TMUX_LAYOUT)
 
 .PHONY: all clean check install docs
 .PHONY: monitor clean-monitor check-monitor install-monitor

--- a/src/bin/pg_autoctl/cli_do_root.c
+++ b/src/bin/pg_autoctl/cli_do_root.c
@@ -234,14 +234,39 @@ CommandLine do_tmux_script =
 	make_command("script",
 				 "Produce a tmux script for a demo or a test case",
 				 "[option ...]",
-				 "  --root          path where to create a cluster\n" \
-				 "  --first-port    first Postgres port to use (5500)\n" \
-				 "  --nodes         number of Postgres nodes to create (2)",
+				 "  --root          path where to create a cluster\n"
+				 "  --first-pgport  first Postgres port to use (5500)\n"
+				 "  --nodes         number of Postgres nodes to create (2)"
+				 "  --layout        tmux layout to use (even-vertical)",
 				 cli_do_tmux_script_getopts,
 				 cli_do_tmux_script);
 
+CommandLine do_tmux_session =
+	make_command("session",
+				 "Run a a tmux session for a demo or a test case",
+				 "[option ...]",
+				 "  --root          path where to create a cluster\n"
+				 "  --first-pgport  first Postgres port to use (5500)\n"
+				 "  --nodes         number of Postgres nodes to create (2)"
+				 "  --layout        tmux layout to use (even-vertical)",
+				 cli_do_tmux_script_getopts,
+				 cli_do_tmux_session);
+
+CommandLine do_tmux_stop =
+	make_command("stop",
+				 "Stop pg_autoctl processed that belong to a tmux session ",
+				 "[option ...]",
+				 "  --root          path where to create a cluster\n"
+				 "  --first-pgport  first Postgres port to use (5500)\n"
+				 "  --nodes         number of Postgres nodes to create (2)"
+				 "  --layout        tmux layout to use (even-vertical)",
+				 cli_do_tmux_script_getopts,
+				 cli_do_tmux_stop);
+
 CommandLine *do_tmux[] = {
 	&do_tmux_script,
+	&do_tmux_session,
+	&do_tmux_stop,
 	NULL
 };
 

--- a/src/bin/pg_autoctl/cli_do_root.c
+++ b/src/bin/pg_autoctl/cli_do_root.c
@@ -255,13 +255,23 @@ CommandLine do_tmux_session =
 
 CommandLine do_tmux_stop =
 	make_command("stop",
-				 "Stop pg_autoctl processed that belong to a tmux session ",
+				 "Stop pg_autoctl processes that belong to a tmux session ",
 				 "[option ...]",
 				 "  --root          path where to create a cluster\n"
 				 "  --first-pgport  first Postgres port to use (5500)\n"
 				 "  --nodes         number of Postgres nodes to create (2)",
 				 cli_do_tmux_script_getopts,
 				 cli_do_tmux_stop);
+
+CommandLine do_tmux_clean =
+	make_command("clean",
+				 "Clean-up a tmux session processes and root dir",
+				 "[option ...]",
+				 "  --root          path where to create a cluster\n"
+				 "  --first-pgport  first Postgres port to use (5500)\n"
+				 "  --nodes         number of Postgres nodes to create (2)",
+				 cli_do_tmux_script_getopts,
+				 cli_do_tmux_clean);
 
 CommandLine do_tmux_wait =
 	make_command("wait",
@@ -278,6 +288,7 @@ CommandLine *do_tmux[] = {
 	&do_tmux_session,
 	&do_tmux_stop,
 	&do_tmux_wait,
+	&do_tmux_clean,
 	NULL
 };
 

--- a/src/bin/pg_autoctl/cli_do_root.c
+++ b/src/bin/pg_autoctl/cli_do_root.c
@@ -252,21 +252,32 @@ CommandLine do_tmux_session =
 				 cli_do_tmux_script_getopts,
 				 cli_do_tmux_session);
 
+
 CommandLine do_tmux_stop =
 	make_command("stop",
 				 "Stop pg_autoctl processed that belong to a tmux session ",
 				 "[option ...]",
 				 "  --root          path where to create a cluster\n"
 				 "  --first-pgport  first Postgres port to use (5500)\n"
-				 "  --nodes         number of Postgres nodes to create (2)"
-				 "  --layout        tmux layout to use (even-vertical)",
+				 "  --nodes         number of Postgres nodes to create (2)",
 				 cli_do_tmux_script_getopts,
 				 cli_do_tmux_stop);
+
+CommandLine do_tmux_wait =
+	make_command("wait",
+				 "Wait until a given node has been registered on the monitor",
+				 "[option ...] nodename",
+				 "  --root          path where to create a cluster\n"
+				 "  --first-pgport  first Postgres port to use (5500)\n"
+				 "  --nodes         number of Postgres nodes to create (2)",
+				 cli_do_tmux_script_getopts,
+				 cli_do_tmux_wait);
 
 CommandLine *do_tmux[] = {
 	&do_tmux_script,
 	&do_tmux_session,
 	&do_tmux_stop,
+	&do_tmux_wait,
 	NULL
 };
 

--- a/src/bin/pg_autoctl/cli_do_root.c
+++ b/src/bin/pg_autoctl/cli_do_root.c
@@ -232,11 +232,11 @@ CommandLine do_pgsetup_commands =
 
 CommandLine do_tmux_script =
 	make_command("script",
-				 "Produce a tmux script for a demo or a test case",
+				 "Produce a tmux script for a demo or a test case (debug only)",
 				 "[option ...]",
 				 "  --root          path where to create a cluster\n"
 				 "  --first-pgport  first Postgres port to use (5500)\n"
-				 "  --nodes         number of Postgres nodes to create (2)"
+				 "  --nodes         number of Postgres nodes to create (2)\n"
 				 "  --layout        tmux layout to use (even-vertical)",
 				 cli_do_tmux_script_getopts,
 				 cli_do_tmux_script);
@@ -247,7 +247,7 @@ CommandLine do_tmux_session =
 				 "[option ...]",
 				 "  --root          path where to create a cluster\n"
 				 "  --first-pgport  first Postgres port to use (5500)\n"
-				 "  --nodes         number of Postgres nodes to create (2)"
+				 "  --nodes         number of Postgres nodes to create (2)\n"
 				 "  --layout        tmux layout to use (even-vertical)",
 				 cli_do_tmux_script_getopts,
 				 cli_do_tmux_session);

--- a/src/bin/pg_autoctl/cli_do_root.h
+++ b/src/bin/pg_autoctl/cli_do_root.h
@@ -91,5 +91,7 @@ void keeper_cli_identify_system(int argc, char **argv);
 /* src/bin/pg_autoctl/cli_do_tmux.c */
 int cli_do_tmux_script_getopts(int argc, char **argv);
 void cli_do_tmux_script(int argc, char **argv);
+void cli_do_tmux_session(int argc, char **argv);
+void cli_do_tmux_stop(int argc, char **argv);
 
 #endif  /* CLI_DO_ROOT_H */

--- a/src/bin/pg_autoctl/cli_do_root.h
+++ b/src/bin/pg_autoctl/cli_do_root.h
@@ -93,6 +93,7 @@ int cli_do_tmux_script_getopts(int argc, char **argv);
 void cli_do_tmux_script(int argc, char **argv);
 void cli_do_tmux_session(int argc, char **argv);
 void cli_do_tmux_stop(int argc, char **argv);
+void cli_do_tmux_clean(int argc, char **argv);
 void cli_do_tmux_wait(int argc, char **argv);
 
 #endif  /* CLI_DO_ROOT_H */

--- a/src/bin/pg_autoctl/cli_do_root.h
+++ b/src/bin/pg_autoctl/cli_do_root.h
@@ -93,5 +93,6 @@ int cli_do_tmux_script_getopts(int argc, char **argv);
 void cli_do_tmux_script(int argc, char **argv);
 void cli_do_tmux_session(int argc, char **argv);
 void cli_do_tmux_stop(int argc, char **argv);
+void cli_do_tmux_wait(int argc, char **argv);
 
 #endif  /* CLI_DO_ROOT_H */

--- a/src/bin/pg_autoctl/cli_do_tmux.c
+++ b/src/bin/pg_autoctl/cli_do_tmux.c
@@ -540,6 +540,12 @@ tmux_start_server(const char *root, const char *scriptName)
 		return false;
 	}
 
+	if (setenv("PG_AUTOCTL_DEBUG", "1", 1) != 0)
+	{
+		log_error("Failed to set environment PG_AUTOCTL_DEBUG: %m");
+		return false;
+	}
+
 	if (!search_path_first("tmux", tmux))
 	{
 		log_fatal("Failed to find program tmux in PATH");

--- a/src/bin/pg_autoctl/cli_do_tmux.c
+++ b/src/bin/pg_autoctl/cli_do_tmux.c
@@ -987,7 +987,9 @@ cli_do_tmux_wait(int argc, char **argv)
 		log_info("Waiting for creation of a state file at \"%s\"",
 				 pathnames.state);
 
-		while (!file_exists(pathnames.state) && timeout > 0)
+		while (!file_exists(pathnames.state) &&
+			   !file_exists(pathnames.init) &&
+			   timeout > 0)
 		{
 			sleep(1);
 			--timeout;

--- a/src/bin/pg_autoctl/cli_do_tmux.c
+++ b/src/bin/pg_autoctl/cli_do_tmux.c
@@ -614,7 +614,7 @@ tmux_stop_pg_autoctl(TmuxOptions *options)
 	/* signal processes using increasing levels of urge to quit now */
 	for (int s = 0; s < signalsCount; s++)
 	{
-		bool countRunning = options->nodes;
+		int countRunning = options->nodes + 1;
 
 		for (int i = 0; i <= options->nodes; i++)
 		{

--- a/src/bin/pg_autoctl/cli_do_tmux.c
+++ b/src/bin/pg_autoctl/cli_do_tmux.c
@@ -329,7 +329,11 @@ tmux_prepare_XDG_environment(const char *root, bool createDirectories)
 			char targetPath[MAXPGPATH] = { 0 };
 
 			sformat(targetPath, sizeof(targetPath),
-					"%s/pg_config/%s", env, root);
+					"%s/pg_config/%s",
+					env,
+
+			        /* skip first / in the root directory */
+					root[0] == '/' ? root + 1 : root);
 
 			log_debug("mkdir -p \"%s\"", targetPath);
 			if (pg_mkdir_p(targetPath, 0700) == -1)

--- a/src/bin/pg_autoctl/cli_do_tmux.c
+++ b/src/bin/pg_autoctl/cli_do_tmux.c
@@ -9,9 +9,13 @@
  */
 
 #include <errno.h>
+#include <fcntl.h>
 #include <getopt.h>
 #include <inttypes.h>
+#include <termios.h>
 #include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
 
 #include "postgres_fe.h"
 #include "pqexpbuffer.h"
@@ -23,8 +27,10 @@
 #include "commandline.h"
 #include "config.h"
 #include "env_utils.h"
+#include "log.h"
 #include "string_utils.h"
 
+#include "runprogram.h"
 
 typedef struct TmuxOptions
 {
@@ -36,6 +42,13 @@ typedef struct TmuxOptions
 
 static TmuxOptions tmuxOptions = { 0 };
 
+char *xdg[][3] = {
+	{ "XDG_DATA_HOME", "share" },
+	{ "XDG_CONFIG_HOME", "config" },
+	{ "XDG_RUNTIME_DIR", "run" },
+	{ NULL, NULL }
+};
+
 
 static void tmux_add_command(PQExpBuffer script, const char *fmt, ...)
 __attribute__((format(printf, 2, 3)));
@@ -44,6 +57,7 @@ static void tmux_add_send_keys_command(PQExpBuffer script, const char *fmt, ...)
 __attribute__((format(printf, 2, 3)));
 
 static void tmux_add_xdg_environment(PQExpBuffer script, const char *root);
+static bool tmux_prepare_XDG_environment(const char *root);
 
 static void tmux_pg_autoctl_create_monitor(PQExpBuffer script,
 										   const char *root,
@@ -55,6 +69,11 @@ static void tmux_pg_autoctl_create_postgres(PQExpBuffer script,
 											int pgport,
 											const char *name,
 											bool setXDG);
+
+static bool tmux_start_server(const char *root, const char *scriptName);
+static bool pg_autoctl_stop(const char *root, const char *name);
+static bool tmux_stop_pg_autoctl(TmuxOptions *options);
+
 
 /*
  * cli_print_version_getopts parses the CLI options for the pg_autoctl version
@@ -251,6 +270,53 @@ tmux_add_send_keys_command(PQExpBuffer script, const char *fmt, ...)
 
 
 /*
+ * tmux_prepare_XDG_environment set XDG environment variables in the current
+ * process tree.
+ */
+static bool
+tmux_prepare_XDG_environment(const char *root)
+{
+	for (int i = 0; xdg[i][0] != NULL; i++)
+	{
+		char *var = xdg[i][0];
+		char *dir = xdg[i][1];
+		char *env = (char *) malloc(MAXPGPATH * sizeof(char));
+
+		if (env == NULL)
+		{
+			log_fatal("Failed to malloc MAXPGPATH bytes: %m");
+			return false;
+		}
+
+		sformat(env, MAXPGPATH, "%s/%s", root, dir);
+
+		log_debug("mkdir -p \"%s\"", env);
+		if (!ensure_empty_dir(env, 0700))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+
+		if (!normalize_filename(env, env, MAXPGPATH))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+
+		log_info("export %s=\"%s\"", var, env);
+
+		if (setenv(var, env, 1) != 0)
+		{
+			log_error("Failed to set environment variable %s to \"%s\": %m",
+					  var, env);
+		}
+	}
+
+	return true;
+}
+
+
+/*
  * tmux_add_xdg_environment appends the XDG environment that makes the test
  * target self-contained, as a series of tmux send-keys commands, to the given
  * script buffer.
@@ -258,17 +324,11 @@ tmux_add_send_keys_command(PQExpBuffer script, const char *fmt, ...)
 static void
 tmux_add_xdg_environment(PQExpBuffer script, const char *root)
 {
-	char *xdg[][3] = {
-		{ "XDG_DATA_HOME", "share" },
-		{ "XDG_CONFIG_HOME", "config" },
-		{ "XDG_RUNTIME_DIR", "run" },
-	};
-
 	/*
 	 * For demo/tests purposes, arrange a self-contained setup where everything
 	 * is to be found in the given options.root directory.
 	 */
-	for (int i = 0; i < 3; i++)
+	for (int i = 0; xdg[i][0] != NULL; i++)
 	{
 		char *var = xdg[i][0];
 		char *dir = xdg[i][1];
@@ -415,7 +475,10 @@ prepare_tmux_script(TmuxOptions *options, PQExpBuffer script, bool setXDG)
 	tmux_add_command(script, "split-window -v");
 	tmux_add_command(script, "select-layout even-vertical");
 
-	tmux_add_xdg_environment(script, root);
+	if (setXDG)
+	{
+		tmux_add_xdg_environment(script, root);
+	}
 	tmux_add_send_keys_command(script, "export PGDATA=\"%s/monitor\"", root);
 	tmux_add_send_keys_command(script,
 							   "watch -n 0.2 %s show state",
@@ -425,7 +488,9 @@ prepare_tmux_script(TmuxOptions *options, PQExpBuffer script, bool setXDG)
 	tmux_add_command(script, "split-window -v");
 	tmux_add_command(script, "select-layout even-vertical");
 
+	/* seems that we need to inconditionnaly set the XDG env in this one */
 	tmux_add_xdg_environment(script, root);
+	tmux_add_send_keys_command(script, "cd \"%s\"", root);
 	tmux_add_send_keys_command(script, "export PGDATA=\"%s/monitor\"", root);
 
 	/* now select our target layout */
@@ -452,6 +517,179 @@ prepare_tmux_script(TmuxOptions *options, PQExpBuffer script, bool setXDG)
 			appendPQExpBuffer(script, "%s\n", extraLines[lineNumber]);
 		}
 	}
+}
+
+
+/*
+ * tmux_start_server starts a tmux session with the given script.
+ */
+static bool
+tmux_start_server(const char *root, const char *scriptName)
+{
+	Program program;
+
+	char *args[8];
+	int argsIndex = 0;
+
+	char tmux[MAXPGPATH] = { 0 };
+	char command[BUFSIZE] = { 0 };
+
+	/* prepare the XDG environment */
+	if (!tmux_prepare_XDG_environment(root))
+	{
+		return false;
+	}
+
+	if (!search_path_first("tmux", tmux))
+	{
+		log_fatal("Failed to find program tmux in PATH");
+		return false;
+	}
+
+	/*
+	 * Run the tmux command with our script:
+	 *   tmux start-server \; source-file ${scriptName}
+	 */
+	args[argsIndex++] = (char *) tmux;
+	args[argsIndex++] = "-v";
+	args[argsIndex++] = "start-server";
+	args[argsIndex++] = ";";
+	args[argsIndex++] = "source-file";
+	args[argsIndex++] = (char *) scriptName;
+	args[argsIndex] = NULL;
+
+	/* we do not want to call setsid() when running this program. */
+	program = initialize_program(args, false);
+
+	program.capture = false;    /* don't capture output */
+	program.tty = true;         /* allow sharing the parent's tty */
+
+	/* log the exact command line we're using */
+	(void) snprintf_program_command_line(&program, command, BUFSIZE);
+	log_info("%s", command);
+
+	(void) execute_subprogram(&program);
+
+	/* we only get there when the tmux session is done */
+	return true;
+}
+
+
+/*
+ * pg_autoctl_stop calls pg_autoctl stop --pgdata ${root}/${name}
+ */
+static bool
+pg_autoctl_stop(const char *root, const char *name)
+{
+	Program program;
+	char command[BUFSIZE] = { 0 };
+	char pgdata[MAXPGPATH] = { 0 };
+
+	bool success = true;
+
+	sformat(pgdata, sizeof(pgdata), "%s/%s", root, name);
+
+	program = run_program(pg_autoctl_argv0, "stop", "--pgdata", pgdata, NULL);
+
+	(void) snprintf_program_command_line(&program, command, BUFSIZE);
+	log_info("%s", command);
+
+	if (program.stdErr != NULL)
+	{
+		char *errorLines[BUFSIZE];
+		int lineCount = splitLines(program.stdErr, errorLines, BUFSIZE);
+		int lineNumber = 0;
+
+		for (lineNumber = 0; lineNumber < lineCount; lineNumber++)
+		{
+			fformat(stderr, "%s\n", errorLines[lineNumber]);
+		}
+	}
+
+	if (program.returnCode != 0)
+	{
+		success = false;
+		log_warn("Failed to stop pg_autoctl for \"%s\"", pgdata);
+	}
+
+	free_program(&program);
+
+	return success;
+}
+
+
+/*
+ * tmux_stop_pg_autoctl stops all started pg_autoctl programs in a tmux
+ * sessions.
+ */
+static bool
+tmux_stop_pg_autoctl(TmuxOptions *options)
+{
+	bool success = true;
+
+	/* first stop all the nodes */
+	for (int i = 0; i < options->nodes; i++)
+	{
+		char name[NAMEDATALEN] = { 0 };
+
+		sformat(name, sizeof(name), "node%d", i + 1);
+
+		success = success && pg_autoctl_stop(options->root, name);
+	}
+
+	/* and then the monitor */
+	success = success && pg_autoctl_stop(options->root, "monitor");
+
+	return success;
+}
+
+
+/*
+ * tmux_kill_session runs the command:
+ *   tmux kill-session -t pgautofailover-${first-pgport}
+ */
+static bool
+tmux_kill_session(TmuxOptions *options)
+{
+	Program program;
+	char tmux[MAXPGPATH] = { 0 };
+	char command[BUFSIZE] = { 0 };
+	char sessionName[BUFSIZE] = { 0 };
+
+	bool success = true;
+
+	sformat(sessionName, BUFSIZE, "pgautofailover-%d", options->firstPort);
+
+	if (!search_path_first("tmux", tmux))
+	{
+		log_fatal("Failed to find program tmux in PATH");
+		return false;
+	}
+
+	program = run_program(tmux, "kill-session", "-t", sessionName, NULL);
+
+	(void) snprintf_program_command_line(&program, command, BUFSIZE);
+	log_info("%s", command);
+
+	if (program.stdOut)
+	{
+		fformat(stdout, "%s", program.stdOut);
+	}
+
+	if (program.stdErr)
+	{
+		fformat(stderr, "%s", program.stdErr);
+	}
+
+	if (program.returnCode != 0)
+	{
+		success = false;
+		log_warn("Failed to kill tmux sessions \"%s\"", sessionName);
+	}
+
+	free_program(&program);
+
+	return success;
 }
 
 
@@ -486,4 +724,117 @@ cli_do_tmux_script(int argc, char **argv)
 	fformat(stdout, "%s", script->data);
 
 	destroyPQExpBuffer(script);
+}
+
+
+/*
+ * cli_do_tmux_session starts an interactive tmux session with the given
+ * specifications for a cluster. When the session is detached, the pg_autoctl
+ * processes are stopped.
+ */
+void
+cli_do_tmux_session(int argc, char **argv)
+{
+	TmuxOptions options = tmuxOptions;
+	PQExpBuffer script = createPQExpBuffer();
+
+	char scriptName[MAXPGPATH] = { 0 };
+
+	bool success = true;
+
+	/*
+	 * Write the script to "script-${first-pgport}.tmux" file in the root
+	 * directory.
+	 */
+	log_debug("mkdir -p \"%s\"", options.root);
+	if (!ensure_empty_dir(options.root, 0700))
+	{
+		/* errors have already been logged. */
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+
+	if (!normalize_filename(options.root, options.root, sizeof(options.root)))
+	{
+		/* errors have already been logged. */
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+
+	/*
+	 * Prepare the tmux script.
+	 */
+	if (script == NULL)
+	{
+		log_error("Failed to allocate memory");
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+
+	(void) prepare_tmux_script(&options, script, false);
+
+	/* memory allocation could have failed while building string */
+	if (PQExpBufferBroken(script))
+	{
+		log_error("Failed to allocate memory");
+		destroyPQExpBuffer(script);
+
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+
+	/*
+	 * Write the script to file.
+	 */
+	sformat(scriptName, sizeof(scriptName),
+			"%s/script-%d.tmux", options.root, options.firstPort);
+
+	log_info("Writing tmux session script \"%s\"", scriptName);
+
+	if (!write_file(script->data, script->len, scriptName))
+	{
+		log_fatal("Failed to write tmux script at \"%s\"", scriptName);
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+
+	destroyPQExpBuffer(script);
+
+	/*
+	 * Start a tmux session from the script.
+	 */
+	if (!tmux_start_server(options.root, scriptName))
+	{
+		success = false;
+		log_fatal("Failed to start the tmux session, see above for details");
+	}
+
+	/*
+	 * Stop our pg_autoctl processes and kill the tmux session.
+	 */
+	log_info("tmux session ended: kill pg_autoct processes");
+	success = success && tmux_stop_pg_autoctl(&options);
+	success = success && tmux_kill_session(&options);
+
+	if (!success)
+	{
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+}
+
+
+/*
+ * cli_do_tmux_stop runs pg_autoctl stop on all the pg_autoctl process that
+ * might be running in a tmux session.
+ */
+void
+cli_do_tmux_stop(int argc, char **argv)
+{
+	TmuxOptions options = tmuxOptions;
+
+	/* prepare the XDG environment */
+	if (!tmux_prepare_XDG_environment(options.root))
+	{
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+
+	if (!tmux_stop_pg_autoctl(&options))
+	{
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
 }

--- a/src/bin/pg_autoctl/config.c
+++ b/src/bin/pg_autoctl/config.c
@@ -159,7 +159,7 @@ SetConfigFilePath(ConfigFilePaths *pathnames, const char *pgdata)
 		{
 			log_error("Failed to build our configuration file pathname, "
 					  "see above.");
-			exit(EXIT_CODE_INTERNAL_ERROR);
+			return false;
 		}
 	}
 
@@ -188,7 +188,7 @@ SetStateFilePath(ConfigFilePaths *pathnames, const char *pgdata)
 		{
 			log_error("Failed to build pg_autoctl state file pathname, "
 					  "see above.");
-			exit(EXIT_CODE_INTERNAL_ERROR);
+			return false;
 		}
 	}
 	log_trace("SetStateFilePath: \"%s\"", pathnames->state);
@@ -203,7 +203,7 @@ SetStateFilePath(ConfigFilePaths *pathnames, const char *pgdata)
 		{
 			log_error("Failed to build pg_autoctl init state file pathname, "
 					  "see above.");
-			exit(EXIT_CODE_INTERNAL_ERROR);
+			return false;
 		}
 	}
 	log_trace("SetKeeperStateFilePath: \"%s\"", pathnames->init);
@@ -228,7 +228,7 @@ SetPidFilePath(ConfigFilePaths *pathnames, const char *pgdata)
 		{
 			log_error("Failed to build pg_autoctl pid file pathname, "
 					  "see above.");
-			exit(EXIT_CODE_INTERNAL_ERROR);
+			return false;
 		}
 	}
 


### PR DESCRIPTION
Implement `pg_autoctl do tmux session`, a command that starts the tmux session and then kills
the pg_autoctl process created within at exit, and the tmux session too.
It allows to finish the test session with `C-b d`.

See #407, which it kind of replaces, fixing the same list of problems in passing.