### PR TITLE
Fix when we switch synchronous_standby_names to '*'.

### DIFF
--- a/src/monitor/node_active_protocol.c
+++ b/src/monitor/node_active_protocol.c
@@ -2178,7 +2178,7 @@ synchronous_standby_names(PG_FUNCTION_ARGS)
 
 		if (secondaryNode != NULL &&
 			secondaryNode->replicationQuorum &&
-			IsCurrentState(secondaryNode, REPLICATION_STATE_SECONDARY))
+			secondaryNode->goalState == REPLICATION_STATE_SECONDARY)
 		{
 			/* enable synchronous replication */
 			PG_RETURN_TEXT_P(cstring_to_text("*"));

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -55,7 +55,8 @@ def test_004_failover():
     print()
     print("Calling pgautofailover.failover() on the monitor")
     cluster.monitor.failover()
-    assert node2.wait_until_state(target_state="primary")
-    assert node1.wait_until_state(target_state="secondary")
 
+    assert node2.wait_until_state(target_state="primary")
     eq_(node2.get_synchronous_standby_names_local(), '*')
+
+    assert node1.wait_until_state(target_state="secondary")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -49,9 +49,13 @@ def test_003_init_secondary():
     assert node2.wait_until_state(target_state="secondary")
     assert node1.wait_until_state(target_state="primary")
 
+    eq_(node1.get_synchronous_standby_names_local(), '*')
+
 def test_004_failover():
     print()
     print("Calling pgautofailover.failover() on the monitor")
     cluster.monitor.failover()
     assert node2.wait_until_state(target_state="primary")
     assert node1.wait_until_state(target_state="secondary")
+
+    eq_(node2.get_synchronous_standby_names_local(), '*')

--- a/tests/test_basic_operation.py
+++ b/tests/test_basic_operation.py
@@ -65,10 +65,10 @@ def test_004_init_secondary():
 
     assert node2.wait_until_state(target_state="secondary")
     assert node1.wait_until_state(target_state="primary")
+    eq_(node1.get_synchronous_standby_names_local(), '*')
 
     assert node1.has_needed_replication_slots()
     assert node2.has_needed_replication_slots()
-    eq_(node1.get_synchronous_standby_names_local(), '*')
 
 def test_005_read_from_secondary():
     results = node2.run_sql_query("SELECT * FROM t1")
@@ -138,10 +138,12 @@ def test_011_writes_to_node2_succeed():
 
 def test_012_start_node1_again():
     node1.run()
+
     assert node2.wait_until_state(target_state="primary")
+    eq_(node2.get_synchronous_standby_names_local(), '*')
+
     assert node1.wait_until_state(target_state="secondary")
 
-    eq_(node2.get_synchronous_standby_names_local(), '*')
 
 def test_013_read_from_new_secondary():
     results = node1.run_sql_query("SELECT * FROM t1 ORDER BY a")
@@ -209,12 +211,13 @@ def test_020_multiple_manual_failover_verify_replication_slots():
     print("Calling pg_autoctl perform promotion on node 2")
     node2.perform_promotion()
     assert node2.wait_until_state(target_state="primary")
+    eq_(node2.get_synchronous_standby_names_local(), '*')
+
     assert node3.wait_until_state(target_state="secondary")
 
     assert node2.has_needed_replication_slots()
     assert node3.has_needed_replication_slots()
 
-    eq_(node2.get_synchronous_standby_names_local(), '*')
 
 #
 # Now test network partition detection. Cut the primary out of the network
@@ -225,6 +228,7 @@ def test_020_multiple_manual_failover_verify_replication_slots():
 def test_021_ifdown_primary():
     print()
     assert node2.wait_until_state(target_state="primary")
+    eq_(node2.get_synchronous_standby_names_local(), '*')
     node2.ifdown()
 
 def test_022_detect_network_partition():
@@ -248,6 +252,7 @@ def test_022_detect_network_partition():
     print()
     assert not node2.pg_is_running()
     assert node3.wait_until_state(target_state="wait_primary")
+    eq_(node3.get_synchronous_standby_names_local(), '')
 
 def test_023_ifup_old_primary():
     print()

--- a/tests/test_basic_operation.py
+++ b/tests/test_basic_operation.py
@@ -68,6 +68,7 @@ def test_004_init_secondary():
 
     assert node1.has_needed_replication_slots()
     assert node2.has_needed_replication_slots()
+    eq_(node1.get_synchronous_standby_names_local(), '*')
 
 def test_005_read_from_secondary():
     results = node2.run_sql_query("SELECT * FROM t1")
@@ -96,6 +97,8 @@ def test_007b_maintenance_primary_allow_failover():
     assert node1.wait_until_state(target_state="secondary")
     assert node2.wait_until_state(target_state="primary")
 
+    eq_(node2.get_synchronous_standby_names_local(), '*')
+
 def test_008_maintenance_secondary():
     print()
     print("Enabling maintenance on node2")
@@ -111,12 +114,16 @@ def test_008_maintenance_secondary():
     assert node1.wait_until_state(target_state="secondary")
     assert node2.wait_until_state(target_state="primary")
 
+    eq_(node2.get_synchronous_standby_names_local(), '*')
+
 # the rest of the tests expect node1 to be primary, make it so
 def test_009_failback():
     print()
     monitor.failover()
     assert node2.wait_until_state(target_state="secondary")
     assert node1.wait_until_state(target_state="primary")
+
+    eq_(node1.get_synchronous_standby_names_local(), '*')
 
 def test_010_fail_primary():
     print()
@@ -133,6 +140,8 @@ def test_012_start_node1_again():
     node1.run()
     assert node2.wait_until_state(target_state="primary")
     assert node1.wait_until_state(target_state="secondary")
+
+    eq_(node2.get_synchronous_standby_names_local(), '*')
 
 def test_013_read_from_new_secondary():
     results = node1.run_sql_query("SELECT * FROM t1 ORDER BY a")
@@ -173,6 +182,8 @@ def test_019_run_secondary():
     assert node2.has_needed_replication_slots()
     assert node3.has_needed_replication_slots()
 
+    eq_(node2.get_synchronous_standby_names_local(), '*')
+
 # In previous versions of pg_auto_failover we removed the replication slot
 # on the secondary after failover. Now, we instead maintain the replication
 # slot's replay_lsn thanks for the monitor tracking of the nodes' LSN
@@ -193,6 +204,8 @@ def test_020_multiple_manual_failover_verify_replication_slots():
     assert node2.has_needed_replication_slots()
     assert node3.has_needed_replication_slots()
 
+    eq_(node3.get_synchronous_standby_names_local(), '*')
+
     print("Calling pg_autoctl perform promotion on node 2")
     node2.perform_promotion()
     assert node2.wait_until_state(target_state="primary")
@@ -200,6 +213,8 @@ def test_020_multiple_manual_failover_verify_replication_slots():
 
     assert node2.has_needed_replication_slots()
     assert node3.has_needed_replication_slots()
+
+    eq_(node2.get_synchronous_standby_names_local(), '*')
 
 #
 # Now test network partition detection. Cut the primary out of the network
@@ -241,6 +256,8 @@ def test_023_ifup_old_primary():
     assert node2.wait_until_pg_is_running()
     assert node2.wait_until_state("secondary")
     assert node3.wait_until_state("primary")
+
+    eq_(node3.get_synchronous_standby_names_local(), '*')
 
 def test_024_stop_postgres_monitor():
     original_state = node3.get_state()


### PR DESCRIPTION
Because we assign both SECONDARY and PRIMARY in the same monitor
ProceedGroupState call, we might end up with the primary fetching its new
synchronous_standby_names from the monitor before when the secondary has
made it to its new state.

With the previous coding, the primary would then retrieve '', meaning sync
replication is disabled, when what's needed is '*'.

We add some needed test coverage from the situation and fix it in the
monitor by returning '*' as soon as the other node is assigned SECONDARY
rather than only after it has reported the state.