### PR TITLE
Implement HBA hostname DNS checks, and warn users when needed.

### DIFF
--- a/src/bin/pg_autoctl/ipaddr.c
+++ b/src/bin/pg_autoctl/ipaddr.c
@@ -594,3 +594,95 @@ findHostnameFromLocalIpAddress(char *localIpAddress, char *hostname, int size)
 
 	return true;
 }
+
+
+/*
+ * resolveHostnameForwardAndReverse returns true when we could do a forward DNS
+ * lookup for the hostname, and then a reverse DNS lookup, and the reverse DNS
+ * lookup returns a single IP address that is the same as the forward lookup
+ * returned.
+ *
+ * When Postgres runs the DNS checks in the HBA implementation, the client IP
+ * address is looked-up in a reverse DNS query, and that name is compared to
+ * the hostname in the HBA file. Then, a forward DNS query is performed on the
+ * hostname, and one of the IP addresses returned must match with the client IP
+ * address.
+ *
+ *  client ip -- reverse dns lookup --> hostname
+ *   hostname -- forward dns lookup --> { ... client ip ... }
+ *
+ * At this point we don't have a client IP address. That said, the Postgres
+ * check will always fail if we fail to get our hostname back from at least one
+ * of the IP addresses that our hostname forward-DNS query returns.
+ */
+bool
+resolveHostnameForwardAndReverse(const char *hostname, char *ipaddr, int size)
+{
+	int error;
+	struct addrinfo *lookup, *ai;
+
+	bool foundHostnameFromAddress = false;
+
+	error = getaddrinfo(hostname, NULL, 0, &lookup);
+	if (error != 0)
+	{
+		log_warn("Failed to resolve DNS name \"%s\": %s",
+				 hostname, gai_strerror(error));
+		return false;
+	}
+
+	/* loop over the forward DNS results for hostname */
+	for (ai = lookup; ai; ai = ai->ai_next)
+	{
+		int ret;
+		char hbuf[NI_MAXHOST] = { 0 };
+
+		if (ai->ai_family == AF_INET)
+		{
+			struct sockaddr_in *ip = (struct sockaddr_in *) ai->ai_addr;
+
+			if (inet_ntop(AF_INET, (void *) &(ip->sin_addr), ipaddr, size) == NULL)
+			{
+				log_debug("Failed to determine local ip address: %m");
+				continue;
+			}
+		}
+		else if (ai->ai_family == AF_INET6)
+		{
+			struct sockaddr_in6 *ip = (struct sockaddr_in6 *) ai->ai_addr;
+
+			if (inet_ntop(AF_INET6, (void *) &(ip->sin6_addr), ipaddr, size) == NULL)
+			{
+				log_debug("Failed to determine local ip address: %m");
+				continue;
+			}
+		}
+		else
+		{
+			/* Highly unexpected */
+			log_debug("Non supported ai_family %d", ai->ai_family);
+			continue;
+		}
+
+		/* now reverse lookup (NI_NAMEREQD) the address with getnameinfo() */
+		ret = getnameinfo(ai->ai_addr, ai->ai_addrlen,
+						  hbuf, sizeof(hbuf), NULL, 0, NI_NAMEREQD);
+
+		if (ret != 0)
+		{
+			log_debug("Failed to resolve hostname from address \"%s\": %s",
+					  ipaddr, gai_strerror(ret));
+			continue;
+		}
+
+		/* compare reverse-DNS lookup result with our hostname */
+		if (strcmp(hbuf, hostname) == 0)
+		{
+			foundHostnameFromAddress = true;
+			break;
+		}
+	}
+	freeaddrinfo(lookup);
+
+	return foundHostnameFromAddress;
+}

--- a/src/bin/pg_autoctl/ipaddr.c
+++ b/src/bin/pg_autoctl/ipaddr.c
@@ -598,9 +598,8 @@ findHostnameFromLocalIpAddress(char *localIpAddress, char *hostname, int size)
 
 /*
  * resolveHostnameForwardAndReverse returns true when we could do a forward DNS
- * lookup for the hostname, and then a reverse DNS lookup, and the reverse DNS
- * lookup returns a single IP address that is the same as the forward lookup
- * returned.
+ * lookup for the hostname and one of the IP addresses from the lookup resolves
+ * back to the hostname when doing a reverse-DNS lookup from it.
  *
  * When Postgres runs the DNS checks in the HBA implementation, the client IP
  * address is looked-up in a reverse DNS query, and that name is compared to

--- a/src/bin/pg_autoctl/ipaddr.h
+++ b/src/bin/pg_autoctl/ipaddr.h
@@ -29,5 +29,8 @@ bool findHostnameLocalAddress(const char *hostname,
 bool findHostnameFromLocalIpAddress(char *localIpAddress,
 									char *hostname, int size);
 
+bool resolveHostnameForwardAndReverse(const char *hostname,
+									  char *ipaddr, int size);
+
 
 #endif /* __IPADDRH__ */

--- a/src/bin/pg_autoctl/pghba.c
+++ b/src/bin/pg_autoctl/pghba.c
@@ -188,15 +188,7 @@ pghba_ensure_host_rule_exists(const char *hbaFilePath,
 	 *
 	 * HBA & DNS is hard.
 	 */
-	if (!pghba_check_hostname(host))
-	{
-		log_warn(
-			"Failed to resolve hostname \"%s\" to an IP address that "
-			"resolves batck to the hostname on a reverse DNS lookup.",
-			host);
-		log_warn("Postgres might deny connection attempts from \"%s\", "
-				 "even with the new HBA rules.", host);
-	}
+	(void) pghba_check_hostname(host);
 
 	/* build the new postgresql.conf contents */
 	newHbaContents = createPQExpBuffer();
@@ -329,15 +321,7 @@ pghba_ensure_host_rules_exist(const char *hbaFilePath,
 			 *
 			 * HBA & DNS is hard.
 			 */
-			if (!pghba_check_hostname(node->host))
-			{
-				log_warn(
-					"Failed to resolve hostname \"%s\" to an IP address that "
-					"resolves batck to the hostname on a reverse DNS lookup.",
-					node->host);
-				log_warn("Postgres might deny connection attempts from \"%s\", "
-						 "even with the new HBA rules.", node->host);
-			}
+			(void) pghba_check_hostname(node->host);
 		}
 
 		if (!pghba_append_rule_to_buffer(hbaLineReplicationBuffer,
@@ -705,6 +689,15 @@ pghba_check_hostname(const char *hostname)
 
 	if (!resolveHostnameForwardAndReverse(hostname, ipaddr, sizeof(ipaddr)))
 	{
+		/* warn users about possible DNS misconfiguration */
+		log_warn("Failed to resolve hostname \"%s\" to an IP address that "
+				 "resolves batck to the hostname on a reverse DNS lookup.",
+				 hostname);
+
+		log_warn("Postgres might deny connection attempts from \"%s\", "
+				 "even with the new HBA rules.",
+				 hostname);
+
 		return false;
 	}
 

--- a/src/bin/pg_autoctl/pghba.c
+++ b/src/bin/pg_autoctl/pghba.c
@@ -691,12 +691,15 @@ pghba_check_hostname(const char *hostname)
 	{
 		/* warn users about possible DNS misconfiguration */
 		log_warn("Failed to resolve hostname \"%s\" to an IP address that "
-				 "resolves batck to the hostname on a reverse DNS lookup.",
+				 "resolves back to the hostname on a reverse DNS lookup.",
 				 hostname);
 
 		log_warn("Postgres might deny connection attempts from \"%s\", "
 				 "even with the new HBA rules.",
 				 hostname);
+
+		log_warn("Hint: correct setup of HBA with host names requires proper "
+				 "reverse DNS setup. You might want to use IP addresses.");
 
 		return false;
 	}

--- a/src/bin/pg_autoctl/pghba.c
+++ b/src/bin/pg_autoctl/pghba.c
@@ -180,6 +180,24 @@ pghba_ensure_host_rule_exists(const char *hbaFilePath,
 		return true;
 	}
 
+	/*
+	 * When using a hostname in the HBA host field, Postgres is very picky
+	 * about the matching rules. We have an opportunity here to check the same
+	 * DNS and reverse DNS rules as Postgres, and warn our users when we see
+	 * something that we know Postgres won't be happy with.
+	 *
+	 * HBA & DNS is hard.
+	 */
+	if (!pghba_check_hostname(host))
+	{
+		log_warn(
+			"Failed to resolve hostname \"%s\" to an IP address that "
+			"resolves batck to the hostname on a reverse DNS lookup.",
+			host);
+		log_warn("Postgres might deny connection attempts from \"%s\", "
+				 "even with the new HBA rules.", host);
+	}
+
 	/* build the new postgresql.conf contents */
 	newHbaContents = createPQExpBuffer();
 	if (newHbaContents == NULL)
@@ -299,6 +317,28 @@ pghba_ensure_host_rules_exist(const char *hbaFilePath,
 
 		log_debug("pghba_ensure_host_rules_exist: %d %s:%d",
 				  node->nodeId, node->host, node->port);
+
+		if (!SKIP_HBA(authenticationScheme))
+		{
+			/*
+			 * When using a hostname in the HBA host field, Postgres is very
+			 * picky about the matching rules. We have an opportunity here to
+			 * check the same DNS and reverse DNS rules as Postgres, and warn
+			 * our users when we see something that we know Postgres won't be
+			 * happy with.
+			 *
+			 * HBA & DNS is hard.
+			 */
+			if (!pghba_check_hostname(node->host))
+			{
+				log_warn(
+					"Failed to resolve hostname \"%s\" to an IP address that "
+					"resolves batck to the hostname on a reverse DNS lookup.",
+					node->host);
+				log_warn("Postgres might deny connection attempts from \"%s\", "
+						 "even with the new HBA rules.", node->host);
+			}
+		}
 
 		if (!pghba_append_rule_to_buffer(hbaLineReplicationBuffer,
 										 ssl,
@@ -622,5 +662,53 @@ pghba_enable_lan_cidr(PGSQL *pgsql,
 		log_error("Failed to reload PostgreSQL configuration for new HBA rule");
 		return false;
 	}
+	return true;
+}
+
+
+/*
+ * hba_check_hostname returns true when the DNS setting looks compatible with
+ * Postgres expectations for an HBA hostname entry.
+ *
+ * https://www.postgresql.org/docs/current/auth-pg-hba-conf.html
+ *
+ * If a host name is specified (anything that is not an IP address range or a
+ * special key word is treated as a host name), that name is compared with the
+ * result of a reverse name resolution of the client's IP address (e.g.,
+ * reverse DNS lookup, if DNS is used). Host name comparisons are case
+ * insensitive. If there is a match, then a forward name resolution (e.g.,
+ * forward DNS lookup) is performed on the host name to check whether any of
+ * the addresses it resolves to are equal to the client's IP address. If both
+ * directions match, then the entry is considered to match. (The host name that
+ * is used in pg_hba.conf should be the one that address-to-name resolution of
+ * the client's IP address returns, otherwise the line won't be matched. Some
+ * host name databases allow associating an IP address with multiple host
+ * names, but the operating system will only return one host name when asked to
+ * resolve an IP address.)
+ */
+bool
+pghba_check_hostname(const char *hostname)
+{
+	char ipaddr[BUFSIZE] = { 0 };
+
+	/*
+	 * IP addresses do not require any DNS properties/lookups. Also hostname
+	 * won't contain a '/' character, but CIDR notations would, such as
+	 * 1.2.3.4/32 or ::1/128. We don't want to trust ip_address_type() value of
+	 * IPTYPE_NONE when we find a '/' character in the hostname.
+	 *
+	 */
+	if (strchr(hostname, '/') || ip_address_type(hostname) != IPTYPE_NONE)
+	{
+		return true;
+	}
+
+	if (!resolveHostnameForwardAndReverse(hostname, ipaddr, sizeof(ipaddr)))
+	{
+		return false;
+	}
+
+	log_debug("pghba_check_hostname: \"%s\" <-> %s", hostname, ipaddr);
+
 	return true;
 }

--- a/src/bin/pg_autoctl/pghba.h
+++ b/src/bin/pg_autoctl/pghba.h
@@ -45,4 +45,6 @@ bool pghba_enable_lan_cidr(PGSQL *pgsql,
 						   const char *authenticationScheme,
 						   const char *pgdata);
 
+bool pghba_check_hostname(const char *hostname);
+
 #endif /* PGHBA_H */


### PR DESCRIPTION
Postgres HBA implementation with hostname is pretty picky, in order to be
secure enough. The reverse DNS lookup requirements are often missed, and
sometimes hard or impossible to achieve (Cloud VM environments).

As more users get confused with their hostname based setup, we should
provide more guidance when that's possible.

See #452.