### PR TITLE
Ensure that the monitor owns the Postgres (sub-)process.

### DIFF
--- a/src/bin/pg_autoctl/defaults.h
+++ b/src/bin/pg_autoctl/defaults.h
@@ -73,6 +73,7 @@
 #define PG_AUTOCTL_KEEPER_SLEEP_TIME 1      /* seconds */
 #define PG_AUTOCTL_KEEPER_RETRY_TIME_MS 350 /* milliseconds */
 #define PG_AUTOCTL_MONITOR_SLEEP_TIME 10 /* seconds */
+#define PG_AUTOCTL_MONITOR_RETRY_TIME 1  /* seconds */
 
 #define PG_AUTOCTL_LISTEN_NOTIFICATIONS_TIMEOUT 60
 

--- a/src/bin/pg_autoctl/pgsql.c
+++ b/src/bin/pg_autoctl/pgsql.c
@@ -869,6 +869,13 @@ pgsql_execute_with_params(PGSQL *pgsql, const char *sql, int paramCount,
 			strlcpy(ctx->sqlstate, sqlstate, SQLSTATE_LENGTH);
 		}
 
+		/* if we get a connection exception, track that */
+		if (sqlstate &&
+			strncmp(sqlstate, STR_ERRCODE_CLASS_CONNECTION_EXCEPTION, 2) == 0)
+		{
+			pgsql->status = PG_CONNECTION_BAD;
+		}
+
 		PQclear(result);
 		clear_results(pgsql);
 		pgsql_finish(pgsql);

--- a/src/bin/pg_autoctl/pgsql.h
+++ b/src/bin/pg_autoctl/pgsql.h
@@ -196,6 +196,8 @@ typedef enum
  */
 #define SQLSTATE_LENGTH 6
 
+#define STR_ERRCODE_CLASS_CONNECTION_EXCEPTION "08"
+
 typedef struct AbstractResultContext
 {
 	char sqlstate[SQLSTATE_LENGTH];

--- a/src/bin/pg_autoctl/primary_standby.h
+++ b/src/bin/pg_autoctl/primary_standby.h
@@ -58,6 +58,7 @@ void local_postgres_finish(LocalPostgresServer *postgres);
 bool local_postgres_update(LocalPostgresServer *postgres,
 						   bool postgresNotRunningIsOk);
 bool ensure_postgres_service_is_running(LocalPostgresServer *postgres);
+bool ensure_postgres_service_is_running_as_subprocess(LocalPostgresServer *postgres);
 bool ensure_postgres_service_is_stopped(LocalPostgresServer *postgres);
 
 bool primary_has_replica(LocalPostgresServer *postgres, char *userName,

--- a/src/bin/pg_autoctl/service_monitor.c
+++ b/src/bin/pg_autoctl/service_monitor.c
@@ -233,6 +233,8 @@ monitor_service_run(Monitor *monitor)
 
 		if (asked_to_stop || asked_to_stop_fast)
 		{
+			log_info("Listener service received signal %s, terminating",
+					 signal_to_string(get_current_signal(SIGTERM)));
 			break;
 		}
 
@@ -248,8 +250,32 @@ monitor_service_run(Monitor *monitor)
 		 */
 		if (firstLoop)
 		{
-			/* if Postgres is running, it can't be our sub-process, stop it */
-			if (pg_setup_is_ready(pgSetup, pgIsNotRunningIsOk))
+			pid_t pgServicePid = 0;
+			char pgServicePidFile[MAXPGPATH] = { 0 };
+
+			(void) get_service_pidfile(mconfig->pathnames.pid,
+									   "postgres",
+									   pgServicePidFile);
+
+			/*
+			 * If Postgres is running, and it's not our sub-process, stop it
+			 * now, and restart it in the next code block, to ensure that
+			 * Postgres is our sub-process, an invariant that allows us to
+			 * upgrade our pgautofailover extension when that's needed, etc.
+			 *
+			 * When we read a non-stale pid from the service pidfile, we
+			 * consider that the Postgres that is running is a legit
+			 * sub-process of pg_autoctl. The pid file contains the pid of the
+			 * "pg_autoctl: start/stop postgres" process (the Postgres
+			 * controler), and the pgSetup->pidFile.pid contains the pid of
+			 * "postgres" itself, so we don't go as far as comparing them here.
+			 *
+			 * One case we must pay attention to is when restarting the
+			 * listener service (pg_autoctl do service restart listener), we
+			 * don't want to force a restart of Postgres itself at that point.
+			 */
+			if (pg_setup_is_ready(pgSetup, pgIsNotRunningIsOk) &&
+				!read_pidfile(pgServicePidFile, &pgServicePid))
 			{
 				log_info("Postgres is already running for \"%s\" with pid %d, "
 						 "which is not a sub-process of pg_autoctl, "

--- a/src/bin/pg_autoctl/service_postgres.c
+++ b/src/bin/pg_autoctl/service_postgres.c
@@ -130,6 +130,9 @@ service_postgres_stop(Service *service)
 		return false;
 	}
 
+	/* cache invalidation */
+	service->pid = 0;
+
 	return true;
 }
 

--- a/src/bin/pg_autoctl/state.c
+++ b/src/bin/pg_autoctl/state.c
@@ -840,6 +840,11 @@ ExpectedPostgresStatusToString(ExpectedPostgresStatus pgExpectedStatus)
 		{
 			return "Postgres should be running";
 		}
+
+		case PG_EXPECTED_STATUS_RUNNING_AS_SUBPROCESS:
+		{
+			return "Postgres should be running as a pg_autoctl subprocess";
+		}
 	}
 
 	/* make compiler happy */
@@ -870,6 +875,20 @@ keeper_set_postgres_state_running(KeeperStatePostgres *pgStatus,
 								  const char *filename)
 {
 	pgStatus->pgExpectedStatus = PG_EXPECTED_STATUS_RUNNING;
+
+	return keeper_postgres_state_update(pgStatus, filename);
+}
+
+
+/*
+ * keeper_set_postgres_state_running updates the Postgres expected status file
+ * to running as subprocess.
+ */
+bool
+keeper_set_postgres_state_running_as_subprocess(KeeperStatePostgres *pgStatus,
+												const char *filename)
+{
+	pgStatus->pgExpectedStatus = PG_EXPECTED_STATUS_RUNNING_AS_SUBPROCESS;
 
 	return keeper_postgres_state_update(pgStatus, filename);
 }

--- a/src/bin/pg_autoctl/state.h
+++ b/src/bin/pg_autoctl/state.h
@@ -169,7 +169,8 @@ typedef enum
 {
 	PG_EXPECTED_STATUS_UNKNOWN = 0,
 	PG_EXPECTED_STATUS_STOPPED,
-	PG_EXPECTED_STATUS_RUNNING
+	PG_EXPECTED_STATUS_RUNNING,
+	PG_EXPECTED_STATUS_RUNNING_AS_SUBPROCESS
 } ExpectedPostgresStatus;
 
 /*
@@ -219,6 +220,8 @@ bool keeper_set_postgres_state_unknown(KeeperStatePostgres *pgStatus,
 									   const char *filename);
 bool keeper_set_postgres_state_running(KeeperStatePostgres *pgStatus,
 									   const char *filename);
+bool keeper_set_postgres_state_running_as_subprocess(KeeperStatePostgres *pgStatus,
+													 const char *filename);
 bool keeper_set_postgres_state_stopped(KeeperStatePostgres *pgStatus,
 									   const char *filename);
 bool keeper_postgres_state_update(KeeperStatePostgres *pgStatus,

--- a/tests/test_basic_operation.py
+++ b/tests/test_basic_operation.py
@@ -245,7 +245,11 @@ def test_023_ifup_old_primary():
 def test_024_stop_postgres_monitor():
     original_state = node3.get_state()
     monitor.stop_postgres()
-    monitor.wait_until_pg_is_running()
+
+    # allow trying twice to make Travis CI stable
+    if not monitor.wait_until_pg_is_running():
+        assert monitor.wait_until_pg_is_running()
+
     print()
     assert node3.wait_until_state(target_state=original_state)
 


### PR DESCRIPTION
When we don't own the Postgres subprocess, we can't ensure that a pending
monitor upgrade is being done properly. This is mostly a problem when
upgrading from 1.3.1 to 1.4(.0, fix going to appeart in .1).

Fixes #434 