### PR TITLE
Always use node id and node name in messages.

### DIFF
--- a/src/bin/pg_autoctl/cli_do_monitor.c
+++ b/src/bin/pg_autoctl/cli_do_monitor.c
@@ -181,6 +181,8 @@ cli_do_monitor_get_primary_node(int argc, char **argv)
 
 		json_object_set_string(root, "formation", config.formation);
 		json_object_set_number(root, "groupId", (double) config.groupId);
+		json_object_set_number(root, "nodeId", (double) primaryNode.nodeId);
+		json_object_set_string(root, "name", primaryNode.name);
 		json_object_set_string(root, "host", primaryNode.host);
 		json_object_set_number(root, "port", (double) primaryNode.port);
 

--- a/src/bin/pg_autoctl/fsm_transition.c
+++ b/src/bin/pg_autoctl/fsm_transition.c
@@ -1392,7 +1392,7 @@ fsm_follow_new_primary(Keeper *keeper)
 	if (!standby_follow_new_primary(postgres))
 	{
 		log_error("Failed to change standby setup to follow new primary "
-				  "node %d \"%s\" at %s:%d, see above for details",
+				  "node %d \"%s\" (%s:%d), see above for details",
 				  replicationSource->primaryNode.nodeId,
 				  replicationSource->primaryNode.name,
 				  replicationSource->primaryNode.host,

--- a/src/bin/pg_autoctl/fsm_transition.c
+++ b/src/bin/pg_autoctl/fsm_transition.c
@@ -1392,8 +1392,9 @@ fsm_follow_new_primary(Keeper *keeper)
 	if (!standby_follow_new_primary(postgres))
 	{
 		log_error("Failed to change standby setup to follow new primary "
-				  "node %d at %s:%d, see above for details",
+				  "node %d \"%s\" at %s:%d, see above for details",
 				  replicationSource->primaryNode.nodeId,
+				  replicationSource->primaryNode.name,
 				  replicationSource->primaryNode.host,
 				  replicationSource->primaryNode.port);
 		return false;

--- a/src/bin/pg_autoctl/monitor.c
+++ b/src/bin/pg_autoctl/monitor.c
@@ -3402,8 +3402,9 @@ monitor_notification_process_apply_settings(void *context,
 	{
 		ctx->applySettingsTransitionInProgress = true;
 
-		log_debug("step 1/4: primary node %d (%s:%d) is assigned \"%s\"",
+		log_debug("step 1/4: primary node %d \"%s\" (%s:%d) is assigned \"%s\"",
 				  nodeState->node.nodeId,
+				  nodeState->node.name,
 				  nodeState->node.host,
 				  nodeState->node.port,
 				  NodeStateToString(nodeState->goalState));
@@ -3413,8 +3414,9 @@ monitor_notification_process_apply_settings(void *context,
 	{
 		ctx->applySettingsTransitionInProgress = true;
 
-		log_debug("step 2/4: primary node %d (%s:%d) reported \"%s\"",
+		log_debug("step 2/4: primary node %d \"%s\" (%s:%d) reported \"%s\"",
 				  nodeState->node.nodeId,
+				  nodeState->node.name,
 				  nodeState->node.host,
 				  nodeState->node.port,
 				  NodeStateToString(nodeState->reportedState));
@@ -3424,8 +3426,9 @@ monitor_notification_process_apply_settings(void *context,
 	{
 		ctx->applySettingsTransitionInProgress = true;
 
-		log_debug("step 3/4: primary node %d (%s:%d) is assigned \"%s\"",
+		log_debug("step 3/4: primary node %d \"%s\" (%s:%d) is assigned \"%s\"",
 				  nodeState->node.nodeId,
+				  nodeState->node.name,
 				  nodeState->node.host,
 				  nodeState->node.port,
 				  NodeStateToString(nodeState->goalState));
@@ -3436,8 +3439,9 @@ monitor_notification_process_apply_settings(void *context,
 	{
 		ctx->applySettingsTransitionDone = true;
 
-		log_debug("step 4/4: primary node %d (%s:%d) reported \"%s\"",
+		log_debug("step 4/4: primary node %d \"%s\" (%s:%d) reported \"%s\"",
 				  nodeState->node.nodeId,
+				  nodeState->node.name,
 				  nodeState->node.host,
 				  nodeState->node.port,
 				  NodeStateToString(nodeState->reportedState));

--- a/src/bin/pg_autoctl/pgctl.c
+++ b/src/bin/pg_autoctl/pgctl.c
@@ -1682,8 +1682,11 @@ prepare_recovery_settings(const char *pgdata,
 	/* when reaching REPORT_LSN we set recovery with no primary conninfo */
 	if (!IS_EMPTY_STRING_BUFFER(primaryNode->host))
 	{
-		log_debug("prepare_recovery_settings: primary node %s:%d",
-				  primaryNode->host, primaryNode->port);
+		log_debug("prepare_recovery_settings: primary node %d \"%s\" (%s:%d)",
+				  primaryNode->nodeId,
+				  primaryNode->name,
+				  primaryNode->host,
+				  primaryNode->port);
 
 		if (!prepare_primary_conninfo(primaryConnInfo,
 									  MAXCONNINFO,

--- a/src/bin/pg_autoctl/pghba.c
+++ b/src/bin/pg_autoctl/pghba.c
@@ -307,8 +307,8 @@ pghba_ensure_host_rules_exist(const char *hbaFilePath,
 			return false;
 		}
 
-		log_debug("pghba_ensure_host_rules_exist: %d %s:%d",
-				  node->nodeId, node->host, node->port);
+		log_debug("pghba_ensure_host_rules_exist: %d \"%s\" (%s:%d)",
+				  node->nodeId, node->name, node->host, node->port);
 
 		if (!SKIP_HBA(authenticationScheme))
 		{
@@ -364,8 +364,8 @@ pghba_ensure_host_rules_exist(const char *hbaFilePath,
 			return false;
 		}
 
-		log_info("Ensuring HBA rules for node %d (%s:%d)",
-				 node->nodeId, node->host, node->port);
+		log_info("Ensuring HBA rules for node %d \"%s\" (%s:%d)",
+				 node->nodeId, node->name, node->host, node->port);
 
 		hbaLines[0] = hbaLineReplicationBuffer;
 		hbaLines[1] = hbaLineDatabaseBuffer;

--- a/src/bin/pg_autoctl/primary_standby.c
+++ b/src/bin/pg_autoctl/primary_standby.c
@@ -988,8 +988,11 @@ primary_rewind_to_standby(LocalPostgresServer *postgres)
 	NodeAddress *primaryNode = &(replicationSource->primaryNode);
 
 	log_trace("primary_rewind_to_standby");
-	log_info("Rewinding PostgreSQL to follow new primary %s:%d",
-			 primaryNode->host, primaryNode->port);
+	log_info("Rewinding PostgreSQL to follow new primary node %d \"%s\" (%s:%d)",
+			 primaryNode->nodeId,
+			 primaryNode->name,
+			 primaryNode->host,
+			 primaryNode->port);
 
 	if (!ensure_postgres_service_is_stopped(postgres))
 	{
@@ -1194,7 +1197,11 @@ standby_follow_new_primary(LocalPostgresServer *postgres)
 	ReplicationSource *replicationSource = &(postgres->replicationSource);
 	NodeAddress *primaryNode = &(replicationSource->primaryNode);
 
-	log_info("Follow new primary %s:%d", primaryNode->host, primaryNode->port);
+	log_info("Follow new primary node %d \"%s\" (%s:%d)",
+			 primaryNode->nodeId,
+			 primaryNode->name,
+			 primaryNode->host,
+			 primaryNode->port);
 
 	/* when we have a primary, only proceed if we can reach it */
 	if (!IS_EMPTY_STRING_BUFFER(replicationSource->primaryNode.host))

--- a/src/monitor/formation_metadata.c
+++ b/src/monitor/formation_metadata.c
@@ -593,8 +593,8 @@ set_formation_number_sync_standbys(PG_FUNCTION_ARGS)
 		ereport(ERROR,
 				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 				 errmsg("cannot set number_sync_standbys when current "
-						"goal state for primary node %d \"%s\" (%s:%d) is \"%s\", "
-						"and current reported state is \"%s\"",
+						"goal state for primary " NODE_FORMAT " is \"%s\", "
+															  "and current reported state is \"%s\"",
 						primaryNode->nodeId,
 						primaryNode->nodeName,
 						primaryNode->nodeHost,
@@ -630,8 +630,8 @@ set_formation_number_sync_standbys(PG_FUNCTION_ARGS)
 	/* and now ask the primary to change its settings */
 	LogAndNotifyMessage(
 		message, BUFSIZE,
-		"Setting goal state of node %d \"%s\" (%s:%d) to apply_settings "
-		"after updating number_sync_standbys to %d for formation %s.",
+		"Setting goal state of " NODE_FORMAT " to apply_settings "
+											 "after updating number_sync_standbys to %d for formation %s.",
 		primaryNode->nodeId,
 		primaryNode->nodeName,
 		primaryNode->nodeHost,

--- a/src/monitor/formation_metadata.c
+++ b/src/monitor/formation_metadata.c
@@ -593,12 +593,9 @@ set_formation_number_sync_standbys(PG_FUNCTION_ARGS)
 		ereport(ERROR,
 				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 				 errmsg("cannot set number_sync_standbys when current "
-						"goal state for primary " NODE_FORMAT " is \"%s\", "
-															  "and current reported state is \"%s\"",
-						primaryNode->nodeId,
-						primaryNode->nodeName,
-						primaryNode->nodeHost,
-						primaryNode->nodePort,
+						"goal state for primary " NODE_FORMAT
+						" is \"%s\", and current reported state is \"%s\"",
+						NODE_FORMAT_ARGS(primaryNode),
 						ReplicationStateGetName(primaryNode->goalState),
 						ReplicationStateGetName(primaryNode->reportedState)),
 				 errdetail("The primary node so must be in state \"primary\" "
@@ -630,12 +627,10 @@ set_formation_number_sync_standbys(PG_FUNCTION_ARGS)
 	/* and now ask the primary to change its settings */
 	LogAndNotifyMessage(
 		message, BUFSIZE,
-		"Setting goal state of " NODE_FORMAT " to apply_settings "
-											 "after updating number_sync_standbys to %d for formation %s.",
-		primaryNode->nodeId,
-		primaryNode->nodeName,
-		primaryNode->nodeHost,
-		primaryNode->nodePort,
+		"Setting goal state of " NODE_FORMAT
+		" to apply_settings "
+		"after updating number_sync_standbys to %d for formation %s.",
+		NODE_FORMAT_ARGS(primaryNode),
 		formation->number_sync_standbys,
 		formation->formationId);
 

--- a/src/monitor/formation_metadata.c
+++ b/src/monitor/formation_metadata.c
@@ -593,9 +593,10 @@ set_formation_number_sync_standbys(PG_FUNCTION_ARGS)
 		ereport(ERROR,
 				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 				 errmsg("cannot set number_sync_standbys when current "
-						"goal state for primary node %d (%s:%d) is \"%s\", "
+						"goal state for primary node %d \"%s\" (%s:%d) is \"%s\", "
 						"and current reported state is \"%s\"",
 						primaryNode->nodeId,
+						primaryNode->nodeName,
 						primaryNode->nodeHost,
 						primaryNode->nodePort,
 						ReplicationStateGetName(primaryNode->goalState),
@@ -629,9 +630,12 @@ set_formation_number_sync_standbys(PG_FUNCTION_ARGS)
 	/* and now ask the primary to change its settings */
 	LogAndNotifyMessage(
 		message, BUFSIZE,
-		"Setting goal state of %s:%d to apply_settings "
+		"Setting goal state of node %d \"%s\" (%s:%d) to apply_settings "
 		"after updating number_sync_standbys to %d for formation %s.",
-		primaryNode->nodeHost, primaryNode->nodePort,
+		primaryNode->nodeId,
+		primaryNode->nodeName,
+		primaryNode->nodeHost,
+		primaryNode->nodePort,
 		formation->number_sync_standbys,
 		formation->formationId);
 

--- a/src/monitor/group_state_machine.c
+++ b/src/monitor/group_state_machine.c
@@ -115,12 +115,9 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of node %d \"%s\" (%s:%d) to single "
-			"as there is no other node.",
-			activeNode->nodeId,
-			activeNode->nodeName,
-			activeNode->nodeHost,
-			activeNode->nodePort);
+			"Setting goal state of " NODE_FORMAT " to single "
+												 "as there is no other node.",
+			NODE_FORMAT_ARGS(activeNode));
 
 		/* other node may have been removed */
 		AssignGoalState(activeNode, REPLICATION_STATE_SINGLE, message);
@@ -163,11 +160,8 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 				(errmsg("ProceedGroupState couldn't find the primary node "
 						"in formation \"%s\", group %d",
 						formationId, groupId),
-				 errdetail("activeNode is node %d \"%s\" (%s:%d) in state %s",
-						   activeNode->nodeId,
-						   activeNode->nodeName,
-						   activeNode->nodeHost,
-						   activeNode->nodePort,
+				 errdetail("activeNode is " NODE_FORMAT " in state %s",
+						   NODE_FORMAT_ARGS(activeNode),
 						   ReplicationStateGetName(activeNode->goalState))));
 	}
 
@@ -181,12 +175,9 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 			LogAndNotifyMessage(
 				message, BUFSIZE,
-				"Setting goal state of node %d \"%s\" (%s:%d) to draining "
-				"after it became unhealthy.",
-				primaryNode->nodeId,
-				primaryNode->nodeName,
-				primaryNode->nodeHost,
-				primaryNode->nodePort);
+				"Setting goal state of " NODE_FORMAT " to draining "
+													 "after it became unhealthy.",
+				NODE_FORMAT_ARGS(primaryNode));
 
 			AssignGoalState(primaryNode, REPLICATION_STATE_DRAINING, message);
 		}
@@ -222,16 +213,11 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of node %d \"%s\" (%s:%d) to secondary "
-			"after node %d \"%s\" (%s:%d) got selected as the failover candidate.",
-			activeNode->nodeId,
-			activeNode->nodeName,
-			activeNode->nodeHost,
-			activeNode->nodePort,
-			primaryNode->nodeId,
-			primaryNode->nodeName,
-			primaryNode->nodeHost,
-			primaryNode->nodePort);
+			"Setting goal state of " NODE_FORMAT " to secondary "
+												 "after " NODE_FORMAT
+			" got selected as the failover candidate.",
+			NODE_FORMAT_ARGS(activeNode),
+			NODE_FORMAT_ARGS(primaryNode));
 
 		AssignGoalState(activeNode, REPLICATION_STATE_SECONDARY, message);
 		AssignGoalState(primaryNode, REPLICATION_STATE_PRIMARY, message);
@@ -251,16 +237,11 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of node %d \"%s\" (%s:%d) to secondary "
-			"after node %d \"%s\" (%s:%d) got selected as the failover candidate.",
-			activeNode->nodeId,
-			activeNode->nodeName,
-			activeNode->nodeHost,
-			activeNode->nodePort,
-			primaryNode->nodeId,
-			primaryNode->nodeName,
-			primaryNode->nodeHost,
-			primaryNode->nodePort);
+			"Setting goal state of " NODE_FORMAT " to secondary "
+												 "after " NODE_FORMAT
+			" got selected as the failover candidate.",
+			NODE_FORMAT_ARGS(activeNode),
+			NODE_FORMAT_ARGS(primaryNode));
 
 		AssignGoalState(activeNode, REPLICATION_STATE_SECONDARY, message);
 
@@ -277,11 +258,8 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of node %d \"%s\" (%s:%d) to prepare_promotion",
-			activeNode->nodeId,
-			activeNode->nodeName,
-			activeNode->nodeHost,
-			activeNode->nodePort);
+			"Setting goal state of " NODE_FORMAT " to prepare_promotion",
+			NODE_FORMAT_ARGS(activeNode));
 
 		AssignGoalState(activeNode, REPLICATION_STATE_PREPARE_PROMOTION, message);
 
@@ -310,16 +288,11 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of node %d \"%s\" (%s:%d) to catchingup "
-			"after node %d \"%s\" (%s:%d) converged to wait_primary.",
-			activeNode->nodeId,
-			activeNode->nodeName,
-			activeNode->nodeHost,
-			activeNode->nodePort,
-			primaryNode->nodeId,
-			primaryNode->nodeName,
-			primaryNode->nodeHost,
-			primaryNode->nodePort);
+			"Setting goal state of " NODE_FORMAT " to catchingup "
+												 "after " NODE_FORMAT
+			" converged to wait_primary.",
+			NODE_FORMAT_ARGS(activeNode),
+			NODE_FORMAT_ARGS(primaryNode));
 
 		/* start replication */
 		AssignGoalState(activeNode, REPLICATION_STATE_CATCHINGUP, message);
@@ -343,21 +316,11 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of node %d \"%s\" (%s:%d) to primary and "
-			"node %d \"%s\" (%s:%d) to secondary "
-			"after node %d \"%s\" (%s:%d) caught up.",
-			primaryNode->nodeId,
-			primaryNode->nodeName,
-			primaryNode->nodeHost,
-			primaryNode->nodePort,
-			activeNode->nodeId,
-			activeNode->nodeName,
-			activeNode->nodeHost,
-			activeNode->nodePort,
-			activeNode->nodeId,
-			activeNode->nodeName,
-			activeNode->nodeHost,
-			activeNode->nodePort);
+			"Setting goal state of " NODE_FORMAT " to primary and "
+			NODE_FORMAT " to secondary after " NODE_FORMAT " caught up.",
+			NODE_FORMAT_ARGS(primaryNode),
+			NODE_FORMAT_ARGS(activeNode),
+			NODE_FORMAT_ARGS(activeNode));
 
 		/* node is ready for promotion */
 		AssignGoalState(activeNode, REPLICATION_STATE_SECONDARY, message);
@@ -382,21 +345,14 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of node %d \"%s\" (%s:%d) to draining "
-			"and node %d \"%s\" (%s:%d) to prepare_promotion "
-			"after node %d \"%s\" (%s:%d) became unhealthy.",
-			primaryNode->nodeId,
-			primaryNode->nodeName,
-			primaryNode->nodeHost,
-			primaryNode->nodePort,
-			activeNode->nodeId,
-			activeNode->nodeName,
-			activeNode->nodeHost,
-			activeNode->nodePort,
-			primaryNode->nodeId,
-			primaryNode->nodeName,
-			primaryNode->nodeHost,
-			primaryNode->nodePort);
+			"Setting goal state of " NODE_FORMAT " to draining "
+												 "and " NODE_FORMAT
+			" to prepare_promotion "
+			"after " NODE_FORMAT
+			" became unhealthy.",
+			NODE_FORMAT_ARGS(primaryNode),
+			NODE_FORMAT_ARGS(activeNode),
+			NODE_FORMAT_ARGS(primaryNode));
 
 		/* keep reading until no more records are available */
 		AssignGoalState(activeNode, REPLICATION_STATE_PREPARE_PROMOTION, message);
@@ -419,16 +375,11 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of node %d \"%s\" (%s:%d) to maintenance "
-			"after node %d \"%s\" (%s:%d) converged to wait_primary.",
-			activeNode->nodeId,
-			activeNode->nodeName,
-			activeNode->nodeHost,
-			activeNode->nodePort,
-			primaryNode->nodeId,
-			primaryNode->nodeName,
-			primaryNode->nodeHost,
-			primaryNode->nodePort);
+			"Setting goal state of " NODE_FORMAT " to maintenance "
+												 "after " NODE_FORMAT
+			" converged to wait_primary.",
+			NODE_FORMAT_ARGS(activeNode),
+			NODE_FORMAT_ARGS(primaryNode));
 
 		/* secondary reached maintenance */
 		AssignGoalState(activeNode, REPLICATION_STATE_MAINTENANCE, message);
@@ -448,16 +399,11 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of node %d \"%s\" (%s:%d) to maintenance "
-			"after node %d \"%s\" (%s:%d) converged to wait_primary.",
-			activeNode->nodeId,
-			activeNode->nodeName,
-			activeNode->nodeHost,
-			activeNode->nodePort,
-			primaryNode->nodeId,
-			primaryNode->nodeName,
-			primaryNode->nodeHost,
-			primaryNode->nodePort);
+			"Setting goal state of " NODE_FORMAT " to maintenance "
+												 "after " NODE_FORMAT
+			" converged to wait_primary.",
+			NODE_FORMAT_ARGS(activeNode),
+			NODE_FORMAT_ARGS(primaryNode));
 
 		/* secondary reached maintenance */
 		AssignGoalState(activeNode, REPLICATION_STATE_MAINTENANCE, message);
@@ -479,16 +425,11 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of node %d \"%s\" (%s:%d) to stop_replication "
-			"after node %d \"%s\" (%s:%d) converged to prepare_maintenance.",
-			activeNode->nodeId,
-			activeNode->nodeName,
-			activeNode->nodeHost,
-			activeNode->nodePort,
-			primaryNode->nodeId,
-			primaryNode->nodeName,
-			primaryNode->nodeHost,
-			primaryNode->nodePort);
+			"Setting goal state of " NODE_FORMAT " to stop_replication "
+												 "after " NODE_FORMAT
+			" converged to prepare_maintenance.",
+			NODE_FORMAT_ARGS(activeNode),
+			NODE_FORMAT_ARGS(primaryNode));
 
 		/* promote the secondary */
 		AssignGoalState(activeNode, REPLICATION_STATE_STOP_REPLICATION, message);
@@ -507,17 +448,11 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of node %d \"%s\" (%s:%d) to wait_primary "
-			"and node %d \"%s\" (%s:%d) to demoted "
-			"after the coordinator metadata was updated.",
-			activeNode->nodeId,
-			activeNode->nodeName,
-			activeNode->nodeHost,
-			activeNode->nodePort,
-			primaryNode->nodeId,
-			primaryNode->nodeName,
-			primaryNode->nodeHost,
-			primaryNode->nodePort);
+			"Setting goal state of " NODE_FORMAT " to wait_primary "
+												 "and " NODE_FORMAT " to demoted "
+																	"after the coordinator metadata was updated.",
+			NODE_FORMAT_ARGS(activeNode),
+			NODE_FORMAT_ARGS(primaryNode));
 
 		/* node is now taking writes */
 		AssignGoalState(activeNode, REPLICATION_STATE_WAIT_PRIMARY, message);
@@ -544,21 +479,14 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of node %d \"%s\" (%s:%d) to demote_timeout "
-			"and node %d \"%s\" (%s:%d) to stop_replication "
-			"after node %d \"%s\" (%s:%d) converged to prepare_promotion.",
-			primaryNode->nodeId,
-			primaryNode->nodeName,
-			primaryNode->nodeHost,
-			primaryNode->nodePort,
-			activeNode->nodeId,
-			activeNode->nodeName,
-			activeNode->nodeHost,
-			activeNode->nodePort,
-			activeNode->nodeId,
-			activeNode->nodeName,
-			activeNode->nodeHost,
-			activeNode->nodePort);
+			"Setting goal state of " NODE_FORMAT " to demote_timeout "
+												 "and " NODE_FORMAT
+			" to stop_replication "
+			"after " NODE_FORMAT
+			" converged to prepare_promotion.",
+			NODE_FORMAT_ARGS(primaryNode),
+			NODE_FORMAT_ARGS(activeNode),
+			NODE_FORMAT_ARGS(activeNode));
 
 		/* perform promotion to stop replication */
 		AssignGoalState(activeNode, REPLICATION_STATE_STOP_REPLICATION, message);
@@ -580,16 +508,11 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of and node %d \"%s\" (%s:%d) to wait_primary "
-			"after node %d \"%s\" (%s:%d) converged to prepare_promotion.",
-			activeNode->nodeId,
-			activeNode->nodeName,
-			activeNode->nodeHost,
-			activeNode->nodePort,
-			activeNode->nodeId,
-			activeNode->nodeName,
-			activeNode->nodeHost,
-			activeNode->nodePort);
+			"Setting goal state of and " NODE_FORMAT " to wait_primary "
+													 "after " NODE_FORMAT
+			" converged to prepare_promotion.",
+			NODE_FORMAT_ARGS(activeNode),
+			NODE_FORMAT_ARGS(activeNode));
 
 		/* perform promotion to stop replication */
 		AssignGoalState(activeNode, REPLICATION_STATE_WAIT_PRIMARY, message);
@@ -609,16 +532,10 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of node %d \"%s\" (%s:%d) to wait_primary "
-			"and node %d \"%s\" (%s:%d) to maintenance.",
-			activeNode->nodeId,
-			activeNode->nodeName,
-			activeNode->nodeHost,
-			activeNode->nodePort,
-			primaryNode->nodeId,
-			primaryNode->nodeName,
-			primaryNode->nodeHost,
-			primaryNode->nodePort);
+			"Setting goal state of " NODE_FORMAT " to wait_primary "
+												 "and " NODE_FORMAT " to maintenance.",
+			NODE_FORMAT_ARGS(activeNode),
+			NODE_FORMAT_ARGS(primaryNode));
 
 		/* node is now taking writes */
 		AssignGoalState(activeNode, REPLICATION_STATE_WAIT_PRIMARY, message);
@@ -641,17 +558,11 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of node %d \"%s\" (%s:%d) to wait_primary "
-			"and node %d \"%s\" (%s:%d) to demoted "
-			"after the demote timeout expired.",
-			activeNode->nodeId,
-			activeNode->nodeName,
-			activeNode->nodeHost,
-			activeNode->nodePort,
-			primaryNode->nodeId,
-			primaryNode->nodeName,
-			primaryNode->nodeHost,
-			primaryNode->nodePort);
+			"Setting goal state of " NODE_FORMAT " to wait_primary "
+												 "and " NODE_FORMAT " to demoted "
+																	"after the demote timeout expired.",
+			NODE_FORMAT_ARGS(activeNode),
+			NODE_FORMAT_ARGS(primaryNode));
 
 		/* node is now taking writes */
 		AssignGoalState(activeNode, REPLICATION_STATE_WAIT_PRIMARY, message);
@@ -673,17 +584,11 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of node %d \"%s\" (%s:%d) to wait_primary "
-			"and node %d \"%s\" (%s:%d) to demoted "
-			"after the coordinator metadata was updated.",
-			activeNode->nodeId,
-			activeNode->nodeName,
-			activeNode->nodeHost,
-			activeNode->nodePort,
-			primaryNode->nodeId,
-			primaryNode->nodeName,
-			primaryNode->nodeHost,
-			primaryNode->nodePort);
+			"Setting goal state of " NODE_FORMAT " to wait_primary "
+												 "and " NODE_FORMAT " to demoted "
+																	"after the coordinator metadata was updated.",
+			NODE_FORMAT_ARGS(activeNode),
+			NODE_FORMAT_ARGS(primaryNode));
 
 		/* node is now taking writes */
 		AssignGoalState(activeNode, REPLICATION_STATE_WAIT_PRIMARY, message);
@@ -705,17 +610,12 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of node %d \"%s\" (%s:%d) to catchingup "
-			"after it converged to demotion "
-			"and node %d \"%s\" (%s:%d) converged to primary.",
-			activeNode->nodeId,
-			activeNode->nodeName,
-			activeNode->nodeHost,
-			activeNode->nodePort,
-			primaryNode->nodeId,
-			primaryNode->nodeName,
-			primaryNode->nodeHost,
-			primaryNode->nodePort);
+			"Setting goal state of " NODE_FORMAT " to catchingup "
+												 "after it converged to demotion "
+												 "and " NODE_FORMAT
+			" converged to primary.",
+			NODE_FORMAT_ARGS(activeNode),
+			NODE_FORMAT_ARGS(primaryNode));
 
 		/* it's safe to rejoin as a secondary */
 		AssignGoalState(activeNode, REPLICATION_STATE_CATCHINGUP, message);
@@ -735,17 +635,12 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of node %d \"%s\" (%s:%d) to catchingup "
-			"after it converged to demotion "
-			"and node %d \"%s\" (%s:%d) converged to wait_primary.",
-			activeNode->nodeId,
-			activeNode->nodeName,
-			activeNode->nodeHost,
-			activeNode->nodePort,
-			primaryNode->nodeId,
-			primaryNode->nodeName,
-			primaryNode->nodeHost,
-			primaryNode->nodePort);
+			"Setting goal state of " NODE_FORMAT " to catchingup "
+												 "after it converged to demotion "
+												 "and " NODE_FORMAT
+			" converged to wait_primary.",
+			NODE_FORMAT_ARGS(activeNode),
+			NODE_FORMAT_ARGS(primaryNode));
 
 		/* it's safe to rejoin as a secondary */
 		AssignGoalState(activeNode, REPLICATION_STATE_CATCHINGUP, message);
@@ -773,17 +668,11 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of node %d \"%s\" (%s:%d) to secondary "
-			"and node %d \"%s\" (%s:%d) to primary "
-			"after it converged to wait_primary.",
-			activeNode->nodeId,
-			activeNode->nodeName,
-			activeNode->nodeHost,
-			activeNode->nodePort,
-			primaryNode->nodeId,
-			primaryNode->nodeName,
-			primaryNode->nodeHost,
-			primaryNode->nodePort);
+			"Setting goal state of " NODE_FORMAT " to secondary "
+												 "and " NODE_FORMAT " to primary "
+																	"after it converged to wait_primary.",
+			NODE_FORMAT_ARGS(activeNode),
+			NODE_FORMAT_ARGS(primaryNode));
 
 		/* it's safe to rejoin as a secondary */
 		AssignGoalState(activeNode, REPLICATION_STATE_SECONDARY, message);
@@ -806,16 +695,11 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of node %d \"%s\" (%s:%d) to secondary "
-			"after node %d \"%s\" (%s:%d) converged to primary.",
-			activeNode->nodeId,
-			activeNode->nodeName,
-			activeNode->nodeHost,
-			activeNode->nodePort,
-			primaryNode->nodeId,
-			primaryNode->nodeName,
-			primaryNode->nodeHost,
-			primaryNode->nodePort);
+			"Setting goal state of " NODE_FORMAT " to secondary "
+												 "after " NODE_FORMAT
+			" converged to primary.",
+			NODE_FORMAT_ARGS(activeNode),
+			NODE_FORMAT_ARGS(primaryNode));
 
 		/* it's safe to rejoin as a secondary */
 		AssignGoalState(activeNode, REPLICATION_STATE_SECONDARY, message);
@@ -854,16 +738,10 @@ ProceedGroupStateForPrimaryNode(AutoFailoverNode *primaryNode)
 
 				LogAndNotifyMessage(
 					message, BUFSIZE,
-					"Setting goal state of %d \"%s\" (%s:%d) to wait_primary "
-					"after node %d \"%s\" (%s:%d) joined.",
-					primaryNode->nodeId,
-					primaryNode->nodeName,
-					primaryNode->nodeHost,
-					primaryNode->nodePort,
-					otherNode->nodeId,
-					otherNode->nodeName,
-					otherNode->nodeHost,
-					otherNode->nodePort);
+					"Setting goal state of " NODE_FORMAT " to wait_primary "
+														 "after " NODE_FORMAT " joined.",
+					NODE_FORMAT_ARGS(primaryNode),
+					NODE_FORMAT_ARGS(otherNode));
 
 				/* prepare replication slot and pg_hba.conf */
 				AssignGoalState(primaryNode,
@@ -893,16 +771,10 @@ ProceedGroupStateForPrimaryNode(AutoFailoverNode *primaryNode)
 
 				LogAndNotifyMessage(
 					message, BUFSIZE,
-					"Setting goal state of node %d \"%s\" (%s:%d) to join_primary "
-					"after node %d \"%s\" (%s:%d) joined.",
-					primaryNode->nodeId,
-					primaryNode->nodeName,
-					primaryNode->nodeHost,
-					primaryNode->nodePort,
-					otherNode->nodeId,
-					otherNode->nodeName,
-					otherNode->nodeHost,
-					otherNode->nodePort);
+					"Setting goal state of " NODE_FORMAT " to join_primary "
+														 "after " NODE_FORMAT " joined.",
+					NODE_FORMAT_ARGS(primaryNode),
+					NODE_FORMAT_ARGS(otherNode));
 
 				/* prepare replication slot and pg_hba.conf */
 				AssignGoalState(primaryNode,
@@ -943,12 +815,9 @@ ProceedGroupStateForPrimaryNode(AutoFailoverNode *primaryNode)
 
 				LogAndNotifyMessage(
 					message, BUFSIZE,
-					"Setting goal state of node %d \"%s\" (%s:%d) to catchingup "
-					"after it became unhealthy.",
-					otherNode->nodeId,
-					otherNode->nodeName,
-					otherNode->nodeHost,
-					otherNode->nodePort);
+					"Setting goal state of " NODE_FORMAT " to catchingup "
+														 "after it became unhealthy.",
+					NODE_FORMAT_ARGS(otherNode));
 
 				/* other node is behind, no longer eligible for promotion */
 				AssignGoalState(otherNode,
@@ -986,12 +855,9 @@ ProceedGroupStateForPrimaryNode(AutoFailoverNode *primaryNode)
 
 				LogAndNotifyMessage(
 					message, BUFSIZE,
-					"Setting goal state of node %d \"%s\" (%s:%d) to wait_primary "
-					"now that none of the standbys are healthy anymore.",
-					primaryNode->nodeId,
-					primaryNode->nodeName,
-					primaryNode->nodeHost,
-					primaryNode->nodePort);
+					"Setting goal state of " NODE_FORMAT " to wait_primary "
+														 "now that none of the standbys are healthy anymore.",
+					NODE_FORMAT_ARGS(primaryNode));
 
 				AssignGoalState(primaryNode,
 								REPLICATION_STATE_WAIT_PRIMARY, message);
@@ -1011,12 +877,9 @@ ProceedGroupStateForPrimaryNode(AutoFailoverNode *primaryNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of node %d \"%s\" (%s:%d) to primary "
-			"after it applied replication properties change.",
-			primaryNode->nodeId,
-			primaryNode->nodeName,
-			primaryNode->nodeHost,
-			primaryNode->nodePort);
+			"Setting goal state of " NODE_FORMAT " to primary "
+												 "after it applied replication properties change.",
+			NODE_FORMAT_ARGS(primaryNode));
 
 		AssignGoalState(primaryNode, REPLICATION_STATE_PRIMARY, message);
 
@@ -1058,11 +921,8 @@ ProceedGroupStateForPrimaryNode(AutoFailoverNode *primaryNode)
 
 			LogAndNotifyMessage(
 				message, BUFSIZE,
-				"Setting goal state of node %d \"%s\" (%s:%d) back to primary",
-				primaryNode->nodeId,
-				primaryNode->nodeName,
-				primaryNode->nodeHost,
-				primaryNode->nodePort);
+				"Setting goal state of " NODE_FORMAT " back to primary",
+				NODE_FORMAT_ARGS(primaryNode));
 
 			AssignGoalState(primaryNode, REPLICATION_STATE_PRIMARY, message);
 
@@ -1107,11 +967,8 @@ ProceedGroupStateForMSFailover(AutoFailoverNode *activeNode,
 	 */
 	if (nodeBeingPromoted != NULL)
 	{
-		elog(LOG, "Found candidate node %d \"%s\" (%s:%d)",
-			 nodeBeingPromoted->nodeId,
-			 nodeBeingPromoted->nodeName,
-			 nodeBeingPromoted->nodeHost,
-			 nodeBeingPromoted->nodePort);
+		elog(LOG, "Found candidate " NODE_FORMAT,
+			 NODE_FORMAT_ARGS(nodeBeingPromoted));
 
 		return ProceedWithMSFailover(activeNode, nodeBeingPromoted);
 	}
@@ -1159,10 +1016,7 @@ ProceedGroupStateForMSFailover(AutoFailoverNode *activeNode,
 			"activeNode is %d \"%s\" (%s:%d) and reported state \"%s\"",
 			candidateList.candidateCount,
 			candidateList.missingNodesCount,
-			activeNode->nodeId,
-			activeNode->nodeName,
-			activeNode->nodeHost,
-			activeNode->nodePort,
+			NODE_FORMAT_ARGS(activeNode),
 			ReplicationStateGetName(activeNode->reportedState));
 
 		return false;
@@ -1203,13 +1057,10 @@ ProceedGroupStateForMSFailover(AutoFailoverNode *activeNode,
 			LogAndNotifyMessage(
 				message, BUFSIZE,
 				"The current most advanced reported LSN is %X/%X, "
-				"as reported by node %d \"%s\" (%s:%d) and %d other nodes",
+				"as reported by " NODE_FORMAT " and %d other nodes",
 				(uint32) (mostAdvancedNode->reportedLSN >> 32),
 				(uint32) mostAdvancedNode->reportedLSN,
-				mostAdvancedNode->nodeId,
-				mostAdvancedNode->nodeName,
-				mostAdvancedNode->nodeHost,
-				mostAdvancedNode->nodePort,
+				NODE_FORMAT_ARGS(mostAdvancedNode),
 				list_length(mostAdvancedNodeList) - 1);
 		}
 		else
@@ -1236,10 +1087,7 @@ ProceedGroupStateForMSFailover(AutoFailoverNode *activeNode,
 				"reported their LSN and we failed to select one of them; "
 				"activeNode is %d \"%s\" (%s:%d) and reported state \"%s\"",
 				candidateList.candidateCount,
-				activeNode->nodeId,
-				activeNode->nodeName,
-				activeNode->nodeHost,
-				activeNode->nodePort,
+				NODE_FORMAT_ARGS(activeNode),
 				ReplicationStateGetName(activeNode->reportedState));
 
 			return false;
@@ -1282,8 +1130,8 @@ BuildCandidateList(List *nodesGroupList, CandidateList *candidateList)
 		if (StateBelongsToPrimary(node->goalState))
 		{
 			elog(LOG,
-				 "Skipping candidate node %d \"%s\" (%s:%d), "
-				 "which is a primary (old or new)",
+				 "Skipping candidate " NODE_FORMAT ", "
+												   "which is a primary (old or new)",
 				 node->nodeId, node->nodeName, node->nodeHost, node->nodePort);
 			continue;
 		}
@@ -1296,7 +1144,7 @@ BuildCandidateList(List *nodesGroupList, CandidateList *candidateList)
 		if (IsUnhealthy(node) && !IsReporting(node))
 		{
 			elog(LOG,
-				 "Skipping candidate node %d \"%s\" (%s:%d), which is unhealthy",
+				 "Skipping candidate " NODE_FORMAT ", which is unhealthy",
 				 node->nodeId, node->nodeName, node->nodeHost, node->nodePort);
 
 			continue;
@@ -1331,8 +1179,8 @@ BuildCandidateList(List *nodesGroupList, CandidateList *candidateList)
 
 			LogAndNotifyMessage(
 				message, BUFSIZE,
-				"Setting goal state of node %d \"%s\" (%s:%d) to report_lsn "
-				"to find the failover candidate",
+				"Setting goal state of " NODE_FORMAT " to report_lsn "
+													 "to find the failover candidate",
 				node->nodeId, node->nodeName, node->nodeHost, node->nodePort);
 
 			AssignGoalState(node, REPLICATION_STATE_REPORT_LSN, message);
@@ -1377,16 +1225,11 @@ ProceedWithMSFailover(AutoFailoverNode *activeNode,
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of node %d \"%s\" (%s:%d) to join_secondary "
-			"after node %d \"%s\" (%s:%d) got selected as the failover candidate.",
-			activeNode->nodeId,
-			activeNode->nodeName,
-			activeNode->nodeHost,
-			activeNode->nodePort,
-			candidateNode->nodeId,
-			candidateNode->nodeName,
-			candidateNode->nodeHost,
-			candidateNode->nodePort);
+			"Setting goal state of " NODE_FORMAT " to join_secondary "
+												 "after " NODE_FORMAT
+			" got selected as the failover candidate.",
+			NODE_FORMAT_ARGS(activeNode),
+			NODE_FORMAT_ARGS(candidateNode));
 
 		AssignGoalState(activeNode, REPLICATION_STATE_JOIN_SECONDARY, message);
 
@@ -1460,21 +1303,15 @@ SelectFailoverCandidateNode(CandidateList *candidateList,
 		LogAndNotifyMessage(
 			message, BUFSIZE,
 			"One of the most advanced standby node in the group "
-			"is node %d \"%s\" (%s:%d) "
-			"with reported LSN %X/%X, which is more than "
-			"pgautofailover.enable_sync_wal_log_threshold (%d) behind "
-			"the primary node %d \"%s\" (%s:%d), which has reported %X/%X",
-			mostAdvancedNode->nodeId,
-			mostAdvancedNode->nodeName,
-			mostAdvancedNode->nodeHost,
-			mostAdvancedNode->nodePort,
+			"is " NODE_FORMAT " "
+							  "with reported LSN %X/%X, which is more than "
+							  "pgautofailover.enable_sync_wal_log_threshold (%d) behind "
+							  "the primary " NODE_FORMAT ", which has reported %X/%X",
+			NODE_FORMAT_ARGS(mostAdvancedNode),
 			(uint32) (mostAdvancedNode->reportedLSN >> 32),
 			(uint32) mostAdvancedNode->reportedLSN,
 			PromoteXlogThreshold,
-			primaryNode->nodeId,
-			primaryNode->nodeName,
-			primaryNode->nodeHost,
-			primaryNode->nodePort,
+			NODE_FORMAT_ARGS(primaryNode),
 			(uint32) (primaryNode->reportedLSN >> 32),
 			(uint32) primaryNode->reportedLSN);
 
@@ -1497,9 +1334,9 @@ SelectFailoverCandidateNode(CandidateList *candidateList,
 
 			LogAndNotifyMessage(
 				message, BUFSIZE,
-				"Not selecting failover candidate node %d \"%s\" (%s:%d) "
-				"because it is unhealthy",
-				node->nodeId, node->nodeName, node->nodeHost, node->nodePort);
+				"Not selecting failover candidate " NODE_FORMAT " "
+																"because it is unhealthy",
+				NODE_FORMAT_ARGS(node));
 
 			continue;
 		}
@@ -1559,10 +1396,7 @@ SelectFailoverCandidateNode(CandidateList *candidateList,
 				"WAL to reach LSN %X/%X (from current reported LSN %X/%X) "
 				"and none of the most advanced standby nodes are healthy "
 				"at the moment.",
-				selectedNode->nodeId,
-				selectedNode->nodeName,
-				selectedNode->nodeHost,
-				selectedNode->nodePort,
+				NODE_FORMAT_ARGS(selectedNode),
 				(uint32) (mostAdvancedNode->reportedLSN >> 32),
 				(uint32) mostAdvancedNode->reportedLSN,
 				(uint32) (selectedNode->reportedLSN >> 32),
@@ -1615,12 +1449,9 @@ PromoteSelectedNode(AutoFailoverNode *selectedNode,
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Updating candidate priority back to %d for node %d \"%s\" (%s:%d)",
+			"Updating candidate priority back to %d for " NODE_FORMAT,
 			selectedNode->candidatePriority,
-			selectedNode->nodeId,
-			selectedNode->nodeName,
-			selectedNode->nodeHost,
-			selectedNode->nodePort);
+			NODE_FORMAT_ARGS(selectedNode));
 
 		NotifyStateChange(selectedNode, message);
 	}
@@ -1633,31 +1464,21 @@ PromoteSelectedNode(AutoFailoverNode *selectedNode,
 		{
 			LogAndNotifyMessage(
 				message, BUFSIZE,
-				"Setting goal state of node %d \"%s\" (%s:%d) "
-				"to prepare_promotion "
-				"after node %d \"%s\" (%s:%d) became unhealthy "
+				"Setting goal state of " NODE_FORMAT "to prepare_promotion "
+													 "after " NODE_FORMAT
+				" became unhealthy "
 				"and %d nodes reported their LSN position.",
-				selectedNode->nodeId,
-				selectedNode->nodeName,
-				selectedNode->nodeHost,
-				selectedNode->nodePort,
-				primaryNode->nodeId,
-				primaryNode->nodeName,
-				primaryNode->nodeHost,
-				primaryNode->nodePort,
+				NODE_FORMAT_ARGS(selectedNode),
+				NODE_FORMAT_ARGS(primaryNode),
 				candidateList->candidateCount);
 		}
 		else
 		{
 			LogAndNotifyMessage(
 				message, BUFSIZE,
-				"Setting goal state of node %d \"%s\" (%s:%d) "
-				"to prepare_promotion "
-				"and %d nodes reported their LSN position.",
-				selectedNode->nodeId,
-				selectedNode->nodeName,
-				selectedNode->nodeHost,
-				selectedNode->nodePort,
+				"Setting goal state of " NODE_FORMAT " to prepare_promotion "
+													 "and %d nodes reported their LSN position.",
+				NODE_FORMAT_ARGS(selectedNode),
 				candidateList->candidateCount);
 		}
 
@@ -1676,29 +1497,21 @@ PromoteSelectedNode(AutoFailoverNode *selectedNode,
 		{
 			LogAndNotifyMessage(
 				message, BUFSIZE,
-				"Setting goal state of node %d \"%s\" (%s:%d) to fast_forward "
-				"after node %d \"%s\" (%s:%d) became unhealthy "
+				"Setting goal state of " NODE_FORMAT " to fast_forward "
+													 "after " NODE_FORMAT
+				" became unhealthy "
 				"and %d nodes reported their LSN position.",
-				selectedNode->nodeId,
-				selectedNode->nodeName,
-				selectedNode->nodeHost,
-				selectedNode->nodePort,
-				primaryNode->nodeId,
-				primaryNode->nodeName,
-				primaryNode->nodeHost,
-				primaryNode->nodePort,
+				NODE_FORMAT_ARGS(selectedNode),
+				NODE_FORMAT_ARGS(primaryNode),
 				candidateList->candidateCount);
 		}
 		else
 		{
 			LogAndNotifyMessage(
 				message, BUFSIZE,
-				"Setting goal state of node %d \"%s\" (%s:%d) to fast_forward "
-				"and %d nodes reported their LSN position.",
-				selectedNode->nodeId,
-				selectedNode->nodeName,
-				selectedNode->nodeHost,
-				selectedNode->nodePort,
+				"Setting goal state of " NODE_FORMAT " to fast_forward "
+													 "and %d nodes reported their LSN position.",
+				NODE_FORMAT_ARGS(selectedNode),
 				candidateList->candidateCount);
 		}
 

--- a/src/monitor/group_state_machine.c
+++ b/src/monitor/group_state_machine.c
@@ -115,8 +115,8 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of " NODE_FORMAT " to single "
-												 "as there is no other node.",
+			"Setting goal state of " NODE_FORMAT
+			" to single as there is no other node.",
 			NODE_FORMAT_ARGS(activeNode));
 
 		/* other node may have been removed */
@@ -160,7 +160,8 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 				(errmsg("ProceedGroupState couldn't find the primary node "
 						"in formation \"%s\", group %d",
 						formationId, groupId),
-				 errdetail("activeNode is " NODE_FORMAT " in state %s",
+				 errdetail("activeNode is " NODE_FORMAT
+						   " in state %s",
 						   NODE_FORMAT_ARGS(activeNode),
 						   ReplicationStateGetName(activeNode->goalState))));
 	}
@@ -175,8 +176,8 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 			LogAndNotifyMessage(
 				message, BUFSIZE,
-				"Setting goal state of " NODE_FORMAT " to draining "
-													 "after it became unhealthy.",
+				"Setting goal state of " NODE_FORMAT
+				" to draining after it became unhealthy.",
 				NODE_FORMAT_ARGS(primaryNode));
 
 			AssignGoalState(primaryNode, REPLICATION_STATE_DRAINING, message);
@@ -213,8 +214,8 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of " NODE_FORMAT " to secondary "
-												 "after " NODE_FORMAT
+			"Setting goal state of " NODE_FORMAT
+			" to secondary after " NODE_FORMAT
 			" got selected as the failover candidate.",
 			NODE_FORMAT_ARGS(activeNode),
 			NODE_FORMAT_ARGS(primaryNode));
@@ -237,8 +238,8 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of " NODE_FORMAT " to secondary "
-												 "after " NODE_FORMAT
+			"Setting goal state of " NODE_FORMAT
+			" to secondary after " NODE_FORMAT
 			" got selected as the failover candidate.",
 			NODE_FORMAT_ARGS(activeNode),
 			NODE_FORMAT_ARGS(primaryNode));
@@ -258,7 +259,8 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of " NODE_FORMAT " to prepare_promotion",
+			"Setting goal state of " NODE_FORMAT
+			" to prepare_promotion",
 			NODE_FORMAT_ARGS(activeNode));
 
 		AssignGoalState(activeNode, REPLICATION_STATE_PREPARE_PROMOTION, message);
@@ -288,8 +290,8 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of " NODE_FORMAT " to catchingup "
-												 "after " NODE_FORMAT
+			"Setting goal state of " NODE_FORMAT
+			" to catchingup after " NODE_FORMAT
 			" converged to wait_primary.",
 			NODE_FORMAT_ARGS(activeNode),
 			NODE_FORMAT_ARGS(primaryNode));
@@ -316,8 +318,10 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of " NODE_FORMAT " to primary and "
-			NODE_FORMAT " to secondary after " NODE_FORMAT " caught up.",
+			"Setting goal state of " NODE_FORMAT
+			" to primary and " NODE_FORMAT
+			" to secondary after " NODE_FORMAT
+			" caught up.",
 			NODE_FORMAT_ARGS(primaryNode),
 			NODE_FORMAT_ARGS(activeNode),
 			NODE_FORMAT_ARGS(activeNode));
@@ -345,8 +349,8 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of " NODE_FORMAT " to draining "
-												 "and " NODE_FORMAT
+			"Setting goal state of " NODE_FORMAT
+			" to draining and " NODE_FORMAT
 			" to prepare_promotion "
 			"after " NODE_FORMAT
 			" became unhealthy.",
@@ -375,8 +379,8 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of " NODE_FORMAT " to maintenance "
-												 "after " NODE_FORMAT
+			"Setting goal state of " NODE_FORMAT
+			" to maintenance after " NODE_FORMAT
 			" converged to wait_primary.",
 			NODE_FORMAT_ARGS(activeNode),
 			NODE_FORMAT_ARGS(primaryNode));
@@ -399,8 +403,8 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of " NODE_FORMAT " to maintenance "
-												 "after " NODE_FORMAT
+			"Setting goal state of " NODE_FORMAT
+			" to maintenance after " NODE_FORMAT
 			" converged to wait_primary.",
 			NODE_FORMAT_ARGS(activeNode),
 			NODE_FORMAT_ARGS(primaryNode));
@@ -425,8 +429,8 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of " NODE_FORMAT " to stop_replication "
-												 "after " NODE_FORMAT
+			"Setting goal state of " NODE_FORMAT
+			" to stop_replication after " NODE_FORMAT
 			" converged to prepare_maintenance.",
 			NODE_FORMAT_ARGS(activeNode),
 			NODE_FORMAT_ARGS(primaryNode));
@@ -448,9 +452,9 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of " NODE_FORMAT " to wait_primary "
-												 "and " NODE_FORMAT " to demoted "
-																	"after the coordinator metadata was updated.",
+			"Setting goal state of " NODE_FORMAT
+			" to wait_primary and " NODE_FORMAT
+			" to demoted after the coordinator metadata was updated.",
 			NODE_FORMAT_ARGS(activeNode),
 			NODE_FORMAT_ARGS(primaryNode));
 
@@ -479,8 +483,8 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of " NODE_FORMAT " to demote_timeout "
-												 "and " NODE_FORMAT
+			"Setting goal state of " NODE_FORMAT
+			" to demote_timeout and " NODE_FORMAT
 			" to stop_replication "
 			"after " NODE_FORMAT
 			" converged to prepare_promotion.",
@@ -508,8 +512,8 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of and " NODE_FORMAT " to wait_primary "
-													 "after " NODE_FORMAT
+			"Setting goal state of and " NODE_FORMAT
+			" to wait_primary after " NODE_FORMAT
 			" converged to prepare_promotion.",
 			NODE_FORMAT_ARGS(activeNode),
 			NODE_FORMAT_ARGS(activeNode));
@@ -532,8 +536,9 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of " NODE_FORMAT " to wait_primary "
-												 "and " NODE_FORMAT " to maintenance.",
+			"Setting goal state of " NODE_FORMAT
+			" to wait_primary and " NODE_FORMAT
+			" to maintenance.",
 			NODE_FORMAT_ARGS(activeNode),
 			NODE_FORMAT_ARGS(primaryNode));
 
@@ -558,9 +563,9 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of " NODE_FORMAT " to wait_primary "
-												 "and " NODE_FORMAT " to demoted "
-																	"after the demote timeout expired.",
+			"Setting goal state of " NODE_FORMAT
+			" to wait_primary and " NODE_FORMAT
+			" to demoted after the demote timeout expired.",
 			NODE_FORMAT_ARGS(activeNode),
 			NODE_FORMAT_ARGS(primaryNode));
 
@@ -584,9 +589,9 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of " NODE_FORMAT " to wait_primary "
-												 "and " NODE_FORMAT " to demoted "
-																	"after the coordinator metadata was updated.",
+			"Setting goal state of " NODE_FORMAT
+			" to wait_primary and " NODE_FORMAT
+			" to demoted after the coordinator metadata was updated.",
 			NODE_FORMAT_ARGS(activeNode),
 			NODE_FORMAT_ARGS(primaryNode));
 
@@ -610,9 +615,8 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of " NODE_FORMAT " to catchingup "
-												 "after it converged to demotion "
-												 "and " NODE_FORMAT
+			"Setting goal state of " NODE_FORMAT
+			" to catchingup after it converged to demotion and " NODE_FORMAT
 			" converged to primary.",
 			NODE_FORMAT_ARGS(activeNode),
 			NODE_FORMAT_ARGS(primaryNode));
@@ -635,9 +639,8 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of " NODE_FORMAT " to catchingup "
-												 "after it converged to demotion "
-												 "and " NODE_FORMAT
+			"Setting goal state of " NODE_FORMAT
+			" to catchingup after it converged to demotion and " NODE_FORMAT
 			" converged to wait_primary.",
 			NODE_FORMAT_ARGS(activeNode),
 			NODE_FORMAT_ARGS(primaryNode));
@@ -668,9 +671,9 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of " NODE_FORMAT " to secondary "
-												 "and " NODE_FORMAT " to primary "
-																	"after it converged to wait_primary.",
+			"Setting goal state of " NODE_FORMAT
+			" to secondary and " NODE_FORMAT
+			" to primary after it converged to wait_primary.",
 			NODE_FORMAT_ARGS(activeNode),
 			NODE_FORMAT_ARGS(primaryNode));
 
@@ -695,8 +698,8 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of " NODE_FORMAT " to secondary "
-												 "after " NODE_FORMAT
+			"Setting goal state of " NODE_FORMAT
+			" to secondary after " NODE_FORMAT
 			" converged to primary.",
 			NODE_FORMAT_ARGS(activeNode),
 			NODE_FORMAT_ARGS(primaryNode));
@@ -738,8 +741,9 @@ ProceedGroupStateForPrimaryNode(AutoFailoverNode *primaryNode)
 
 				LogAndNotifyMessage(
 					message, BUFSIZE,
-					"Setting goal state of " NODE_FORMAT " to wait_primary "
-														 "after " NODE_FORMAT " joined.",
+					"Setting goal state of " NODE_FORMAT
+					" to wait_primary after " NODE_FORMAT
+					" joined.",
 					NODE_FORMAT_ARGS(primaryNode),
 					NODE_FORMAT_ARGS(otherNode));
 
@@ -771,8 +775,9 @@ ProceedGroupStateForPrimaryNode(AutoFailoverNode *primaryNode)
 
 				LogAndNotifyMessage(
 					message, BUFSIZE,
-					"Setting goal state of " NODE_FORMAT " to join_primary "
-														 "after " NODE_FORMAT " joined.",
+					"Setting goal state of " NODE_FORMAT
+					" to join_primary after " NODE_FORMAT
+					" joined.",
 					NODE_FORMAT_ARGS(primaryNode),
 					NODE_FORMAT_ARGS(otherNode));
 
@@ -815,8 +820,8 @@ ProceedGroupStateForPrimaryNode(AutoFailoverNode *primaryNode)
 
 				LogAndNotifyMessage(
 					message, BUFSIZE,
-					"Setting goal state of " NODE_FORMAT " to catchingup "
-														 "after it became unhealthy.",
+					"Setting goal state of " NODE_FORMAT
+					" to catchingup after it became unhealthy.",
 					NODE_FORMAT_ARGS(otherNode));
 
 				/* other node is behind, no longer eligible for promotion */
@@ -855,8 +860,9 @@ ProceedGroupStateForPrimaryNode(AutoFailoverNode *primaryNode)
 
 				LogAndNotifyMessage(
 					message, BUFSIZE,
-					"Setting goal state of " NODE_FORMAT " to wait_primary "
-														 "now that none of the standbys are healthy anymore.",
+					"Setting goal state of " NODE_FORMAT
+					" to wait_primary now that none of the standbys "
+					"are healthy anymore.",
 					NODE_FORMAT_ARGS(primaryNode));
 
 				AssignGoalState(primaryNode,
@@ -877,8 +883,8 @@ ProceedGroupStateForPrimaryNode(AutoFailoverNode *primaryNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of " NODE_FORMAT " to primary "
-												 "after it applied replication properties change.",
+			"Setting goal state of " NODE_FORMAT
+			" to primary after it applied replication properties change.",
 			NODE_FORMAT_ARGS(primaryNode));
 
 		AssignGoalState(primaryNode, REPLICATION_STATE_PRIMARY, message);
@@ -921,7 +927,8 @@ ProceedGroupStateForPrimaryNode(AutoFailoverNode *primaryNode)
 
 			LogAndNotifyMessage(
 				message, BUFSIZE,
-				"Setting goal state of " NODE_FORMAT " back to primary",
+				"Setting goal state of " NODE_FORMAT
+				" back to primary",
 				NODE_FORMAT_ARGS(primaryNode));
 
 			AssignGoalState(primaryNode, REPLICATION_STATE_PRIMARY, message);
@@ -1057,7 +1064,8 @@ ProceedGroupStateForMSFailover(AutoFailoverNode *activeNode,
 			LogAndNotifyMessage(
 				message, BUFSIZE,
 				"The current most advanced reported LSN is %X/%X, "
-				"as reported by " NODE_FORMAT " and %d other nodes",
+				"as reported by " NODE_FORMAT
+				" and %d other nodes",
 				(uint32) (mostAdvancedNode->reportedLSN >> 32),
 				(uint32) mostAdvancedNode->reportedLSN,
 				NODE_FORMAT_ARGS(mostAdvancedNode),
@@ -1130,8 +1138,8 @@ BuildCandidateList(List *nodesGroupList, CandidateList *candidateList)
 		if (StateBelongsToPrimary(node->goalState))
 		{
 			elog(LOG,
-				 "Skipping candidate " NODE_FORMAT ", "
-												   "which is a primary (old or new)",
+				 "Skipping candidate " NODE_FORMAT
+				 ", which is a primary (old or new)",
 				 node->nodeId, node->nodeName, node->nodeHost, node->nodePort);
 			continue;
 		}
@@ -1179,8 +1187,8 @@ BuildCandidateList(List *nodesGroupList, CandidateList *candidateList)
 
 			LogAndNotifyMessage(
 				message, BUFSIZE,
-				"Setting goal state of " NODE_FORMAT " to report_lsn "
-													 "to find the failover candidate",
+				"Setting goal state of " NODE_FORMAT
+				" to report_lsn to find the failover candidate",
 				node->nodeId, node->nodeName, node->nodeHost, node->nodePort);
 
 			AssignGoalState(node, REPLICATION_STATE_REPORT_LSN, message);
@@ -1225,8 +1233,8 @@ ProceedWithMSFailover(AutoFailoverNode *activeNode,
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of " NODE_FORMAT " to join_secondary "
-												 "after " NODE_FORMAT
+			"Setting goal state of " NODE_FORMAT
+			" to join_secondary after " NODE_FORMAT
 			" got selected as the failover candidate.",
 			NODE_FORMAT_ARGS(activeNode),
 			NODE_FORMAT_ARGS(candidateNode));
@@ -1303,10 +1311,11 @@ SelectFailoverCandidateNode(CandidateList *candidateList,
 		LogAndNotifyMessage(
 			message, BUFSIZE,
 			"One of the most advanced standby node in the group "
-			"is " NODE_FORMAT " "
-							  "with reported LSN %X/%X, which is more than "
-							  "pgautofailover.enable_sync_wal_log_threshold (%d) behind "
-							  "the primary " NODE_FORMAT ", which has reported %X/%X",
+			"is " NODE_FORMAT
+			"with reported LSN %X/%X, which is more than "
+			"pgautofailover.enable_sync_wal_log_threshold (%d) behind "
+			"the primary " NODE_FORMAT
+			", which has reported %X/%X",
 			NODE_FORMAT_ARGS(mostAdvancedNode),
 			(uint32) (mostAdvancedNode->reportedLSN >> 32),
 			(uint32) mostAdvancedNode->reportedLSN,
@@ -1334,8 +1343,8 @@ SelectFailoverCandidateNode(CandidateList *candidateList,
 
 			LogAndNotifyMessage(
 				message, BUFSIZE,
-				"Not selecting failover candidate " NODE_FORMAT " "
-																"because it is unhealthy",
+				"Not selecting failover candidate " NODE_FORMAT
+				"because it is unhealthy",
 				NODE_FORMAT_ARGS(node));
 
 			continue;
@@ -1464,8 +1473,8 @@ PromoteSelectedNode(AutoFailoverNode *selectedNode,
 		{
 			LogAndNotifyMessage(
 				message, BUFSIZE,
-				"Setting goal state of " NODE_FORMAT "to prepare_promotion "
-													 "after " NODE_FORMAT
+				"Setting goal state of " NODE_FORMAT
+				"to prepare_promotion after " NODE_FORMAT
 				" became unhealthy "
 				"and %d nodes reported their LSN position.",
 				NODE_FORMAT_ARGS(selectedNode),
@@ -1476,8 +1485,8 @@ PromoteSelectedNode(AutoFailoverNode *selectedNode,
 		{
 			LogAndNotifyMessage(
 				message, BUFSIZE,
-				"Setting goal state of " NODE_FORMAT " to prepare_promotion "
-													 "and %d nodes reported their LSN position.",
+				"Setting goal state of " NODE_FORMAT
+				" to prepare_promotion and %d nodes reported their LSN position.",
 				NODE_FORMAT_ARGS(selectedNode),
 				candidateList->candidateCount);
 		}
@@ -1497,8 +1506,8 @@ PromoteSelectedNode(AutoFailoverNode *selectedNode,
 		{
 			LogAndNotifyMessage(
 				message, BUFSIZE,
-				"Setting goal state of " NODE_FORMAT " to fast_forward "
-													 "after " NODE_FORMAT
+				"Setting goal state of " NODE_FORMAT
+				" to fast_forward after " NODE_FORMAT
 				" became unhealthy "
 				"and %d nodes reported their LSN position.",
 				NODE_FORMAT_ARGS(selectedNode),
@@ -1509,8 +1518,8 @@ PromoteSelectedNode(AutoFailoverNode *selectedNode,
 		{
 			LogAndNotifyMessage(
 				message, BUFSIZE,
-				"Setting goal state of " NODE_FORMAT " to fast_forward "
-													 "and %d nodes reported their LSN position.",
+				"Setting goal state of " NODE_FORMAT
+				" to fast_forward and %d nodes reported their LSN position.",
 				NODE_FORMAT_ARGS(selectedNode),
 				candidateList->candidateCount);
 		}

--- a/src/monitor/group_state_machine.c
+++ b/src/monitor/group_state_machine.c
@@ -115,9 +115,12 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of node %d (%s:%d) to single "
+			"Setting goal state of node %d \"%s\" (%s:%d) to single "
 			"as there is no other node.",
-			activeNode->nodeId, activeNode->nodeHost, activeNode->nodePort);
+			activeNode->nodeId,
+			activeNode->nodeName,
+			activeNode->nodeHost,
+			activeNode->nodePort);
 
 		/* other node may have been removed */
 		AssignGoalState(activeNode, REPLICATION_STATE_SINGLE, message);
@@ -160,8 +163,11 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 				(errmsg("ProceedGroupState couldn't find the primary node "
 						"in formation \"%s\", group %d",
 						formationId, groupId),
-				 errdetail("activeNode is %s:%d in state %s",
-						   activeNode->nodeHost, activeNode->nodePort,
+				 errdetail("activeNode is node %d \"%s\" (%s:%d) in state %s",
+						   activeNode->nodeId,
+						   activeNode->nodeName,
+						   activeNode->nodeHost,
+						   activeNode->nodePort,
 						   ReplicationStateGetName(activeNode->goalState))));
 	}
 
@@ -175,9 +181,10 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 			LogAndNotifyMessage(
 				message, BUFSIZE,
-				"Setting goal state of node %d (%s:%d) to draining "
+				"Setting goal state of node %d \"%s\" (%s:%d) to draining "
 				"after it became unhealthy.",
 				primaryNode->nodeId,
+				primaryNode->nodeName,
 				primaryNode->nodeHost,
 				primaryNode->nodePort);
 
@@ -215,12 +222,14 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of node %d (%s:%d) to secondary "
-			"after node %d (%s:%d) got selected as the failover candidate.",
+			"Setting goal state of node %d \"%s\" (%s:%d) to secondary "
+			"after node %d \"%s\" (%s:%d) got selected as the failover candidate.",
 			activeNode->nodeId,
+			activeNode->nodeName,
 			activeNode->nodeHost,
 			activeNode->nodePort,
 			primaryNode->nodeId,
+			primaryNode->nodeName,
 			primaryNode->nodeHost,
 			primaryNode->nodePort);
 
@@ -242,12 +251,14 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of node %d (%s:%d) to secondary "
-			"after node %d (%s:%d) got selected as the failover candidate.",
+			"Setting goal state of node %d \"%s\" (%s:%d) to secondary "
+			"after node %d \"%s\" (%s:%d) got selected as the failover candidate.",
 			activeNode->nodeId,
+			activeNode->nodeName,
 			activeNode->nodeHost,
 			activeNode->nodePort,
 			primaryNode->nodeId,
+			primaryNode->nodeName,
 			primaryNode->nodeHost,
 			primaryNode->nodePort);
 
@@ -266,8 +277,11 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of node %d (%s:%d) to prepare_promotion",
-			activeNode->nodeId, activeNode->nodeHost, activeNode->nodePort);
+			"Setting goal state of node %d \"%s\" (%s:%d) to prepare_promotion",
+			activeNode->nodeId,
+			activeNode->nodeName,
+			activeNode->nodeHost,
+			activeNode->nodePort);
 
 		AssignGoalState(activeNode, REPLICATION_STATE_PREPARE_PROMOTION, message);
 
@@ -296,10 +310,16 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of node %d (%s:%d) to catchingup "
-			"after node %d (%s:%d) converged to wait_primary.",
-			activeNode->nodeId, activeNode->nodeHost, activeNode->nodePort,
-			primaryNode->nodeId, primaryNode->nodeHost, primaryNode->nodePort);
+			"Setting goal state of node %d \"%s\" (%s:%d) to catchingup "
+			"after node %d \"%s\" (%s:%d) converged to wait_primary.",
+			activeNode->nodeId,
+			activeNode->nodeName,
+			activeNode->nodeHost,
+			activeNode->nodePort,
+			primaryNode->nodeId,
+			primaryNode->nodeName,
+			primaryNode->nodeHost,
+			primaryNode->nodePort);
 
 		/* start replication */
 		AssignGoalState(activeNode, REPLICATION_STATE_CATCHINGUP, message);
@@ -323,11 +343,21 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of node %d (%s:%d) to primary and "
-			"node %d (%s:%d) to secondary after node %d (%s:%d) caught up.",
-			primaryNode->nodeId, primaryNode->nodeHost, primaryNode->nodePort,
-			activeNode->nodeId, activeNode->nodeHost, activeNode->nodePort,
-			activeNode->nodeId, activeNode->nodeHost, activeNode->nodePort);
+			"Setting goal state of node %d \"%s\" (%s:%d) to primary and "
+			"node %d \"%s\" (%s:%d) to secondary "
+			"after node %d \"%s\" (%s:%d) caught up.",
+			primaryNode->nodeId,
+			primaryNode->nodeName,
+			primaryNode->nodeHost,
+			primaryNode->nodePort,
+			activeNode->nodeId,
+			activeNode->nodeName,
+			activeNode->nodeHost,
+			activeNode->nodePort,
+			activeNode->nodeId,
+			activeNode->nodeName,
+			activeNode->nodeHost,
+			activeNode->nodePort);
 
 		/* node is ready for promotion */
 		AssignGoalState(activeNode, REPLICATION_STATE_SECONDARY, message);
@@ -352,12 +382,21 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of node %d (%s:%d) to draining "
-			"and node %d (%s:%d) to prepare_promotion "
-			"after node %d (%s:%d) became unhealthy.",
-			primaryNode->nodeId, primaryNode->nodeHost, primaryNode->nodePort,
-			activeNode->nodeId, activeNode->nodeHost, activeNode->nodePort,
-			primaryNode->nodeId, primaryNode->nodeHost, primaryNode->nodePort);
+			"Setting goal state of node %d \"%s\" (%s:%d) to draining "
+			"and node %d \"%s\" (%s:%d) to prepare_promotion "
+			"after node %d \"%s\" (%s:%d) became unhealthy.",
+			primaryNode->nodeId,
+			primaryNode->nodeName,
+			primaryNode->nodeHost,
+			primaryNode->nodePort,
+			activeNode->nodeId,
+			activeNode->nodeName,
+			activeNode->nodeHost,
+			activeNode->nodePort,
+			primaryNode->nodeId,
+			primaryNode->nodeName,
+			primaryNode->nodeHost,
+			primaryNode->nodePort);
 
 		/* keep reading until no more records are available */
 		AssignGoalState(activeNode, REPLICATION_STATE_PREPARE_PROMOTION, message);
@@ -380,10 +419,16 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of %s:%d to maintenance "
-			"after %s:%d converged to wait_primary.",
-			activeNode->nodeHost, activeNode->nodePort,
-			primaryNode->nodeHost, primaryNode->nodePort);
+			"Setting goal state of node %d \"%s\" (%s:%d) to maintenance "
+			"after node %d \"%s\" (%s:%d) converged to wait_primary.",
+			activeNode->nodeId,
+			activeNode->nodeName,
+			activeNode->nodeHost,
+			activeNode->nodePort,
+			primaryNode->nodeId,
+			primaryNode->nodeName,
+			primaryNode->nodeHost,
+			primaryNode->nodePort);
 
 		/* secondary reached maintenance */
 		AssignGoalState(activeNode, REPLICATION_STATE_MAINTENANCE, message);
@@ -403,10 +448,16 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of %s:%d to maintenance "
-			"after %s:%d converged to wait_primary.",
-			activeNode->nodeHost, activeNode->nodePort,
-			primaryNode->nodeHost, primaryNode->nodePort);
+			"Setting goal state of node %d \"%s\" (%s:%d) to maintenance "
+			"after node %d \"%s\" (%s:%d) converged to wait_primary.",
+			activeNode->nodeId,
+			activeNode->nodeName,
+			activeNode->nodeHost,
+			activeNode->nodePort,
+			primaryNode->nodeId,
+			primaryNode->nodeName,
+			primaryNode->nodeHost,
+			primaryNode->nodePort);
 
 		/* secondary reached maintenance */
 		AssignGoalState(activeNode, REPLICATION_STATE_MAINTENANCE, message);
@@ -428,10 +479,16 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of %s:%d to stop_replication "
-			"after %s:%d converged to prepare_maintenance.",
-			activeNode->nodeHost, activeNode->nodePort,
-			primaryNode->nodeHost, primaryNode->nodePort);
+			"Setting goal state of node %d \"%s\" (%s:%d) to stop_replication "
+			"after node %d \"%s\" (%s:%d) converged to prepare_maintenance.",
+			activeNode->nodeId,
+			activeNode->nodeName,
+			activeNode->nodeHost,
+			activeNode->nodePort,
+			primaryNode->nodeId,
+			primaryNode->nodeName,
+			primaryNode->nodeHost,
+			primaryNode->nodePort);
 
 		/* promote the secondary */
 		AssignGoalState(activeNode, REPLICATION_STATE_STOP_REPLICATION, message);
@@ -450,11 +507,17 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of node %d (%s:%d) to wait_primary "
-			"and node %d (%s:%d) to demoted "
+			"Setting goal state of node %d \"%s\" (%s:%d) to wait_primary "
+			"and node %d \"%s\" (%s:%d) to demoted "
 			"after the coordinator metadata was updated.",
-			activeNode->nodeId, activeNode->nodeHost, activeNode->nodePort,
-			primaryNode->nodeId, primaryNode->nodeHost, primaryNode->nodePort);
+			activeNode->nodeId,
+			activeNode->nodeName,
+			activeNode->nodeHost,
+			activeNode->nodePort,
+			primaryNode->nodeId,
+			primaryNode->nodeName,
+			primaryNode->nodeHost,
+			primaryNode->nodePort);
 
 		/* node is now taking writes */
 		AssignGoalState(activeNode, REPLICATION_STATE_WAIT_PRIMARY, message);
@@ -481,12 +544,21 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of node %d (%s:%d) to demote_timeout "
-			"and node %d (%s:%d) to stop_replication "
-			"after node %d (%s:%d) converged to prepare_promotion.",
-			primaryNode->nodeId, primaryNode->nodeHost, primaryNode->nodePort,
-			activeNode->nodeId, activeNode->nodeHost, activeNode->nodePort,
-			activeNode->nodeId, activeNode->nodeHost, activeNode->nodePort);
+			"Setting goal state of node %d \"%s\" (%s:%d) to demote_timeout "
+			"and node %d \"%s\" (%s:%d) to stop_replication "
+			"after node %d \"%s\" (%s:%d) converged to prepare_promotion.",
+			primaryNode->nodeId,
+			primaryNode->nodeName,
+			primaryNode->nodeHost,
+			primaryNode->nodePort,
+			activeNode->nodeId,
+			activeNode->nodeName,
+			activeNode->nodeHost,
+			activeNode->nodePort,
+			activeNode->nodeId,
+			activeNode->nodeName,
+			activeNode->nodeHost,
+			activeNode->nodePort);
 
 		/* perform promotion to stop replication */
 		AssignGoalState(activeNode, REPLICATION_STATE_STOP_REPLICATION, message);
@@ -508,10 +580,16 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of and node %d (%s:%d) to wait_primary "
-			"after node %d (%s:%d) converged to prepare_promotion.",
-			activeNode->nodeId, activeNode->nodeHost, activeNode->nodePort,
-			activeNode->nodeId, activeNode->nodeHost, activeNode->nodePort);
+			"Setting goal state of and node %d \"%s\" (%s:%d) to wait_primary "
+			"after node %d \"%s\" (%s:%d) converged to prepare_promotion.",
+			activeNode->nodeId,
+			activeNode->nodeName,
+			activeNode->nodeHost,
+			activeNode->nodePort,
+			activeNode->nodeId,
+			activeNode->nodeName,
+			activeNode->nodeHost,
+			activeNode->nodePort);
 
 		/* perform promotion to stop replication */
 		AssignGoalState(activeNode, REPLICATION_STATE_WAIT_PRIMARY, message);
@@ -531,10 +609,16 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of %s:%d to wait_primary and %s:%d to "
-			"maintenance.",
-			activeNode->nodeHost, activeNode->nodePort,
-			primaryNode->nodeHost, primaryNode->nodePort);
+			"Setting goal state of node %d \"%s\" (%s:%d) to wait_primary "
+			"and node %d \"%s\" (%s:%d) to maintenance.",
+			activeNode->nodeId,
+			activeNode->nodeName,
+			activeNode->nodeHost,
+			activeNode->nodePort,
+			primaryNode->nodeId,
+			primaryNode->nodeName,
+			primaryNode->nodeHost,
+			primaryNode->nodePort);
 
 		/* node is now taking writes */
 		AssignGoalState(activeNode, REPLICATION_STATE_WAIT_PRIMARY, message);
@@ -557,10 +641,17 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of node %d (%s:%d) to wait_primary "
-			"and node %d (%s:%d) to demoted after the demote timeout expired.",
-			activeNode->nodeId, activeNode->nodeHost, activeNode->nodePort,
-			primaryNode->nodeId, primaryNode->nodeHost, primaryNode->nodePort);
+			"Setting goal state of node %d \"%s\" (%s:%d) to wait_primary "
+			"and node %d \"%s\" (%s:%d) to demoted "
+			"after the demote timeout expired.",
+			activeNode->nodeId,
+			activeNode->nodeName,
+			activeNode->nodeHost,
+			activeNode->nodePort,
+			primaryNode->nodeId,
+			primaryNode->nodeName,
+			primaryNode->nodeHost,
+			primaryNode->nodePort);
 
 		/* node is now taking writes */
 		AssignGoalState(activeNode, REPLICATION_STATE_WAIT_PRIMARY, message);
@@ -582,11 +673,17 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of node %d (%s:%d) to wait_primary "
-			"and %d (%s:%d) to demoted "
+			"Setting goal state of node %d \"%s\" (%s:%d) to wait_primary "
+			"and node %d \"%s\" (%s:%d) to demoted "
 			"after the coordinator metadata was updated.",
-			activeNode->nodeId, activeNode->nodeHost, activeNode->nodePort,
-			primaryNode->nodeId, primaryNode->nodeHost, primaryNode->nodePort);
+			activeNode->nodeId,
+			activeNode->nodeName,
+			activeNode->nodeHost,
+			activeNode->nodePort,
+			primaryNode->nodeId,
+			primaryNode->nodeName,
+			primaryNode->nodeHost,
+			primaryNode->nodePort);
 
 		/* node is now taking writes */
 		AssignGoalState(activeNode, REPLICATION_STATE_WAIT_PRIMARY, message);
@@ -608,10 +705,17 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of node %d (%s:%d) to catchingup after it "
-			"converged to demotion and node %d (%s:%d) converged to primary.",
-			activeNode->nodeId, activeNode->nodeHost, activeNode->nodePort,
-			primaryNode->nodeId, primaryNode->nodeHost, primaryNode->nodePort);
+			"Setting goal state of node %d \"%s\" (%s:%d) to catchingup "
+			"after it converged to demotion "
+			"and node %d \"%s\" (%s:%d) converged to primary.",
+			activeNode->nodeId,
+			activeNode->nodeName,
+			activeNode->nodeHost,
+			activeNode->nodePort,
+			primaryNode->nodeId,
+			primaryNode->nodeName,
+			primaryNode->nodeHost,
+			primaryNode->nodePort);
 
 		/* it's safe to rejoin as a secondary */
 		AssignGoalState(activeNode, REPLICATION_STATE_CATCHINGUP, message);
@@ -631,10 +735,17 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of node %d (%s:%d) to catchingup after it "
-			"converged to demotion and node %d (%s:%d) converged to wait_primary.",
-			activeNode->nodeId, activeNode->nodeHost, activeNode->nodePort,
-			primaryNode->nodeId, primaryNode->nodeHost, primaryNode->nodePort);
+			"Setting goal state of node %d \"%s\" (%s:%d) to catchingup "
+			"after it converged to demotion "
+			"and node %d \"%s\" (%s:%d) converged to wait_primary.",
+			activeNode->nodeId,
+			activeNode->nodeName,
+			activeNode->nodeHost,
+			activeNode->nodePort,
+			primaryNode->nodeId,
+			primaryNode->nodeName,
+			primaryNode->nodeHost,
+			primaryNode->nodePort);
 
 		/* it's safe to rejoin as a secondary */
 		AssignGoalState(activeNode, REPLICATION_STATE_CATCHINGUP, message);
@@ -662,10 +773,17 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of node %d (%s:%d) to secondary "
-			"and node %d (%s:%d) to primary after it converged to wait_primary.",
-			activeNode->nodeId, activeNode->nodeHost, activeNode->nodePort,
-			primaryNode->nodeId, primaryNode->nodeHost, primaryNode->nodePort);
+			"Setting goal state of node %d \"%s\" (%s:%d) to secondary "
+			"and node %d \"%s\" (%s:%d) to primary "
+			"after it converged to wait_primary.",
+			activeNode->nodeId,
+			activeNode->nodeName,
+			activeNode->nodeHost,
+			activeNode->nodePort,
+			primaryNode->nodeId,
+			primaryNode->nodeName,
+			primaryNode->nodeHost,
+			primaryNode->nodePort);
 
 		/* it's safe to rejoin as a secondary */
 		AssignGoalState(activeNode, REPLICATION_STATE_SECONDARY, message);
@@ -688,10 +806,16 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of node %d (%s:%d) to secondary "
-			"after node %d (%s:%d) converged to primary.",
-			activeNode->nodeId, activeNode->nodeHost, activeNode->nodePort,
-			primaryNode->nodeId, primaryNode->nodeHost, primaryNode->nodePort);
+			"Setting goal state of node %d \"%s\" (%s:%d) to secondary "
+			"after node %d \"%s\" (%s:%d) converged to primary.",
+			activeNode->nodeId,
+			activeNode->nodeName,
+			activeNode->nodeHost,
+			activeNode->nodePort,
+			primaryNode->nodeId,
+			primaryNode->nodeName,
+			primaryNode->nodeHost,
+			primaryNode->nodePort);
 
 		/* it's safe to rejoin as a secondary */
 		AssignGoalState(activeNode, REPLICATION_STATE_SECONDARY, message);
@@ -730,12 +854,14 @@ ProceedGroupStateForPrimaryNode(AutoFailoverNode *primaryNode)
 
 				LogAndNotifyMessage(
 					message, BUFSIZE,
-					"Setting goal state of %d (%s:%d) to wait_primary "
-					"after node %d (%s:%d) joined.",
+					"Setting goal state of %d \"%s\" (%s:%d) to wait_primary "
+					"after node %d \"%s\" (%s:%d) joined.",
 					primaryNode->nodeId,
+					primaryNode->nodeName,
 					primaryNode->nodeHost,
 					primaryNode->nodePort,
 					otherNode->nodeId,
+					otherNode->nodeName,
 					otherNode->nodeHost,
 					otherNode->nodePort);
 
@@ -767,12 +893,14 @@ ProceedGroupStateForPrimaryNode(AutoFailoverNode *primaryNode)
 
 				LogAndNotifyMessage(
 					message, BUFSIZE,
-					"Setting goal state of node %d (%s:%d) to join_primary "
-					"after node %d (%s:%d) joined.",
+					"Setting goal state of node %d \"%s\" (%s:%d) to join_primary "
+					"after node %d \"%s\" (%s:%d) joined.",
 					primaryNode->nodeId,
+					primaryNode->nodeName,
 					primaryNode->nodeHost,
 					primaryNode->nodePort,
 					otherNode->nodeId,
+					otherNode->nodeName,
 					otherNode->nodeHost,
 					otherNode->nodePort);
 
@@ -815,9 +943,12 @@ ProceedGroupStateForPrimaryNode(AutoFailoverNode *primaryNode)
 
 				LogAndNotifyMessage(
 					message, BUFSIZE,
-					"Setting goal state of node %d (%s:%d) to catchingup "
+					"Setting goal state of node %d \"%s\" (%s:%d) to catchingup "
 					"after it became unhealthy.",
-					otherNode->nodeId, otherNode->nodeHost, otherNode->nodePort);
+					otherNode->nodeId,
+					otherNode->nodeName,
+					otherNode->nodeHost,
+					otherNode->nodePort);
 
 				/* other node is behind, no longer eligible for promotion */
 				AssignGoalState(otherNode,
@@ -855,9 +986,10 @@ ProceedGroupStateForPrimaryNode(AutoFailoverNode *primaryNode)
 
 				LogAndNotifyMessage(
 					message, BUFSIZE,
-					"Setting goal state of node %d (%s:%d) to wait_primary "
+					"Setting goal state of node %d \"%s\" (%s:%d) to wait_primary "
 					"now that none of the standbys are healthy anymore.",
 					primaryNode->nodeId,
+					primaryNode->nodeName,
 					primaryNode->nodeHost,
 					primaryNode->nodePort);
 
@@ -879,9 +1011,12 @@ ProceedGroupStateForPrimaryNode(AutoFailoverNode *primaryNode)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of node %d (%s:%d) to primary "
+			"Setting goal state of node %d \"%s\" (%s:%d) to primary "
 			"after it applied replication properties change.",
-			primaryNode->nodeId, primaryNode->nodeHost, primaryNode->nodePort);
+			primaryNode->nodeId,
+			primaryNode->nodeName,
+			primaryNode->nodeHost,
+			primaryNode->nodePort);
 
 		AssignGoalState(primaryNode, REPLICATION_STATE_PRIMARY, message);
 
@@ -972,8 +1107,9 @@ ProceedGroupStateForMSFailover(AutoFailoverNode *activeNode,
 	 */
 	if (nodeBeingPromoted != NULL)
 	{
-		elog(LOG, "Found candidate node %d (%s:%d)",
+		elog(LOG, "Found candidate node %d \"%s\" (%s:%d)",
 			 nodeBeingPromoted->nodeId,
+			 nodeBeingPromoted->nodeName,
 			 nodeBeingPromoted->nodeHost,
 			 nodeBeingPromoted->nodePort);
 
@@ -1020,10 +1156,13 @@ ProceedGroupStateForMSFailover(AutoFailoverNode *activeNode,
 			message, BUFSIZE,
 			"Failover still in progress after %d nodes reported their LSN "
 			"and we are waiting for %d nodes to report, "
-			"activeNode is %d (%s:%d) and reported state \"%s\"",
+			"activeNode is %d \"%s\" (%s:%d) and reported state \"%s\"",
 			candidateList.candidateCount,
 			candidateList.missingNodesCount,
-			activeNode->nodeId, activeNode->nodeHost, activeNode->nodePort,
+			activeNode->nodeId,
+			activeNode->nodeName,
+			activeNode->nodeHost,
+			activeNode->nodePort,
 			ReplicationStateGetName(activeNode->reportedState));
 
 		return false;
@@ -1064,10 +1203,11 @@ ProceedGroupStateForMSFailover(AutoFailoverNode *activeNode,
 			LogAndNotifyMessage(
 				message, BUFSIZE,
 				"The current most advanced reported LSN is %X/%X, "
-				"as reported by node %d (%s:%d) and %d other nodes",
+				"as reported by node %d \"%s\" (%s:%d) and %d other nodes",
 				(uint32) (mostAdvancedNode->reportedLSN >> 32),
 				(uint32) mostAdvancedNode->reportedLSN,
 				mostAdvancedNode->nodeId,
+				mostAdvancedNode->nodeName,
 				mostAdvancedNode->nodeHost,
 				mostAdvancedNode->nodePort,
 				list_length(mostAdvancedNodeList) - 1);
@@ -1094,9 +1234,12 @@ ProceedGroupStateForMSFailover(AutoFailoverNode *activeNode,
 				message, BUFSIZE,
 				"Failover still in progress after all %d candidate nodes "
 				"reported their LSN and we failed to select one of them; "
-				"activeNode is %d (%s:%d) and reported state \"%s\"",
+				"activeNode is %d \"%s\" (%s:%d) and reported state \"%s\"",
 				candidateList.candidateCount,
-				activeNode->nodeId, activeNode->nodeHost, activeNode->nodePort,
+				activeNode->nodeId,
+				activeNode->nodeName,
+				activeNode->nodeHost,
+				activeNode->nodePort,
 				ReplicationStateGetName(activeNode->reportedState));
 
 			return false;
@@ -1139,9 +1282,9 @@ BuildCandidateList(List *nodesGroupList, CandidateList *candidateList)
 		if (StateBelongsToPrimary(node->goalState))
 		{
 			elog(LOG,
-				 "Skipping candidate node %d (%s:%d), "
+				 "Skipping candidate node %d \"%s\" (%s:%d), "
 				 "which is a primary (old or new)",
-				 node->nodeId, node->nodeHost, node->nodePort);
+				 node->nodeId, node->nodeName, node->nodeHost, node->nodePort);
 			continue;
 		}
 
@@ -1153,8 +1296,8 @@ BuildCandidateList(List *nodesGroupList, CandidateList *candidateList)
 		if (IsUnhealthy(node) && !IsReporting(node))
 		{
 			elog(LOG,
-				 "Skipping candidate node %d (%s:%d), which is unhealthy",
-				 node->nodeId, node->nodeHost, node->nodePort);
+				 "Skipping candidate node %d \"%s\" (%s:%d), which is unhealthy",
+				 node->nodeId, node->nodeName, node->nodeHost, node->nodePort);
 
 			continue;
 		}
@@ -1188,9 +1331,9 @@ BuildCandidateList(List *nodesGroupList, CandidateList *candidateList)
 
 			LogAndNotifyMessage(
 				message, BUFSIZE,
-				"Setting goal state of node %d (%s:%d) to report_lsn "
+				"Setting goal state of node %d \"%s\" (%s:%d) to report_lsn "
 				"to find the failover candidate",
-				node->nodeId, node->nodeHost, node->nodePort);
+				node->nodeId, node->nodeName, node->nodeHost, node->nodePort);
 
 			AssignGoalState(node, REPLICATION_STATE_REPORT_LSN, message);
 
@@ -1234,12 +1377,14 @@ ProceedWithMSFailover(AutoFailoverNode *activeNode,
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of node %d (%s:%d) to join_secondary "
-			"after node %d (%s:%d) got selected as the failover candidate.",
+			"Setting goal state of node %d \"%s\" (%s:%d) to join_secondary "
+			"after node %d \"%s\" (%s:%d) got selected as the failover candidate.",
 			activeNode->nodeId,
+			activeNode->nodeName,
 			activeNode->nodeHost,
 			activeNode->nodePort,
 			candidateNode->nodeId,
+			candidateNode->nodeName,
 			candidateNode->nodeHost,
 			candidateNode->nodePort);
 
@@ -1315,17 +1460,19 @@ SelectFailoverCandidateNode(CandidateList *candidateList,
 		LogAndNotifyMessage(
 			message, BUFSIZE,
 			"One of the most advanced standby node in the group "
-			"is node %d (%s:%d) "
+			"is node %d \"%s\" (%s:%d) "
 			"with reported LSN %X/%X, which is more than "
 			"pgautofailover.enable_sync_wal_log_threshold (%d) behind "
-			"the primary node %d (%s:%d), which has reported %X/%X",
+			"the primary node %d \"%s\" (%s:%d), which has reported %X/%X",
 			mostAdvancedNode->nodeId,
+			mostAdvancedNode->nodeName,
 			mostAdvancedNode->nodeHost,
 			mostAdvancedNode->nodePort,
 			(uint32) (mostAdvancedNode->reportedLSN >> 32),
 			(uint32) mostAdvancedNode->reportedLSN,
 			PromoteXlogThreshold,
 			primaryNode->nodeId,
+			primaryNode->nodeName,
 			primaryNode->nodeHost,
 			primaryNode->nodePort,
 			(uint32) (primaryNode->reportedLSN >> 32),
@@ -1350,9 +1497,9 @@ SelectFailoverCandidateNode(CandidateList *candidateList,
 
 			LogAndNotifyMessage(
 				message, BUFSIZE,
-				"Not selecting failover candidate node %d (%s:%d) "
+				"Not selecting failover candidate node %d \"%s\" (%s:%d) "
 				"because it is unhealthy",
-				node->nodeId, node->nodeHost, node->nodePort);
+				node->nodeId, node->nodeName, node->nodeHost, node->nodePort);
 
 			continue;
 		}
@@ -1408,11 +1555,12 @@ SelectFailoverCandidateNode(CandidateList *candidateList,
 
 			LogAndNotifyMessage(
 				message, BUFSIZE,
-				"The selected candidate %d (%s:%d) needs to fetch missing "
+				"The selected candidate %d \"%s\" (%s:%d) needs to fetch missing "
 				"WAL to reach LSN %X/%X (from current reported LSN %X/%X) "
 				"and none of the most advanced standby nodes are healthy "
 				"at the moment.",
 				selectedNode->nodeId,
+				selectedNode->nodeName,
 				selectedNode->nodeHost,
 				selectedNode->nodePort,
 				(uint32) (mostAdvancedNode->reportedLSN >> 32),
@@ -1485,13 +1633,16 @@ PromoteSelectedNode(AutoFailoverNode *selectedNode,
 		{
 			LogAndNotifyMessage(
 				message, BUFSIZE,
-				"Setting goal state of node %d (%s:%d) to prepare_promotion "
-				"after node %d (%s:%d) became unhealthy "
+				"Setting goal state of node %d \"%s\" (%s:%d) "
+				"to prepare_promotion "
+				"after node %d \"%s\" (%s:%d) became unhealthy "
 				"and %d nodes reported their LSN position.",
 				selectedNode->nodeId,
+				selectedNode->nodeName,
 				selectedNode->nodeHost,
 				selectedNode->nodePort,
 				primaryNode->nodeId,
+				primaryNode->nodeName,
 				primaryNode->nodeHost,
 				primaryNode->nodePort,
 				candidateList->candidateCount);
@@ -1500,9 +1651,11 @@ PromoteSelectedNode(AutoFailoverNode *selectedNode,
 		{
 			LogAndNotifyMessage(
 				message, BUFSIZE,
-				"Setting goal state of node %d (%s:%d) to prepare_promotion "
+				"Setting goal state of node %d \"%s\" (%s:%d) "
+				"to prepare_promotion "
 				"and %d nodes reported their LSN position.",
 				selectedNode->nodeId,
+				selectedNode->nodeName,
 				selectedNode->nodeHost,
 				selectedNode->nodePort,
 				candidateList->candidateCount);
@@ -1523,13 +1676,15 @@ PromoteSelectedNode(AutoFailoverNode *selectedNode,
 		{
 			LogAndNotifyMessage(
 				message, BUFSIZE,
-				"Setting goal state of node %d (%s:%d) to fast_forward "
-				"after node %d (%s:%d) became unhealthy "
+				"Setting goal state of node %d \"%s\" (%s:%d) to fast_forward "
+				"after node %d \"%s\" (%s:%d) became unhealthy "
 				"and %d nodes reported their LSN position.",
 				selectedNode->nodeId,
+				selectedNode->nodeName,
 				selectedNode->nodeHost,
 				selectedNode->nodePort,
 				primaryNode->nodeId,
+				primaryNode->nodeName,
 				primaryNode->nodeHost,
 				primaryNode->nodePort,
 				candidateList->candidateCount);
@@ -1538,9 +1693,10 @@ PromoteSelectedNode(AutoFailoverNode *selectedNode,
 		{
 			LogAndNotifyMessage(
 				message, BUFSIZE,
-				"Setting goal state of node %d (%s:%d) to fast_forward "
+				"Setting goal state of node %d \"%s\" (%s:%d) to fast_forward "
 				"and %d nodes reported their LSN position.",
 				selectedNode->nodeId,
+				selectedNode->nodeName,
 				selectedNode->nodeHost,
 				selectedNode->nodePort,
 				candidateList->candidateCount);

--- a/src/monitor/group_state_machine.c
+++ b/src/monitor/group_state_machine.c
@@ -485,8 +485,7 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 			message, BUFSIZE,
 			"Setting goal state of " NODE_FORMAT
 			" to demote_timeout and " NODE_FORMAT
-			" to stop_replication "
-			"after " NODE_FORMAT
+			" to stop_replication after " NODE_FORMAT
 			" converged to prepare_promotion.",
 			NODE_FORMAT_ARGS(primaryNode),
 			NODE_FORMAT_ARGS(activeNode),

--- a/src/monitor/group_state_machine.c
+++ b/src/monitor/group_state_machine.c
@@ -860,8 +860,8 @@ ProceedGroupStateForPrimaryNode(AutoFailoverNode *primaryNode)
 				LogAndNotifyMessage(
 					message, BUFSIZE,
 					"Setting goal state of " NODE_FORMAT
-					" to wait_primary now that none of the standbys "
-					"are healthy anymore.",
+					" to wait_primary now that none of the standbys"
+					" are healthy anymore.",
 					NODE_FORMAT_ARGS(primaryNode));
 
 				AssignGoalState(primaryNode,

--- a/src/monitor/group_state_machine.c
+++ b/src/monitor/group_state_machine.c
@@ -1477,8 +1477,7 @@ PromoteSelectedNode(AutoFailoverNode *selectedNode,
 				message, BUFSIZE,
 				"Setting goal state of " NODE_FORMAT
 				"to prepare_promotion after " NODE_FORMAT
-				" became unhealthy "
-				"and %d nodes reported their LSN position.",
+				" became unhealthy and %d nodes reported their LSN position.",
 				NODE_FORMAT_ARGS(selectedNode),
 				NODE_FORMAT_ARGS(primaryNode),
 				candidateList->candidateCount);

--- a/src/monitor/group_state_machine.c
+++ b/src/monitor/group_state_machine.c
@@ -1019,7 +1019,8 @@ ProceedGroupStateForMSFailover(AutoFailoverNode *activeNode,
 			message, BUFSIZE,
 			"Failover still in progress after %d nodes reported their LSN "
 			"and we are waiting for %d nodes to report, "
-			"activeNode is %d \"%s\" (%s:%d) and reported state \"%s\"",
+			"activeNode is " NODE_FORMAT
+			" and reported state \"%s\"",
 			candidateList.candidateCount,
 			candidateList.missingNodesCount,
 			NODE_FORMAT_ARGS(activeNode),

--- a/src/monitor/group_state_machine.c
+++ b/src/monitor/group_state_machine.c
@@ -1311,7 +1311,7 @@ SelectFailoverCandidateNode(CandidateList *candidateList,
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"One of the most advanced standby node in the group "
+			"One of the most advanced standby nodes in the group "
 			"is " NODE_FORMAT
 			"with reported LSN %X/%X, which is more than "
 			"pgautofailover.enable_sync_wal_log_threshold (%d) behind "

--- a/src/monitor/group_state_machine.c
+++ b/src/monitor/group_state_machine.c
@@ -1519,7 +1519,7 @@ PromoteSelectedNode(AutoFailoverNode *selectedNode,
 			LogAndNotifyMessage(
 				message, BUFSIZE,
 				"Setting goal state of " NODE_FORMAT
-				" to fast_forward and %d nodes reported their LSN position.",
+				" to fast_forward after %d nodes reported their LSN position.",
 				NODE_FORMAT_ARGS(selectedNode),
 				candidateList->candidateCount);
 		}

--- a/src/monitor/group_state_machine.c
+++ b/src/monitor/group_state_machine.c
@@ -1154,7 +1154,7 @@ BuildCandidateList(List *nodesGroupList, CandidateList *candidateList)
 		{
 			elog(LOG,
 				 "Skipping candidate " NODE_FORMAT ", which is unhealthy",
-				 node->nodeId, node->nodeName, node->nodeHost, node->nodePort);
+				 NODE_FORMAT_ARGS(node));
 
 			continue;
 		}

--- a/src/monitor/group_state_machine.c
+++ b/src/monitor/group_state_machine.c
@@ -1402,7 +1402,8 @@ SelectFailoverCandidateNode(CandidateList *candidateList,
 
 			LogAndNotifyMessage(
 				message, BUFSIZE,
-				"The selected candidate %d \"%s\" (%s:%d) needs to fetch missing "
+				"The selected candidate " NODE_FORMAT
+				" needs to fetch missing "
 				"WAL to reach LSN %X/%X (from current reported LSN %X/%X) "
 				"and none of the most advanced standby nodes are healthy "
 				"at the moment.",

--- a/src/monitor/group_state_machine.c
+++ b/src/monitor/group_state_machine.c
@@ -1093,7 +1093,8 @@ ProceedGroupStateForMSFailover(AutoFailoverNode *activeNode,
 				message, BUFSIZE,
 				"Failover still in progress after all %d candidate nodes "
 				"reported their LSN and we failed to select one of them; "
-				"activeNode is %d \"%s\" (%s:%d) and reported state \"%s\"",
+				"activeNode is " NODE_FORMAT
+				" and reported state \"%s\"",
 				candidateList.candidateCount,
 				NODE_FORMAT_ARGS(activeNode),
 				ReplicationStateGetName(activeNode->reportedState));

--- a/src/monitor/group_state_machine.c
+++ b/src/monitor/group_state_machine.c
@@ -1509,8 +1509,7 @@ PromoteSelectedNode(AutoFailoverNode *selectedNode,
 				message, BUFSIZE,
 				"Setting goal state of " NODE_FORMAT
 				" to fast_forward after " NODE_FORMAT
-				" became unhealthy "
-				"and %d nodes reported their LSN position.",
+				" became unhealthy and %d nodes reported their LSN position.",
 				NODE_FORMAT_ARGS(selectedNode),
 				NODE_FORMAT_ARGS(primaryNode),
 				candidateList->candidateCount);

--- a/src/monitor/group_state_machine.c
+++ b/src/monitor/group_state_machine.c
@@ -1190,7 +1190,7 @@ BuildCandidateList(List *nodesGroupList, CandidateList *candidateList)
 				message, BUFSIZE,
 				"Setting goal state of " NODE_FORMAT
 				" to report_lsn to find the failover candidate",
-				node->nodeId, node->nodeName, node->nodeHost, node->nodePort);
+				NODE_FORMAT_ARGS(node));
 
 			AssignGoalState(node, REPLICATION_STATE_REPORT_LSN, message);
 

--- a/src/monitor/group_state_machine.c
+++ b/src/monitor/group_state_machine.c
@@ -1141,7 +1141,7 @@ BuildCandidateList(List *nodesGroupList, CandidateList *candidateList)
 			elog(LOG,
 				 "Skipping candidate " NODE_FORMAT
 				 ", which is a primary (old or new)",
-				 node->nodeId, node->nodeName, node->nodeHost, node->nodePort);
+				 NODE_FORMAT_ARGS(node));
 			continue;
 		}
 

--- a/src/monitor/node_active_protocol.c
+++ b/src/monitor/node_active_protocol.c
@@ -440,12 +440,8 @@ NodeActive(char *formationId, AutoFailoverNodeState *currentNodeState)
 			{
 				LogAndNotifyMessage(
 					message, BUFSIZE,
-					"Node %d \"%s\" (%s:%d) reported new state \"%s\" "
-					"with LSN %X/%X",
-					pgAutoFailoverNode->nodeId,
-					pgAutoFailoverNode->nodeName,
-					pgAutoFailoverNode->nodeHost,
-					pgAutoFailoverNode->nodePort,
+					NODE_FORMAT " reported new state \"%s\" with LSN %X/%X",
+					NODE_FORMAT_ARGS(pgAutoFailoverNode),
 					ReplicationStateGetName(currentNodeState->replicationState),
 					(uint32) (pgAutoFailoverNode->reportedLSN >> 32),
 					(uint32) pgAutoFailoverNode->reportedLSN);
@@ -454,11 +450,8 @@ NodeActive(char *formationId, AutoFailoverNodeState *currentNodeState)
 			{
 				LogAndNotifyMessage(
 					message, BUFSIZE,
-					"Node %d \"%s\" (%s:%d) reported new state \"%s\"",
-					pgAutoFailoverNode->nodeId,
-					pgAutoFailoverNode->nodeName,
-					pgAutoFailoverNode->nodeHost,
-					pgAutoFailoverNode->nodePort,
+					NODE_FORMAT " reported new state \"%s\"",
+					NODE_FORMAT_ARGS(pgAutoFailoverNode),
 					ReplicationStateGetName(currentNodeState->replicationState));
 			}
 
@@ -1051,9 +1044,9 @@ RemoveNode(AutoFailoverNode *currentNode)
 
 			LogAndNotifyMessage(
 				message, BUFSIZE,
-				"Setting goal state of node %d \"%s\" (%s:%d) to report_lsn "
-				"after primary node removal.",
-				node->nodeId, node->nodeName, node->nodeHost, node->nodePort);
+				"Setting goal state of " NODE_FORMAT " to report_lsn "
+													 "after primary node removal.",
+				NODE_FORMAT_ARGS(node));
 
 			SetNodeGoalState(node, REPLICATION_STATE_REPORT_LSN, message);
 		}
@@ -1064,11 +1057,8 @@ RemoveNode(AutoFailoverNode *currentNode)
 
 	LogAndNotifyMessage(
 		message, BUFSIZE,
-		"Removing node %d \"%s\" (%s:%d) from formation \"%s\" and group %d",
-		currentNode->nodeId,
-		currentNode->nodeName,
-		currentNode->nodeHost,
-		currentNode->nodePort,
+		"Removing " NODE_FORMAT " from formation \"%s\" and group %d",
+		NODE_FORMAT_ARGS(currentNode),
 		currentNode->formationId,
 		currentNode->groupId);
 
@@ -1216,12 +1206,9 @@ perform_failover(PG_FUNCTION_ARGS)
 
 			ereport(ERROR,
 					(errmsg(
-						 "standby node %d \"%s\" (%s:%d) is in state \"%s\", "
-						 "which prevents the node for being a failover candidate",
-						 secondaryNode->nodeId,
-						 secondaryNode->nodeName,
-						 secondaryNode->nodeHost,
-						 secondaryNode->nodePort,
+						 "standby " NODE_FORMAT " is in state \"%s\", "
+												"which prevents the node for being a failover candidate",
+						 NODE_FORMAT_ARGS(secondaryNode),
 						 secondaryState)));
 		}
 
@@ -1238,22 +1225,16 @@ perform_failover(PG_FUNCTION_ARGS)
 			ereport(ERROR,
 					(errmsg(
 						 "cannot fail over: primary node is not in a stable state"),
-					 errdetail("node %d \"%s\" (%s:%d) "
-							   "has reported state \"%s\" and "
-							   "is assigned state \"%s\", "
-							   "and node %d \"%s\" (%s:%d) "
-							   "has reported state \"%s\" "
-							   "and is assigned state \"%s\"",
-							   primaryNode->nodeId,
-							   primaryNode->nodeName,
-							   primaryNode->nodeHost,
-							   primaryNode->nodePort,
+					 errdetail("" NODE_FORMAT " "
+											  "has reported state \"%s\" and "
+											  "is assigned state \"%s\", "
+											  "and " NODE_FORMAT " "
+																 "has reported state \"%s\" "
+																 "and is assigned state \"%s\"",
+							   NODE_FORMAT_ARGS(primaryNode),
 							   ReplicationStateGetName(primaryNode->reportedState),
 							   ReplicationStateGetName(primaryNode->goalState),
-							   secondaryNode->nodeId,
-							   secondaryNode->nodeName,
-							   secondaryNode->nodeHost,
-							   secondaryNode->nodePort,
+							   NODE_FORMAT_ARGS(secondaryNode),
 							   ReplicationStateGetName(secondaryNode->reportedState),
 							   ReplicationStateGetName(secondaryNode->goalState)),
 					 errhint("a stable state must be observed to "
@@ -1262,17 +1243,12 @@ perform_failover(PG_FUNCTION_ARGS)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of node %d \"%s\" (%s:%d) to draining "
-			"and node %d \"%s\" (%s:%d) to prepare_promotion "
+			"Setting goal state of " NODE_FORMAT " to draining "
+												 "and " NODE_FORMAT
+			" to prepare_promotion "
 			"after a user-initiated failover.",
-			primaryNode->nodeId,
-			primaryNode->nodeName,
-			primaryNode->nodeHost,
-			primaryNode->nodePort,
-			secondaryNode->nodeId,
-			secondaryNode->nodeName,
-			secondaryNode->nodeHost,
-			secondaryNode->nodePort);
+			NODE_FORMAT_ARGS(primaryNode),
+			NODE_FORMAT_ARGS(secondaryNode));
 
 		SetNodeGoalState(primaryNode,
 						 REPLICATION_STATE_DRAINING, message);
@@ -1289,12 +1265,9 @@ perform_failover(PG_FUNCTION_ARGS)
 		/* so we have at least one candidate, let's get started */
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of node %d \"%s\" (%s:%d) "
-			"at LSN %X/%X to draining after a user-initiated failover.",
-			primaryNode->nodeId,
-			primaryNode->nodeName,
-			primaryNode->nodeHost,
-			primaryNode->nodePort,
+			"Setting goal state of " NODE_FORMAT " "
+												 "at LSN %X/%X to draining after a user-initiated failover.",
+			NODE_FORMAT_ARGS(primaryNode),
 			(uint32) (primaryNode->reportedLSN >> 32),
 			(uint32) primaryNode->reportedLSN);
 
@@ -1430,12 +1403,9 @@ perform_promotion(PG_FUNCTION_ARGS)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Updating candidate priority to %d for node %d \"%s\" (%s:%d)",
+			"Updating candidate priority to %d for " NODE_FORMAT,
 			currentNode->candidatePriority,
-			currentNode->nodeId,
-			currentNode->nodeName,
-			currentNode->nodeHost,
-			currentNode->nodePort);
+			NODE_FORMAT_ARGS(currentNode));
 
 		NotifyStateChange(currentNode, message);
 
@@ -1600,12 +1570,9 @@ start_maintenance(PG_FUNCTION_ARGS)
 		 */
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of node %d \"%s\" (%s:%d) to prepare_maintenance "
-			"after a user-initiated start_maintenance call.",
-			currentNode->nodeId,
-			currentNode->nodeName,
-			currentNode->nodeHost,
-			currentNode->nodePort);
+			"Setting goal state of " NODE_FORMAT " to prepare_maintenance "
+												 "after a user-initiated start_maintenance call.",
+			NODE_FORMAT_ARGS(currentNode));
 
 		SetNodeGoalState(currentNode,
 						 REPLICATION_STATE_PREPARE_MAINTENANCE, message);
@@ -1619,18 +1586,12 @@ start_maintenance(PG_FUNCTION_ARGS)
 			 */
 			LogAndNotifyMessage(
 				message, BUFSIZE,
-				"Setting goal state of node %d \"%s\" (%s:%d) "
-				" to prepare_maintenance "
-				"and node %d \"%s\" (%s:%d) to prepare_promotion "
+				"Setting goal state of " NODE_FORMAT " to prepare_maintenance "
+													 "and " NODE_FORMAT
+				" to prepare_promotion "
 				"after a user-initiated start_maintenance call.",
-				currentNode->nodeId,
-				currentNode->nodeName,
-				currentNode->nodeHost,
-				currentNode->nodePort,
-				otherNode->nodeId,
-				otherNode->nodeName,
-				otherNode->nodeHost,
-				otherNode->nodePort);
+				NODE_FORMAT_ARGS(currentNode),
+				NODE_FORMAT_ARGS(otherNode));
 
 			SetNodeGoalState(otherNode,
 							 REPLICATION_STATE_PREPARE_PROMOTION, message);
@@ -1664,18 +1625,13 @@ start_maintenance(PG_FUNCTION_ARGS)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of node %d \"%s\" (%s:%d) to %s "
-			"and node %d \"%s\" (%s:%d) to wait_maintenance "
+			"Setting goal state of " NODE_FORMAT " to %s "
+												 "and " NODE_FORMAT
+			" to wait_maintenance "
 			"after a user-initiated start_maintenance call.",
-			primaryNode->nodeId,
-			primaryNode->nodeName,
-			primaryNode->nodeHost,
-			primaryNode->nodePort,
+			NODE_FORMAT_ARGS(primaryNode),
 			ReplicationStateGetName(primaryGoalState),
-			currentNode->nodeId,
-			currentNode->nodeName,
-			currentNode->nodeHost,
-			currentNode->nodePort);
+			NODE_FORMAT_ARGS(currentNode));
 
 		SetNodeGoalState(primaryNode, primaryGoalState, message);
 		SetNodeGoalState(currentNode, REPLICATION_STATE_WAIT_MAINTENANCE, message);
@@ -1685,19 +1641,13 @@ start_maintenance(PG_FUNCTION_ARGS)
 		ereport(ERROR,
 				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 				 errmsg("cannot start maintenance: current state for "
-						"node %d \"%s\" (%s:%d) is \"%s\", "
-						"expected \"secondary\" or \"catchingup\", "
-						"and current state for primary node %d \"%s\" (%s:%d) "
+						NODE_FORMAT " is \"%s\", "
+									"expected \"secondary\" or \"catchingup\", "
+									"and current state for primary " NODE_FORMAT
 						"is \"%s\" ➜ \"%s\" ",
-						currentNode->nodeId,
-						currentNode->nodeName,
-						currentNode->nodeHost,
-						currentNode->nodePort,
+						NODE_FORMAT_ARGS(currentNode),
 						ReplicationStateGetName(currentNode->reportedState),
-						primaryNode->nodeId,
-						primaryNode->nodeName,
-						primaryNode->nodeHost,
-						primaryNode->nodePort,
+						NODE_FORMAT_ARGS(primaryNode),
 						ReplicationStateGetName(primaryNode->reportedState),
 						ReplicationStateGetName(primaryNode->goalState))));
 	}
@@ -1738,11 +1688,8 @@ stop_maintenance(PG_FUNCTION_ARGS)
 		ereport(ERROR,
 				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 				 errmsg("cannot stop maintenance when current state for "
-						"node %d \"%s\" (%s:%d) is not \"maintenance\"",
-						currentNode->nodeId,
-						currentNode->nodeName,
-						currentNode->nodeHost,
-						currentNode->nodePort),
+						"" NODE_FORMAT " is not \"maintenance\"",
+						NODE_FORMAT_ARGS(currentNode)),
 				 errdetail("Current reported state is \"%s\" and "
 						   "assigned state is \"%s\"",
 						   ReplicationStateGetName(currentNode->reportedState),
@@ -1768,12 +1715,9 @@ stop_maintenance(PG_FUNCTION_ARGS)
 
 	LogAndNotifyMessage(
 		message, BUFSIZE,
-		"Setting goal state of node %d \"%s\" (%s:%d) to catchingup  "
-		"after a user-initiated stop_maintenance call.",
-		currentNode->nodeId,
-		currentNode->nodeName,
-		currentNode->nodeHost,
-		currentNode->nodePort);
+		"Setting goal state of " NODE_FORMAT " to catchingup  "
+											 "after a user-initiated stop_maintenance call.",
+		NODE_FORMAT_ARGS(currentNode));
 
 	SetNodeGoalState(currentNode, REPLICATION_STATE_CATCHINGUP, message);
 
@@ -1875,11 +1819,9 @@ set_node_candidate_priority(PG_FUNCTION_ARGS)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Updating candidate priority to %d for node %d (%s:%d)",
+			"Updating candidate priority to %d for " NODE_FORMAT,
 			currentNode->candidatePriority,
-			currentNode->nodeId,
-			currentNode->nodeHost,
-			currentNode->nodePort);
+			NODE_FORMAT_ARGS(currentNode));
 
 		NotifyStateChange(currentNode, message);
 	}
@@ -1904,11 +1846,8 @@ set_node_candidate_priority(PG_FUNCTION_ARGS)
 			ereport(ERROR,
 					(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 					 errmsg("cannot set candidate priority when current state "
-							"for primary node %d \"%s\" (%s:%d) is \"%s\"",
-							primaryNode->nodeId,
-							primaryNode->nodeName,
-							primaryNode->nodeHost,
-							primaryNode->nodePort,
+							"for primary " NODE_FORMAT " is \"%s\"",
+							NODE_FORMAT_ARGS(primaryNode),
 							ReplicationStateGetName(primaryNode->reportedState)),
 					 errdetail("The primary node so must be in state \"primary\" "
 							   "to be able to apply configuration changes to "
@@ -1917,16 +1856,11 @@ set_node_candidate_priority(PG_FUNCTION_ARGS)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of node %d \"%s\" (%s:%d) to apply_settings "
-			"after updating node %d \"%s\" (%s:%d) candidate priority to %d.",
-			primaryNode->nodeId,
-			primaryNode->nodeName,
-			primaryNode->nodeHost,
-			primaryNode->nodePort,
-			currentNode->nodeId,
-			currentNode->nodeName,
-			currentNode->nodeHost,
-			currentNode->nodePort,
+			"Setting goal state of " NODE_FORMAT " to apply_settings "
+												 "after updating " NODE_FORMAT
+			" candidate priority to %d.",
+			NODE_FORMAT_ARGS(primaryNode),
+			NODE_FORMAT_ARGS(currentNode),
 			currentNode->candidatePriority);
 
 		SetNodeGoalState(primaryNode, REPLICATION_STATE_APPLY_SETTINGS, message);
@@ -2028,12 +1962,9 @@ set_node_replication_quorum(PG_FUNCTION_ARGS)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Updating replicationQuorum to %s for node %d \"%s\" (%s:%d)",
+			"Updating replicationQuorum to %s for " NODE_FORMAT "",
 			currentNode->replicationQuorum ? "true" : "false",
-			currentNode->nodeId,
-			currentNode->nodeName,
-			currentNode->nodeHost,
-			currentNode->nodePort);
+			NODE_FORMAT_ARGS(currentNode));
 
 		NotifyStateChange(currentNode, message);
 	}
@@ -2058,11 +1989,8 @@ set_node_replication_quorum(PG_FUNCTION_ARGS)
 			ereport(ERROR,
 					(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 					 errmsg("cannot set replication quorum when current state "
-							"for primary node %d \"%s\" (%s:%d) is \"%s\"",
-							primaryNode->nodeId,
-							primaryNode->nodeName,
-							primaryNode->nodeHost,
-							primaryNode->nodePort,
+							"for primary " NODE_FORMAT " is \"%s\"",
+							NODE_FORMAT_ARGS(primaryNode),
 							ReplicationStateGetName(primaryNode->reportedState)),
 					 errdetail("The primary node so must be in state \"primary\" "
 							   "to be able to apply configuration changes to "
@@ -2071,13 +1999,12 @@ set_node_replication_quorum(PG_FUNCTION_ARGS)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of node %d \"%s\" (%s:%d) to apply_settings "
-			"after updating replication quorum to %s for node %d \"%s\" (%s:%d).",
-			primaryNode->nodeId, primaryNode->nodeName,
-			primaryNode->nodeHost, primaryNode->nodePort,
+			"Setting goal state of " NODE_FORMAT " to apply_settings "
+												 "after updating replication quorum to %s for "
+			NODE_FORMAT ".",
+			NODE_FORMAT_ARGS(primaryNode),
 			currentNode->replicationQuorum ? "true" : "false",
-			currentNode->nodeId, currentNode->nodeName,
-			currentNode->nodeHost, currentNode->nodePort);
+			NODE_FORMAT_ARGS(currentNode));
 
 		SetNodeGoalState(primaryNode, REPLICATION_STATE_APPLY_SETTINGS, message);
 	}

--- a/src/monitor/node_active_protocol.c
+++ b/src/monitor/node_active_protocol.c
@@ -1044,8 +1044,8 @@ RemoveNode(AutoFailoverNode *currentNode)
 
 			LogAndNotifyMessage(
 				message, BUFSIZE,
-				"Setting goal state of " NODE_FORMAT " to report_lsn "
-													 "after primary node removal.",
+				"Setting goal state of " NODE_FORMAT
+				" to report_lsn after primary node removal.",
 				NODE_FORMAT_ARGS(node));
 
 			SetNodeGoalState(node, REPLICATION_STATE_REPORT_LSN, message);
@@ -1189,12 +1189,9 @@ perform_failover(PG_FUNCTION_ARGS)
 			ereport(ERROR,
 					(errmsg("couldn't find the standby node in "
 							"formation \"%s\", group %d with primary node "
-							"%d \"%s\" (%s:%d)",
+							NODE_FORMAT,
 							formationId, groupId,
-							primaryNode->nodeId,
-							primaryNode->nodeHost,
-							primaryNode->nodeName,
-							primaryNode->nodePort)));
+							NODE_FORMAT_ARGS(primaryNode))));
 		}
 
 		secondaryNode = linitial(standbyNodesGroupList);
@@ -1206,8 +1203,9 @@ perform_failover(PG_FUNCTION_ARGS)
 
 			ereport(ERROR,
 					(errmsg(
-						 "standby " NODE_FORMAT " is in state \"%s\", "
-												"which prevents the node for being a failover candidate",
+						 "standby " NODE_FORMAT
+						 " is in state \"%s\", "
+						 "which prevents the node for being a failover candidate",
 						 NODE_FORMAT_ARGS(secondaryNode),
 						 secondaryState)));
 		}
@@ -1225,12 +1223,12 @@ perform_failover(PG_FUNCTION_ARGS)
 			ereport(ERROR,
 					(errmsg(
 						 "cannot fail over: primary node is not in a stable state"),
-					 errdetail("" NODE_FORMAT " "
-											  "has reported state \"%s\" and "
-											  "is assigned state \"%s\", "
-											  "and " NODE_FORMAT " "
-																 "has reported state \"%s\" "
-																 "and is assigned state \"%s\"",
+					 errdetail(NODE_FORMAT
+							   "has reported state \"%s\" and "
+							   "is assigned state \"%s\", "
+							   "and " NODE_FORMAT
+							   "has reported state \"%s\" "
+							   "and is assigned state \"%s\"",
 							   NODE_FORMAT_ARGS(primaryNode),
 							   ReplicationStateGetName(primaryNode->reportedState),
 							   ReplicationStateGetName(primaryNode->goalState),
@@ -1243,10 +1241,9 @@ perform_failover(PG_FUNCTION_ARGS)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of " NODE_FORMAT " to draining "
-												 "and " NODE_FORMAT
-			" to prepare_promotion "
-			"after a user-initiated failover.",
+			"Setting goal state of " NODE_FORMAT
+			" to draining and " NODE_FORMAT
+			" to prepare_promotion after a user-initiated failover.",
 			NODE_FORMAT_ARGS(primaryNode),
 			NODE_FORMAT_ARGS(secondaryNode));
 
@@ -1265,8 +1262,8 @@ perform_failover(PG_FUNCTION_ARGS)
 		/* so we have at least one candidate, let's get started */
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of " NODE_FORMAT " "
-												 "at LSN %X/%X to draining after a user-initiated failover.",
+			"Setting goal state of " NODE_FORMAT
+			"at LSN %X/%X to draining after a user-initiated failover.",
 			NODE_FORMAT_ARGS(primaryNode),
 			(uint32) (primaryNode->reportedLSN >> 32),
 			(uint32) primaryNode->reportedLSN);
@@ -1570,8 +1567,9 @@ start_maintenance(PG_FUNCTION_ARGS)
 		 */
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of " NODE_FORMAT " to prepare_maintenance "
-												 "after a user-initiated start_maintenance call.",
+			"Setting goal state of " NODE_FORMAT
+			" to prepare_maintenance "
+			"after a user-initiated start_maintenance call.",
 			NODE_FORMAT_ARGS(currentNode));
 
 		SetNodeGoalState(currentNode,
@@ -1586,8 +1584,8 @@ start_maintenance(PG_FUNCTION_ARGS)
 			 */
 			LogAndNotifyMessage(
 				message, BUFSIZE,
-				"Setting goal state of " NODE_FORMAT " to prepare_maintenance "
-													 "and " NODE_FORMAT
+				"Setting goal state of " NODE_FORMAT
+				" to prepare_maintenance and " NODE_FORMAT
 				" to prepare_promotion "
 				"after a user-initiated start_maintenance call.",
 				NODE_FORMAT_ARGS(currentNode),
@@ -1625,8 +1623,8 @@ start_maintenance(PG_FUNCTION_ARGS)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of " NODE_FORMAT " to %s "
-												 "and " NODE_FORMAT
+			"Setting goal state of " NODE_FORMAT
+			" to %s and " NODE_FORMAT
 			" to wait_maintenance "
 			"after a user-initiated start_maintenance call.",
 			NODE_FORMAT_ARGS(primaryNode),
@@ -1641,9 +1639,9 @@ start_maintenance(PG_FUNCTION_ARGS)
 		ereport(ERROR,
 				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 				 errmsg("cannot start maintenance: current state for "
-						NODE_FORMAT " is \"%s\", "
-									"expected \"secondary\" or \"catchingup\", "
-									"and current state for primary " NODE_FORMAT
+						NODE_FORMAT
+						" is \"%s\", expected \"secondary\" or \"catchingup\", "
+						"and current state for primary " NODE_FORMAT
 						"is \"%s\" ➜ \"%s\" ",
 						NODE_FORMAT_ARGS(currentNode),
 						ReplicationStateGetName(currentNode->reportedState),
@@ -1688,7 +1686,8 @@ stop_maintenance(PG_FUNCTION_ARGS)
 		ereport(ERROR,
 				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 				 errmsg("cannot stop maintenance when current state for "
-						"" NODE_FORMAT " is not \"maintenance\"",
+						NODE_FORMAT
+						" is not \"maintenance\"",
 						NODE_FORMAT_ARGS(currentNode)),
 				 errdetail("Current reported state is \"%s\" and "
 						   "assigned state is \"%s\"",
@@ -1715,8 +1714,8 @@ stop_maintenance(PG_FUNCTION_ARGS)
 
 	LogAndNotifyMessage(
 		message, BUFSIZE,
-		"Setting goal state of " NODE_FORMAT " to catchingup  "
-											 "after a user-initiated stop_maintenance call.",
+		"Setting goal state of " NODE_FORMAT
+		" to catchingup  after a user-initiated stop_maintenance call.",
 		NODE_FORMAT_ARGS(currentNode));
 
 	SetNodeGoalState(currentNode, REPLICATION_STATE_CATCHINGUP, message);
@@ -1846,7 +1845,8 @@ set_node_candidate_priority(PG_FUNCTION_ARGS)
 			ereport(ERROR,
 					(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 					 errmsg("cannot set candidate priority when current state "
-							"for primary " NODE_FORMAT " is \"%s\"",
+							"for primary " NODE_FORMAT
+							" is \"%s\"",
 							NODE_FORMAT_ARGS(primaryNode),
 							ReplicationStateGetName(primaryNode->reportedState)),
 					 errdetail("The primary node so must be in state \"primary\" "
@@ -1856,8 +1856,8 @@ set_node_candidate_priority(PG_FUNCTION_ARGS)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of " NODE_FORMAT " to apply_settings "
-												 "after updating " NODE_FORMAT
+			"Setting goal state of " NODE_FORMAT
+			" to apply_settings after updating " NODE_FORMAT
 			" candidate priority to %d.",
 			NODE_FORMAT_ARGS(primaryNode),
 			NODE_FORMAT_ARGS(currentNode),
@@ -1962,7 +1962,7 @@ set_node_replication_quorum(PG_FUNCTION_ARGS)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Updating replicationQuorum to %s for " NODE_FORMAT "",
+			"Updating replicationQuorum to %s for " NODE_FORMAT,
 			currentNode->replicationQuorum ? "true" : "false",
 			NODE_FORMAT_ARGS(currentNode));
 
@@ -1989,7 +1989,8 @@ set_node_replication_quorum(PG_FUNCTION_ARGS)
 			ereport(ERROR,
 					(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 					 errmsg("cannot set replication quorum when current state "
-							"for primary " NODE_FORMAT " is \"%s\"",
+							"for primary " NODE_FORMAT
+							" is \"%s\"",
 							NODE_FORMAT_ARGS(primaryNode),
 							ReplicationStateGetName(primaryNode->reportedState)),
 					 errdetail("The primary node so must be in state \"primary\" "
@@ -1999,9 +2000,9 @@ set_node_replication_quorum(PG_FUNCTION_ARGS)
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Setting goal state of " NODE_FORMAT " to apply_settings "
-												 "after updating replication quorum to %s for "
-			NODE_FORMAT ".",
+			"Setting goal state of " NODE_FORMAT
+			" to apply_settings after updating replication quorum to %s for "
+			NODE_FORMAT,
 			NODE_FORMAT_ARGS(primaryNode),
 			currentNode->replicationQuorum ? "true" : "false",
 			NODE_FORMAT_ARGS(currentNode));

--- a/src/monitor/node_metadata.h
+++ b/src/monitor/node_metadata.h
@@ -89,6 +89,16 @@ typedef enum SyncState
  */
 #define MAX_USER_DEFINED_CANDIDATE_PRIORITY 100
 
+
+/*
+ * Use the same output format each time we are notifying and logging about an
+ * AutoFailoverNode, for consistency. Well, apart when registering, where we
+ * don't have the node id and/or the node name yet.
+ */
+#define NODE_FORMAT "node %d \"%s\" (%s:%d)"
+#define NODE_FORMAT_ARGS(node) \
+	node->nodeId, node->nodeName, node->nodeHost, node->nodePort
+
 /*
  * AutoFailoverNode represents a Postgres node that is being tracked by the
  * pg_auto_failover monitor.


### PR DESCRIPTION
Normalize the use of the notation "node %d \"%s\" (%s:%d)" in every message
that shows a node to the user. That helps a lot with debugging, and also,
when people name things, they usually like using the name again.