### PR TITLE
We can run pg_autoctl without being the parent of Postgres.

### DIFF
--- a/src/bin/pg_autoctl/fsm_transition.c
+++ b/src/bin/pg_autoctl/fsm_transition.c
@@ -158,14 +158,6 @@ fsm_init_primary(Keeper *keeper)
 			return false;
 		}
 	}
-	else if (initState->pgInitState >= PRE_INIT_STATE_RUNNING)
-	{
-		log_error("PostgreSQL is already running at \"%s\", refusing to "
-				  "initialize a new cluster on-top of the current one.",
-				  pgSetup->pgdata);
-
-		return false;
-	}
 
 	/*
 	 * When the PostgreSQL instance either did not exist, or did exist but was


### PR DESCRIPTION
At the first opportunity where pg_autoctl needs to stop Postgres and then
start it again, such as at failover, coming back from maintenance, or after
a service restart, pg_autoctl will be the parent process of Postgres anyway.

Fixes #413 