### PR TITLE
Fix taking control of an already running  Postgres instance.

### DIFF
--- a/src/bin/pg_autoctl/pgsetup.c
+++ b/src/bin/pg_autoctl/pgsetup.c
@@ -830,8 +830,9 @@ pg_setup_get_local_connection_string(PostgresSetup *pgSetup,
 
 
 /*
- * pg_setup_pgdata_exists returns true when the pg_controldata probe was
- * susccessful.
+ * pg_setup_pgdata_exists returns true when PGDATA exists, hosts a
+ * global/pg_control file (so that it looks like a Postgres cluster) and when
+ * the pg_controldata probe was successful.
  */
 bool
 pg_setup_pgdata_exists(PostgresSetup *pgSetup)
@@ -860,7 +861,10 @@ pg_setup_pgdata_exists(PostgresSetup *pgSetup)
 	{
 		bool missingPgdataIsOk = false;
 
-		return pg_controldata(pgSetup, missingPgdataIsOk);
+		/* errors are logged from within pg_controldata */
+		(void) pg_controldata(pgSetup, missingPgdataIsOk);
+
+		return pgSetup->control.system_identifier != 0;
 	}
 
 	return true;

--- a/src/bin/pg_autoctl/pgsetup.c
+++ b/src/bin/pg_autoctl/pgsetup.c
@@ -852,7 +852,18 @@ pg_setup_pgdata_exists(PostgresSetup *pgSetup)
 		return false;
 	}
 
-	return pgSetup->control.system_identifier != 0;
+	/*
+	 * Now that we know that PGDATA exists, let's grab the system identifier if
+	 * we don't have it already.
+	 */
+	if (pgSetup->control.system_identifier == 0)
+	{
+		bool missingPgdataIsOk = false;
+
+		return pg_controldata(pgSetup, missingPgdataIsOk);
+	}
+
+	return true;
 }
 
 


### PR DESCRIPTION
When we optimised away calls to `pg_controldata`, we missed that parts of the code depend on it having been run previously. This is another case of cache invalidation games, and we force getting the control data again when we don't have it in `pg_setup_pgdata_exists`. Given that fix, then we unblock a loop at https://github.com/citusdata/pg_auto_failover/blob/master/src/bin/pg_autoctl/service_postgres_ctl.c#L273 which otherwise is an infinite loop.

Fix #412.