### PR TITLE
Refrain from using FIRST %d in synchronous_standby_names.

### DIFF
--- a/src/monitor/node_active_protocol.c
+++ b/src/monitor/node_active_protocol.c
@@ -2226,9 +2226,6 @@ synchronous_standby_names(PG_FUNCTION_ARGS)
 		}
 		else
 		{
-			bool allTheSamePriority =
-				AllNodesHaveSameCandidatePriority(syncStandbyNodesGroupList);
-
 			/*
 			 * We accept number_sync_standbys to be set to zero to enable our
 			 * failover trade-off, but won't send a synchronous_standby_names
@@ -2243,10 +2240,7 @@ synchronous_standby_names(PG_FUNCTION_ARGS)
 			ListCell *nodeCell = NULL;
 			bool firstNode = true;
 
-			appendStringInfo(sbnames,
-							 "%s %d (",
-							 allTheSamePriority ? "ANY" : "FIRST",
-							 number_sync_standbys);
+			appendStringInfo(sbnames, "ANY %d (", number_sync_standbys);
 
 			foreach(nodeCell, syncStandbyNodesGroupList)
 			{

--- a/src/monitor/node_metadata.c
+++ b/src/monitor/node_metadata.c
@@ -758,30 +758,6 @@ CountSyncStandbys(List *groupNodeList)
 
 
 /*
- * AllNodesHaveSameCandidatePriority returns true when all the nodes in the
- * given list have the same candidate priority.
- */
-bool
-AllNodesHaveSameCandidatePriority(List *groupNodeList)
-{
-	ListCell *nodeCell = NULL;
-	int candidatePriority =
-		((AutoFailoverNode *) linitial(groupNodeList))->candidatePriority;
-
-	foreach(nodeCell, groupNodeList)
-	{
-		AutoFailoverNode *node = (AutoFailoverNode *) lfirst(nodeCell);
-
-		if (node->candidatePriority != candidatePriority)
-		{
-			return false;
-		}
-	}
-	return true;
-}
-
-
-/*
  * GetAutoFailoverNode returns a single AutoFailover node by hostname and port.
  */
 AutoFailoverNode *


### PR DESCRIPTION
In terms of available that's worse than using ANY, and Postgres
implementation of FIRST/ANY has nothing to do with our implementation of the
candidate priority anyway. We don't want to insist on transaction being
preferably committed by any given standby, we have FAST_FORWARD after all.