### PR TITLE
Prepare release 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### pg_auto_failover v1.4.0 (September 2, 2020) ###
+### pg_auto_failover v1.4.0 (September 23, 2020) ###
 
 The main focus of this release is the new capability of pg_auto_failover to
 manage any number of standby nodes, where it used to manage only a single

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ the _replication quorum_ of Postgres.
 ## Dependencies
 
 At runtime, pg_auto_failover depends on only Postgres. Postgres versions 10,
-11, and 12 are currently supported.
+11, 12, and 13 are currently supported.
 
 At buildtime. pg_auto_failover depends on Postgres server development
 package like any other Postgres extensions (the server development package

--- a/src/bin/pg_autoctl/cli_common.c
+++ b/src/bin/pg_autoctl/cli_common.c
@@ -1187,7 +1187,7 @@ keeper_cli_print_version(int argc, char **argv)
 				"pg_autoctl extension version %s\n",
 				PG_AUTOCTL_EXTENSION_VERSION);
 		fformat(stdout, "compiled with %s\n", PG_VERSION_STR);
-		fformat(stdout, "compatible with Postgres 10, 11, and 12\n");
+		fformat(stdout, "compatible with Postgres 10, 11, 12, and 13\n");
 	}
 
 	exit(0);


### PR DESCRIPTION
 - update CHANGELOG date
 - add Postgres 13 to the list of supported Postgres versions