### PR TITLE
Review APPLY_SETTINGS transitions in cases including node removal.

### DIFF
--- a/src/bin/pg_autoctl/fsm.c
+++ b/src/bin/pg_autoctl/fsm.c
@@ -318,7 +318,7 @@ KeeperFSMTransition KeeperFSM[] = {
 	 * monitor.
 	 */
 	{ PRIMARY_STATE, APPLY_SETTINGS_STATE, COMMENT_PRIMARY_TO_APPLY_SETTINGS, &fsm_apply_settings },
-	{ APPLY_SETTINGS_STATE, PRIMARY_STATE, COMMENT_APPLY_SETTINGS_TO_PRIMARY, NULL },
+	{ APPLY_SETTINGS_STATE, PRIMARY_STATE, COMMENT_APPLY_SETTINGS_TO_PRIMARY, &fsm_apply_settings },
 
 	/*
 	 * In case of multiple standbys, failover begins with reporting current LSN

--- a/src/bin/pg_autoctl/fsm.c
+++ b/src/bin/pg_autoctl/fsm.c
@@ -135,7 +135,7 @@
 #define COMMENT_PRIMARY_TO_APPLY_SETTINGS \
 	"Apply new pg_auto_failover settings (synchronous_standby_names)"
 
-# define COMMENT_APPLY_SETTINGS_TO_PRIMARY \
+#define COMMENT_APPLY_SETTINGS_TO_PRIMARY \
 	"Back to primary state after having applied new pg_auto_failover settings"
 
 #define COMMENT_SECONDARY_TO_REPORT_LSN \
@@ -319,6 +319,10 @@ KeeperFSMTransition KeeperFSM[] = {
 	 */
 	{ PRIMARY_STATE, APPLY_SETTINGS_STATE, COMMENT_PRIMARY_TO_APPLY_SETTINGS, &fsm_apply_settings },
 	{ APPLY_SETTINGS_STATE, PRIMARY_STATE, COMMENT_APPLY_SETTINGS_TO_PRIMARY, &fsm_apply_settings },
+
+	{ APPLY_SETTINGS_STATE, SINGLE_STATE, COMMENT_PRIMARY_TO_SINGLE, &fsm_disable_replication },
+	{ APPLY_SETTINGS_STATE, WAIT_PRIMARY_STATE, COMMENT_PRIMARY_TO_WAIT_PRIMARY, &fsm_disable_sync_rep },
+	{ APPLY_SETTINGS_STATE, JOIN_PRIMARY_STATE, COMMENT_PRIMARY_TO_JOIN_PRIMARY, &fsm_prepare_replication },
 
 	/*
 	 * In case of multiple standbys, failover begins with reporting current LSN

--- a/src/bin/pg_autoctl/fsm.c
+++ b/src/bin/pg_autoctl/fsm.c
@@ -317,7 +317,7 @@ KeeperFSMTransition KeeperFSM[] = {
 	 * have to fetch the new value for synchronous_standby_names from the
 	 * monitor.
 	 */
-	{ PRIMARY_STATE, APPLY_SETTINGS_STATE, COMMENT_PRIMARY_TO_APPLY_SETTINGS, &fsm_apply_settings },
+	{ PRIMARY_STATE, APPLY_SETTINGS_STATE, COMMENT_PRIMARY_TO_APPLY_SETTINGS, NULL },
 	{ APPLY_SETTINGS_STATE, PRIMARY_STATE, COMMENT_APPLY_SETTINGS_TO_PRIMARY, &fsm_apply_settings },
 
 	{ APPLY_SETTINGS_STATE, SINGLE_STATE, COMMENT_PRIMARY_TO_SINGLE, &fsm_disable_replication },

--- a/src/bin/pg_autoctl/fsm_transition.c
+++ b/src/bin/pg_autoctl/fsm_transition.c
@@ -672,6 +672,13 @@ fsm_start_postgres(Keeper *keeper)
 		return false;
 	}
 
+	/* fetch synchronous_standby_names setting from the monitor */
+	if (!fsm_apply_settings(keeper))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
 	return true;
 }
 

--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -964,6 +964,26 @@ SELECT reportedstate
         command.execute("drop node", 'drop', 'node')
         return True
 
+    def do_fsm_assign(self, target_state):
+        """
+        Runs `pg_autoctl do fsm assign` on a node
+
+        :return:
+        """
+        command = PGAutoCtl(self)
+        command.execute("do fsm assign", 'do', 'fsm', 'assign', target_state)
+        return True
+
+    def do_fsm_step(self):
+        """
+        Runs `pg_autoctl do fsm step` on a node
+
+        :return:
+        """
+        command = PGAutoCtl(self)
+        command.execute("do fsm step", 'do', 'fsm', 'step')
+        return True
+
     def set_metadata(self, name=None, host=None, port=None):
         """
             Sets node metadata via pg_autoctl
@@ -1062,13 +1082,30 @@ SELECT reportedstate
 
     def get_synchronous_standby_names(self):
         """
-            Gets number sync standbys  via pg_autoctl
+            Gets synchronous standby names  via pg_autoctl
         """
         command = PGAutoCtl(self)
         out, err, ret = command.execute("get synchronous_standby_names",
                                         'show', 'standby-names')
 
         return out.strip()
+
+    def get_synchronous_standby_names_local(self):
+         """
+             Gets synchronous standby names via sql query on data node
+         """
+         query = "select current_setting('synchronous_standby_names')"
+
+         result = self.run_sql_query(query)
+         return result[0][0]
+
+    def print_synchronous_standby_names(self):
+        monitorStandbyNames = self.get_synchronous_standby_names()
+        localStandbyNames = self.get_synchronous_standby_names_local()
+
+        print("synchronous_standby_names       = '%s'" % monitorStandbyNames)
+        print("synchronous_standby_names_local = '%s'" % localStandbyNames)
+        return
 
     def list_replication_slot_names(self):
         """

--- a/tests/test_multi_standbys.py
+++ b/tests/test_multi_standbys.py
@@ -10,6 +10,8 @@ node1 = None
 node2 = None
 node3 = None
 node4 = None
+node5 = None
+node6 = None
 
 def setup_module():
     global cluster
@@ -111,27 +113,38 @@ def test_005_number_sync_standbys():
     print("set number_sync_standbys = 2")
     assert node1.set_number_sync_standbys(2)
     assert node1.get_number_sync_standbys() == 2
-    print("synchronous_standby_names = '%s'" %
-          node1.get_synchronous_standby_names())
+
+    node1.print_synchronous_standby_names()
+    eq_(node1.get_synchronous_standby_names(),
+        node1.get_synchronous_standby_names_local())
 
     print("set number_sync_standbys = 0")
     assert node1.set_number_sync_standbys(0)
     assert node1.get_number_sync_standbys() == 0
-    print("synchronous_standby_names = '%s'" %
-          node1.get_synchronous_standby_names())
+
+    node1.print_synchronous_standby_names()
+    eq_(node1.get_synchronous_standby_names(),
+        node1.get_synchronous_standby_names_local())
 
     print("set number_sync_standbys = 1")
     assert node1.set_number_sync_standbys(1)
     assert node1.get_number_sync_standbys() == 1
-    print("synchronous_standby_names = '%s'" %
-          node1.get_synchronous_standby_names())
+
+    node1.print_synchronous_standby_names()
+    eq_(node1.get_synchronous_standby_names(),
+        node1.get_synchronous_standby_names_local())
 
 def test_006_number_sync_standbys_trigger():
     assert node1.set_number_sync_standbys(2)
     assert node1.get_number_sync_standbys() == 2
 
     node4.drop()
-    assert node1.get_number_sync_standbys() == 1
+
+    # check synchronous_standby_names
+    node1.print_synchronous_standby_names()
+    eq_(node1.get_synchronous_standby_names(),
+        node1.get_synchronous_standby_names_local())
+
     assert node1.wait_until_state(target_state="primary")
 
     # there's no state change to instruct us that the replication slot
@@ -176,6 +189,9 @@ def test_009_failover():
     assert node3.wait_until_state(target_state="secondary")
     assert node1.wait_until_state(target_state="secondary")
 
+    eq_(node2.get_synchronous_standby_names(),
+        node2.get_synchronous_standby_names_local())
+
     assert node1.has_needed_replication_slots()
     assert node2.has_needed_replication_slots()
     assert node3.has_needed_replication_slots()
@@ -201,8 +217,30 @@ def test_012_fail_primary():
     assert node1.wait_until_state(target_state="primary")
     assert node3.wait_until_state(target_state="secondary")
 
+    eq_(node1.get_synchronous_standby_names(),
+        node1.get_synchronous_standby_names_local())
+
 def test_013_remove_old_primary():
     node2.drop()
 
     assert node1.wait_until_state(target_state="primary")
     assert node3.wait_until_state(target_state="secondary")
+
+def test_014_update_standby_names_when_adding_and_removing_a_standby():
+    global node5
+    global node6
+
+    node5 = cluster.create_datanode("/tmp/multi_standby/node5")
+    node6 = cluster.create_datanode("/tmp/multi_standby/node6")
+
+    node1.do_fsm_assign(target_state="join_primary")
+    node1.do_fsm_step()
+
+    print(monitor.get_other_nodes(node1.nodeid))
+
+    # assert node1.wait_until_state(target_state="join_primary")
+    node3.drop()
+
+    # assert node1.wait_until_state(target_state="primary")
+    eq_(node1.get_synchronous_standby_names(),
+        node1.get_synchronous_standby_names_local())


### PR DESCRIPTION
When removing a node we might end up with a race condition if the primary in
parallel is already in a transition, or in any other case when
ProceedGroupState on the primary doesn't change the assigned state.

In that case we now force a new APPLY_SETTINGS state to be assigned, so that
the primary has a chance of fetching the (new) current synchronous standby
names settings.

Also, it might be that a node has been dropped while reaching APPLY_SETTINGS
itself, so in the transition from APPLY_SETTINGS to PRIMARY we also
implement fsm_apply_settings, to protect against race conditions.

Any transition to PRIMARY now also calls fsm_apply_settings.

Fixes #446, fixes #476.