### PR TITLE
Fix when to ProceedWithMSFailover after a candidate is selected.

### DIFF
--- a/src/monitor/group_state_machine.c
+++ b/src/monitor/group_state_machine.c
@@ -1222,7 +1222,7 @@ ProceedWithMSFailover(AutoFailoverNode *activeNode,
 	 * as soon as it's ready.
 	 */
 	if (IsCurrentState(activeNode, REPLICATION_STATE_REPORT_LSN) &&
-		(IsBeingPromoted(candidateNode) ||
+		(CandidateNodeIsReadyToStreamWAL(candidateNode) ||
 		 IsCurrentState(candidateNode, REPLICATION_STATE_PRIMARY)))
 	{
 		char message[BUFSIZE];

--- a/src/monitor/group_state_machine.c
+++ b/src/monitor/group_state_machine.c
@@ -1222,9 +1222,8 @@ ProceedWithMSFailover(AutoFailoverNode *activeNode,
 	 * as soon as it's ready.
 	 */
 	if (IsCurrentState(activeNode, REPLICATION_STATE_REPORT_LSN) &&
-		(IsCurrentState(candidateNode, REPLICATION_STATE_PREPARE_PROMOTION) ||
-		 IsCurrentState(candidateNode, REPLICATION_STATE_STOP_REPLICATION) ||
-		 IsCurrentState(candidateNode, REPLICATION_STATE_WAIT_PRIMARY)))
+		(IsBeingPromoted(candidateNode) ||
+		 IsCurrentState(candidateNode, REPLICATION_STATE_PRIMARY)))
 	{
 		char message[BUFSIZE];
 

--- a/src/monitor/group_state_machine.c
+++ b/src/monitor/group_state_machine.c
@@ -1222,8 +1222,7 @@ ProceedWithMSFailover(AutoFailoverNode *activeNode,
 	 * as soon as it's ready.
 	 */
 	if (IsCurrentState(activeNode, REPLICATION_STATE_REPORT_LSN) &&
-		(CandidateNodeIsReadyToStreamWAL(candidateNode) ||
-		 IsCurrentState(candidateNode, REPLICATION_STATE_PRIMARY)))
+		CandidateNodeIsReadyToStreamWAL(candidateNode))
 	{
 		char message[BUFSIZE];
 

--- a/src/monitor/group_state_machine.c
+++ b/src/monitor/group_state_machine.c
@@ -648,9 +648,15 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 	 *
 	 * As there's no action to implement on the new selected primary for that
 	 * step, we can make progress as soon as we want to.
+	 *
+	 * The primary could be in one of those states:
+	 *  - wait_primary/wait_primary
+	 *  - wait_primary/primary
 	 */
 	if (IsCurrentState(activeNode, REPLICATION_STATE_JOIN_SECONDARY) &&
-		IsCurrentState(primaryNode, REPLICATION_STATE_WAIT_PRIMARY))
+		primaryNode->reportedState == REPLICATION_STATE_WAIT_PRIMARY &&
+		(primaryNode->goalState == REPLICATION_STATE_WAIT_PRIMARY ||
+		 primaryNode->goalState == REPLICATION_STATE_PRIMARY))
 	{
 		char message[BUFSIZE];
 

--- a/src/monitor/node_metadata.c
+++ b/src/monitor/node_metadata.c
@@ -1537,6 +1537,23 @@ IsBeingPromoted(AutoFailoverNode *node)
 
 
 /*
+ * CandidateNodeIsReadyToStreamWAL returns whether a newly selected candidate
+ * node, possibly still being promoted, is ready for the other standby nodes is
+ * REPORT_LSN to already use the new primary as an upstream node.
+ */
+bool
+CandidateNodeIsReadyToStreamWAL(AutoFailoverNode *node)
+{
+	return node != NULL &&
+		   (node->reportedState == REPLICATION_STATE_STOP_REPLICATION ||
+			node->goalState == REPLICATION_STATE_STOP_REPLICATION
+
+			|| node->reportedState == REPLICATION_STATE_WAIT_PRIMARY ||
+			node->goalState == REPLICATION_STATE_WAIT_PRIMARY);
+}
+
+
+/*
  * IsParticipatingInPromotion returns whether a node is currently participating
  * in a promotion, either as a candidate that IsBeingPromoted, or as a
  * "support" node that is reporting its LSN or re-joining as a secondary.

--- a/src/monitor/node_metadata.c
+++ b/src/monitor/node_metadata.c
@@ -1549,7 +1549,10 @@ CandidateNodeIsReadyToStreamWAL(AutoFailoverNode *node)
 			node->goalState == REPLICATION_STATE_STOP_REPLICATION
 
 			|| node->reportedState == REPLICATION_STATE_WAIT_PRIMARY ||
-			node->goalState == REPLICATION_STATE_WAIT_PRIMARY);
+			node->goalState == REPLICATION_STATE_WAIT_PRIMARY
+
+			|| node->reportedState == REPLICATION_STATE_PRIMARY ||
+			node->goalState == REPLICATION_STATE_PRIMARY);
 }
 
 

--- a/src/monitor/node_metadata.c
+++ b/src/monitor/node_metadata.c
@@ -1526,7 +1526,8 @@ IsBeingPromoted(AutoFailoverNode *node)
 {
 	return node != NULL &&
 		   ((node->reportedState == REPLICATION_STATE_REPORT_LSN &&
-			 node->goalState == REPLICATION_STATE_PREPARE_PROMOTION) ||
+			 (node->goalState == REPLICATION_STATE_FAST_FORWARD ||
+			  node->goalState == REPLICATION_STATE_PREPARE_PROMOTION)) ||
 
 			(node->reportedState == REPLICATION_STATE_FAST_FORWARD &&
 			 (node->goalState == REPLICATION_STATE_FAST_FORWARD ||

--- a/src/monitor/node_metadata.h
+++ b/src/monitor/node_metadata.h
@@ -201,6 +201,7 @@ extern bool CanTakeWritesInState(ReplicationState state);
 extern bool CanInitiateFailover(ReplicationState state);
 extern bool StateBelongsToPrimary(ReplicationState state);
 extern bool IsBeingPromoted(AutoFailoverNode *node);
+extern bool CandidateNodeIsReadyToStreamWAL(AutoFailoverNode *node);
 extern bool IsParticipatingInPromotion(AutoFailoverNode *node);
 extern bool IsInWaitOrJoinState(AutoFailoverNode *node);
 extern bool IsInPrimaryState(AutoFailoverNode *pgAutoFailoverNode);

--- a/tests/test_multi_async.py
+++ b/tests/test_multi_async.py
@@ -155,7 +155,7 @@ def test_010_promote_node1():
     print("Calling pgautofailover.perform_promotion(node1) on the monitor")
 
     # we don't use node1.perform_promotion() here because using the
-    # pg_autoctl client means we would lsiten to notification and get back
+    # pg_autoctl client means we would listen to notification and get back
     # to the rest of the code when the promotion is all over with
     #
     # we need to take control way before that, so just trigger the failover

--- a/tests/test_multi_async.py
+++ b/tests/test_multi_async.py
@@ -121,6 +121,8 @@ def test_008_set_sync_async():
     assert node2.set_replication_quorum("true")  # primary
     assert node3.set_replication_quorum("false") # secondary
 
+    assert node3.set_candidate_priority(0)
+
     assert node2.wait_until_state(target_state="primary")
 
 def test_009_add_sync_standby():


### PR DESCRIPTION
We might reach intermediate states on the newly elected primary such as
wait_primary/primary and in that situation we can already move forward and
have the secondary nodes re-configured to follow the new primary.