### PR TITLE
Review memory/malloc errors and potential leaks.

### DIFF
--- a/src/bin/pg_autoctl/cli_do_tmux.c
+++ b/src/bin/pg_autoctl/cli_do_tmux.c
@@ -316,7 +316,7 @@ tmux_prepare_XDG_environment(const char *root, bool createDirectories)
 
 		if (env == NULL)
 		{
-			log_fatal("Failed to malloc MAXPGPATH bytes: %m");
+			log_fatal(ALLOCATION_FAILED_ERROR);
 			return false;
 		}
 

--- a/src/bin/pg_autoctl/cli_show.c
+++ b/src/bin/pg_autoctl/cli_show.c
@@ -1525,6 +1525,8 @@ fprint_file_contents(const char *filename)
 	if (read_file(filename, &contents, &size))
 	{
 		fformat(stdout, "%s\n", contents);
+		free(contents);
+
 		return true;
 	}
 	else

--- a/src/bin/pg_autoctl/defaults.h
+++ b/src/bin/pg_autoctl/defaults.h
@@ -157,4 +157,8 @@
  */
 #define FOPEN_FLAGS_A O_APPEND | O_RDWR | O_CREAT
 
+
+/* when malloc fails, what do we tell our users */
+#define ALLOCATION_FAILED_ERROR "Failed to allocate memory: %m"
+
 #endif /* DEFAULTS_H */

--- a/src/bin/pg_autoctl/file_utils.c
+++ b/src/bin/pg_autoctl/file_utils.c
@@ -328,6 +328,7 @@ read_file_internal(FILE *fileStream,
 	if (data == NULL)
 	{
 		log_error("Failed to allocate %ld bytes", *fileSize);
+		log_error(ALLOCATION_FAILED_ERROR);
 		fclose(fileStream);
 		return false;
 	}
@@ -595,7 +596,7 @@ search_path(const char *filename, char ***result)
 	*result = malloc(pathListLength * sizeof(char *));
 	if (!*result)
 	{
-		log_error("Failed to allocate memory, probably because it's all used");
+		log_error(ALLOCATION_FAILED_ERROR);
 		return 0;
 	}
 
@@ -603,7 +604,7 @@ search_path(const char *filename, char ***result)
 	stringSpace = malloc(pathListLength * MAXPGPATH);
 	if (!stringSpace)
 	{
-		log_error("Failed to allocate memory, probably because it's all used");
+		log_error(ALLOCATION_FAILED_ERROR);
 		free(*result);
 		return 0;
 	}

--- a/src/bin/pg_autoctl/keeper.c
+++ b/src/bin/pg_autoctl/keeper.c
@@ -909,6 +909,7 @@ keeper_ensure_configuration(Keeper *keeper, bool postgresNotRunningIsOk)
 											 state->current_node_id))
 		{
 			/* can't happen at the moment */
+			free(currentConfContents);
 			return false;
 		}
 
@@ -920,6 +921,7 @@ keeper_ensure_configuration(Keeper *keeper, bool postgresNotRunningIsOk)
 		{
 			log_error("Failed to setup Postgres as a standby after primary "
 					  "connection settings change");
+			free(currentConfContents);
 			return false;
 		}
 
@@ -927,6 +929,7 @@ keeper_ensure_configuration(Keeper *keeper, bool postgresNotRunningIsOk)
 		if (!read_file(upstreamConfPath, &newConfContents, &newConfSize))
 		{
 			/* errors have already been logged */
+			free(currentConfContents);
 			return false;
 		}
 
@@ -934,10 +937,7 @@ keeper_ensure_configuration(Keeper *keeper, bool postgresNotRunningIsOk)
 			currentConfContents == NULL ||
 			strcmp(newConfContents, currentConfContents) != 0;
 
-		if (currentConfContents != NULL)
-		{
-			free(currentConfContents);
-		}
+		free(currentConfContents);
 		free(newConfContents);
 
 		if (replicationSettingsHaveChanged)

--- a/src/bin/pg_autoctl/lock_utils.c
+++ b/src/bin/pg_autoctl/lock_utils.c
@@ -211,6 +211,8 @@ semaphore_cleanup(const char *pidfile)
 		return false;
 	}
 
+	free(fileContents);
+
 	log_trace("Read semaphore id %d from stale pidfile", semaphore.semId);
 
 	return semaphore_unlink(&semaphore);

--- a/src/bin/pg_autoctl/parsing.c
+++ b/src/bin/pg_autoctl/parsing.c
@@ -97,9 +97,10 @@ regexp_first_match(const char *string, const char *regex)
 		int finish = m[1].rm_eo;
 		int length = finish - start + 1;
 		char *result = (char *) malloc(length * sizeof(char));
+
 		if (result == NULL)
 		{
-			log_error("Failed to allocate memory, probably because it's all used");
+			log_error(ALLOCATION_FAILED_ERROR);
 			return NULL;
 		}
 

--- a/src/bin/pg_autoctl/pidfile.c
+++ b/src/bin/pg_autoctl/pidfile.c
@@ -327,8 +327,8 @@ read_service_pidfile_version_strings(const char *pidfile,
 		/* extension version string, comes later in the file */
 		if (pidLine == PIDFILE_LINE_EXTENSION_VERSION)
 		{
-			free(fileContents);
 			strlcpy(extensionVersionString, fileLines[lineNumber], BUFSIZE);
+			free(fileContents);
 			return true;
 		}
 	}

--- a/src/bin/pg_autoctl/pidfile.c
+++ b/src/bin/pg_autoctl/pidfile.c
@@ -307,12 +307,7 @@ read_service_pidfile_version_strings(const char *pidfile,
 	int lineCount = 0;
 	int lineNumber;
 
-	if (!file_exists(pidfile))
-	{
-		return false;
-	}
-
-	if (!read_file(pidfile, &fileContents, &fileSize))
+	if (!read_file_if_exists(pidfile, &fileContents, &fileSize))
 	{
 		return false;
 	}
@@ -332,10 +327,13 @@ read_service_pidfile_version_strings(const char *pidfile,
 		/* extension version string, comes later in the file */
 		if (pidLine == PIDFILE_LINE_EXTENSION_VERSION)
 		{
+			free(fileContents);
 			strlcpy(extensionVersionString, fileLines[lineNumber], BUFSIZE);
 			return true;
 		}
 	}
+
+	free(fileContents);
 
 	return false;
 }
@@ -362,12 +360,7 @@ pidfile_as_json(JSON_Value *js, const char *pidfile, bool includeStatus)
 	int lineCount = 0;
 	int lineNumber;
 
-	if (!file_exists(pidfile))
-	{
-		exit(EXIT_CODE_INTERNAL_ERROR);
-	}
-
-	if (!read_file(pidfile, &fileContents, &fileSize))
+	if (!read_file_if_exists(pidfile, &fileContents, &fileSize))
 	{
 		exit(EXIT_CODE_INTERNAL_ERROR);
 	}
@@ -504,4 +497,6 @@ pidfile_as_json(JSON_Value *js, const char *pidfile, bool includeStatus)
 	}
 
 	json_object_set_value(jsobj, "services", jsServices);
+
+	free(fileContents);
 }

--- a/src/bin/pg_autoctl/supervisor.c
+++ b/src/bin/pg_autoctl/supervisor.c
@@ -897,9 +897,12 @@ supervisor_find_service_pid(const char *pidfile,
 		{
 			*separator = '\0';
 			stringToInt(fileLines[lineNumber], pid);
+			free(fileContents);
 			return true;
 		}
 	}
+
+	free(fileContents);
 
 	return false;
 }


### PR DESCRIPTION
We avoid using malloc in most of the code base, and still require it when
reading a file from disk. Some places in the code didn't get the memo that
read_file() and read_file_if_exists() leak memory, and the caller needs to
call free().

Also, because we only have a handful of malloc() failed error messages, it's
a good thing to always use the same error message format. And this format
should not require memory allocation of course. I believe %m is okay with
that.

Fixes #473 