### PR TITLE
After removing a standby node, transition primary to apply settings

### DIFF
--- a/src/bin/pg_autoctl/cli_create_drop_node.c
+++ b/src/bin/pg_autoctl/cli_create_drop_node.c
@@ -1005,6 +1005,8 @@ cli_drop_node(int argc, char **argv)
 				exit(EXIT_CODE_BAD_ARGS);
 			}
 
+			/* TODO: Maybe update settings on primary? */
+
 			/* pg_autoctl drop node on the monitor drops another node */
 			(void) cli_drop_node_from_monitor(&config,
 											  config.hostname,

--- a/src/bin/pg_autoctl/fsm.c
+++ b/src/bin/pg_autoctl/fsm.c
@@ -313,7 +313,7 @@ KeeperFSMTransition KeeperFSM[] = {
 
 	/*
 	 * Applying new replication/cluster settings (per node replication quorum,
-	 * candidate priorities, or per formation number_sync_standbys) means we
+	 * candidate priorities, removing/adding a standby node, or per formation number_sync_standbys) means we
 	 * have to fetch the new value for synchronous_standby_names from the
 	 * monitor.
 	 */

--- a/src/bin/pg_autoctl/fsm.c
+++ b/src/bin/pg_autoctl/fsm.c
@@ -318,6 +318,11 @@ KeeperFSMTransition KeeperFSM[] = {
 	 * monitor.
 	 */
 	{ PRIMARY_STATE, APPLY_SETTINGS_STATE, COMMENT_PRIMARY_TO_APPLY_SETTINGS, &fsm_apply_settings },
+//	{ SINGLE_STATE, APPLY_SETTINGS_STATE, COMMENT_PRIMARY_TO_APPLY_SETTINGS, &fsm_apply_settings },
+	// TODO - add other transitions
+	// TODO - we beleive in `wait_primary` and `join_primary` as valid transitions like above
+	// Still don't feel good about `single` -- need explaination from Dimitri
+
 	{ APPLY_SETTINGS_STATE, PRIMARY_STATE, COMMENT_APPLY_SETTINGS_TO_PRIMARY, NULL },
 
 	/*

--- a/src/bin/pg_autoctl/fsm_transition.c
+++ b/src/bin/pg_autoctl/fsm_transition.c
@@ -617,7 +617,7 @@ fsm_enable_sync_rep(Keeper *keeper)
 /*
  * fsm_apply_settings is used when a pg_auto_failover setting has changed, such
  * as number_sync_standbys or node priorities and replication quorum
- * properties.
+ * properties, or when a standby node has been removed/appears.
  *
  * So we have to fetch the current synchronous_standby_names setting value from
  * the monitor and apply it (reload) to the current node.

--- a/src/bin/pg_autoctl/service_keeper.c
+++ b/src/bin/pg_autoctl/service_keeper.c
@@ -421,7 +421,7 @@ keeper_node_active_loop(Keeper *keeper, pid_t start_pid)
 		 * the monitor asked us to stop serving queries, in order to ensure
 		 * consistency.
 		 *
-		 * Only enfore current state when we have a recent enough version of
+		 * Only enforce current state when we have a recent enough version of
 		 * it, meaning that we could contact the monitor.
 		 *
 		 * We need to prevent the keeper from restarting PostgreSQL at boot

--- a/src/monitor/group_state_machine.c
+++ b/src/monitor/group_state_machine.c
@@ -785,7 +785,7 @@ ProceedGroupStateForPrimaryNode(AutoFailoverNode *primaryNode)
 	 *   secondary ➜ catchingup
 	 *     primary ➜ wait_primary
 	 *
-	 * We only swith the primary to wait_primary when there's no healthy
+	 * We only switch the primary to wait_primary when there's no healthy
 	 * secondary anymore. In other cases, there's by definition at least one
 	 * candidate for failover.
 	 */

--- a/src/monitor/node_active_protocol.c
+++ b/src/monitor/node_active_protocol.c
@@ -1129,6 +1129,14 @@ RemoveNode(AutoFailoverNode *currentNode)
 		if (primaryNode)
 		{
 			(void) ProceedGroupState(primaryNode);
+			LogAndNotifyMessage(
+				message, BUFSIZE,
+				"Setting goal state of %s:%d to apply_settings "
+				"after removing standby node %s:%d from formation %s.",
+				primaryNode->nodeHost, primaryNode->nodePort,
+				currentNode->nodeHost, currentNode->nodePort,
+				formation->formationId);
+			SetNodeGoalState(primaryNode, REPLICATION_STATE_APPLY_SETTINGS, message);
 		}
 	}
 

--- a/src/monitor/node_active_protocol.c
+++ b/src/monitor/node_active_protocol.c
@@ -1108,22 +1108,6 @@ RemoveNode(AutoFailoverNode *currentNode)
 			formation->number_sync_standbys,
 			formation->formationId,
 			countSyncStandbys);
-
-		AutoFailoverNode *primaryNode =
-			GetPrimaryNodeInGroup(currentNode->formationId,
-								  currentNode->groupId);
-
-		if (primaryNode)
-		{
-			LogAndNotifyMessage(
-				message, BUFSIZE,
-				"Setting goal state of %s:%d to apply_settings "
-				"after removing standby node %s:%d from formation %s.",
-				primaryNode->nodeHost, primaryNode->nodePort,
-				currentNode->nodeHost, currentNode->nodePort,
-				formation->formationId);
-			SetNodeGoalState(primaryNode, REPLICATION_STATE_APPLY_SETTINGS, message);
-		}
 	}
 
 	/* now proceed with the failover, starting with the first standby */
@@ -1145,6 +1129,12 @@ RemoveNode(AutoFailoverNode *currentNode)
 		if (primaryNode)
 		{
 			(void) ProceedGroupState(primaryNode);
+			if (primaryNode->goalState == primaryNode->reportedState)
+			{
+				const char *message = "whatever";
+				SetNodeGoalState(primaryNode,
+								 REPLICATION_STATE_APPLY_SETTINGS, message);
+			}
 		}
 	}
 

--- a/src/monitor/node_active_protocol.c
+++ b/src/monitor/node_active_protocol.c
@@ -1108,6 +1108,22 @@ RemoveNode(AutoFailoverNode *currentNode)
 			formation->number_sync_standbys,
 			formation->formationId,
 			countSyncStandbys);
+
+		AutoFailoverNode *primaryNode =
+			GetPrimaryNodeInGroup(currentNode->formationId,
+								  currentNode->groupId);
+
+		if (primaryNode)
+		{
+			LogAndNotifyMessage(
+				message, BUFSIZE,
+				"Setting goal state of %s:%d to apply_settings "
+				"after removing standby node %s:%d from formation %s.",
+				primaryNode->nodeHost, primaryNode->nodePort,
+				currentNode->nodeHost, currentNode->nodePort,
+				formation->formationId);
+			SetNodeGoalState(primaryNode, REPLICATION_STATE_APPLY_SETTINGS, message);
+		}
 	}
 
 	/* now proceed with the failover, starting with the first standby */
@@ -1129,14 +1145,6 @@ RemoveNode(AutoFailoverNode *currentNode)
 		if (primaryNode)
 		{
 			(void) ProceedGroupState(primaryNode);
-			LogAndNotifyMessage(
-				message, BUFSIZE,
-				"Setting goal state of %s:%d to apply_settings "
-				"after removing standby node %s:%d from formation %s.",
-				primaryNode->nodeHost, primaryNode->nodePort,
-				currentNode->nodeHost, currentNode->nodePort,
-				formation->formationId);
-			SetNodeGoalState(primaryNode, REPLICATION_STATE_APPLY_SETTINGS, message);
 		}
 	}
 

--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -1062,7 +1062,7 @@ SELECT reportedstate
 
     def get_synchronous_standby_names(self):
         """
-            Gets number sync standbys  via pg_autoctl
+            Gets synchronous standby names via pg_autoctl
         """
         command = PGAutoCtl(self)
         out, err, ret = command.execute("get synchronous_standby_names",
@@ -1072,7 +1072,7 @@ SELECT reportedstate
 
     def get_synchronous_standby_names_local(self):
         """
-            Gets number sync standbys  via pg_autoctl
+            Gets synchronous standby names via sql query on data node
         """
         query = "select current_setting('synchronous_standby_names')"
 

--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -1070,6 +1070,22 @@ SELECT reportedstate
 
         return out.strip()
 
+    def get_synchronous_standby_names_local(self):
+        """
+            Gets number sync standbys  via pg_autoctl
+        """
+        query = "select current_setting('synchronous_standby_names')"
+
+        result = self.run_sql_query(query)
+        return result[0][0]
+
+    def print_synchronous_standby_names(self):
+        print("synchronous_standby_names       = '%s'\nsynchronous_standby_names_local = '%s'" %
+              (self.get_synchronous_standby_names(),
+               self.get_synchronous_standby_names_local())
+              )
+        return
+
     def list_replication_slot_names(self):
         """
             Returns a list of the replication slot names on the local Postgres.

--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -964,6 +964,26 @@ SELECT reportedstate
         command.execute("drop node", 'drop', 'node')
         return True
 
+    def do_fsm_assign(self, target_state):
+        """
+        Runs `pg_autoctl do fsm assign` on a node
+
+        :return:
+        """
+        command = PGAutoCtl(self)
+        command.execute("do fsm assign", 'do', 'fsm', 'assign', target_state)
+        return True
+
+    def do_fsm_step(self):
+        """
+        Runs `pg_autoctl do fsm step` on a node
+
+        :return:
+        """
+        command = PGAutoCtl(self)
+        command.execute("do fsm step", 'do', 'fsm', 'step')
+        return True
+
     def set_metadata(self, name=None, host=None, port=None):
         """
             Sets node metadata via pg_autoctl

--- a/tests/test_multi_standbys.py
+++ b/tests/test_multi_standbys.py
@@ -112,19 +112,19 @@ def test_005_number_sync_standbys():
     assert node1.set_number_sync_standbys(2)
     assert node1.get_number_sync_standbys() == 2
     node1.print_synchronous_standby_names()
-    assert node1.get_synchronous_standby_names() == node1.get_synchronous_standby_names_local()
+    eq_(node1.get_synchronous_standby_names(), node1.get_synchronous_standby_names_local())
 
     print("set number_sync_standbys = 0")
     assert node1.set_number_sync_standbys(0)
     assert node1.get_number_sync_standbys() == 0
     node1.print_synchronous_standby_names()
-    assert node1.get_synchronous_standby_names() == node1.get_synchronous_standby_names_local()
+    eq_(node1.get_synchronous_standby_names(), node1.get_synchronous_standby_names_local())
 
     print("set number_sync_standbys = 1")
     assert node1.set_number_sync_standbys(1)
     assert node1.get_number_sync_standbys() == 1
     node1.print_synchronous_standby_names()
-    assert node1.get_synchronous_standby_names() == node1.get_synchronous_standby_names_local()
+    eq_(node1.get_synchronous_standby_names(), node1.get_synchronous_standby_names_local())
 
 
 def test_006_number_sync_standbys_trigger():
@@ -135,7 +135,7 @@ def test_006_number_sync_standbys_trigger():
     assert node1.get_number_sync_standbys() == 1
     assert node1.wait_until_state(target_state="primary")
     node1.print_synchronous_standby_names()
-    assert node1.get_synchronous_standby_names() == node1.get_synchronous_standby_names_local()
+    eq_(node1.get_synchronous_standby_names(), node1.get_synchronous_standby_names_local())
 
     # there's no state change to instruct us that the replication slot
     # maintenance is now done, so we have to wait for awhile instead.

--- a/tests/test_multi_standbys.py
+++ b/tests/test_multi_standbys.py
@@ -111,20 +111,21 @@ def test_005_number_sync_standbys():
     print("set number_sync_standbys = 2")
     assert node1.set_number_sync_standbys(2)
     assert node1.get_number_sync_standbys() == 2
-    print("synchronous_standby_names = '%s'" %
-          node1.get_synchronous_standby_names())
+    node1.print_synchronous_standby_names()
+    assert node1.get_synchronous_standby_names() == node1.get_synchronous_standby_names_local()
 
     print("set number_sync_standbys = 0")
     assert node1.set_number_sync_standbys(0)
     assert node1.get_number_sync_standbys() == 0
-    print("synchronous_standby_names = '%s'" %
-          node1.get_synchronous_standby_names())
+    node1.print_synchronous_standby_names()
+    assert node1.get_synchronous_standby_names() == node1.get_synchronous_standby_names_local()
 
     print("set number_sync_standbys = 1")
     assert node1.set_number_sync_standbys(1)
     assert node1.get_number_sync_standbys() == 1
-    print("synchronous_standby_names = '%s'" %
-          node1.get_synchronous_standby_names())
+    node1.print_synchronous_standby_names()
+    assert node1.get_synchronous_standby_names() == node1.get_synchronous_standby_names_local()
+
 
 def test_006_number_sync_standbys_trigger():
     assert node1.set_number_sync_standbys(2)
@@ -133,6 +134,8 @@ def test_006_number_sync_standbys_trigger():
     node4.drop()
     assert node1.get_number_sync_standbys() == 1
     assert node1.wait_until_state(target_state="primary")
+    node1.print_synchronous_standby_names()
+    assert node1.get_synchronous_standby_names() == node1.get_synchronous_standby_names_local()
 
     # there's no state change to instruct us that the replication slot
     # maintenance is now done, so we have to wait for awhile instead.


### PR DESCRIPTION
The primary node is assigned to APPLY_SETTINGS_STATE so that the synchronous_standby_names are correctly updated on the primary.

Fixes #445

with @soumyadeep2007 and @jchampio
