### PR TITLE
Force closing the connection used to check replication slots.

### DIFF
--- a/src/bin/pg_autoctl/primary_standby.c
+++ b/src/bin/pg_autoctl/primary_standby.c
@@ -400,9 +400,11 @@ upstream_has_replication_slot(ReplicationSource *upstream,
 									   hasReplicationSlot))
 	{
 		/* errors have already been logged */
+		PQfinish(upstreamClient.connection);
 		return false;
 	}
 
+	PQfinish(upstreamClient.connection);
 	return true;
 }
 


### PR DESCRIPTION
We connect to the primary using the pgautofailover_replicator username to
check if the replication slot has been created already on the primary, but
in that case we didn't have another use for the connection, no clean-up
happens later.

Close the connection as soon as we have the information we are looking for.
We reconnect each time anyway.

Fixes #450.