### PR TITLE
Fix/non default formation

### DIFF
--- a/src/bin/pg_autoctl/cli_common.c
+++ b/src/bin/pg_autoctl/cli_common.c
@@ -1541,7 +1541,7 @@ cli_node_metadata_getopts(int argc, char **argv)
 	options.postgresql_restart_failure_timeout = -1;
 	options.postgresql_restart_failure_max_retries = -1;
 
-	strlcpy(options.formation, "default", NAMEDATALEN);
+	/* do not set a default formation, it should be found in the config file */
 
 	optind = 0;
 

--- a/src/bin/pg_autoctl/cli_common.c
+++ b/src/bin/pg_autoctl/cli_common.c
@@ -1479,7 +1479,7 @@ cli_common_pgsetup_init(ConfigFilePaths *pathnames, PostgresSetup *pgSetup)
 
 
 /*
- * cli_common_set_formation reads the formation name from the configuration
+ * cli_common_ensure_formation reads the formation name from the configuration
  * file where it's not been given on the command line. When the local node is a
  * monitor, the target formation should be found on the command line with the
  * option --formation, otherwise we default to FORMATION_DEFAULT.

--- a/src/bin/pg_autoctl/cli_common.h
+++ b/src/bin/pg_autoctl/cli_common.h
@@ -178,6 +178,7 @@ void cli_drop_local_node(KeeperConfig *config, bool dropAndDestroy);
 char * logLevelToString(int logLevel);
 
 bool cli_common_pgsetup_init(ConfigFilePaths *pathnames, PostgresSetup *pgSetup);
+bool cli_common_ensure_formation(KeeperConfig *options);
 
 bool cli_pg_autoctl_reload(const char *pidfile);
 

--- a/src/bin/pg_autoctl/cli_show.c
+++ b/src/bin/pg_autoctl/cli_show.c
@@ -181,8 +181,6 @@ cli_show_state_getopts(int argc, char **argv)
 	options.postgresql_restart_failure_timeout = -1;
 	options.postgresql_restart_failure_max_retries = -1;
 
-	strlcpy(options.formation, "default", NAMEDATALEN);
-
 	optind = 0;
 
 	while ((c = getopt_long(argc, argv, "D:f:g:n:Vvqh",
@@ -306,6 +304,13 @@ cli_show_state_getopts(int argc, char **argv)
 
 	if (!keeper_config_set_pathnames_from_pgdata(&(options.pathnames),
 												 options.pgSetup.pgdata))
+	{
+		/* errors have already been logged */
+		exit(EXIT_CODE_BAD_ARGS);
+	}
+
+	/* ensure --formation, or get it from the configuration file */
+	if (!cli_common_ensure_formation(&options))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_BAD_ARGS);
@@ -564,7 +569,7 @@ cli_show_standby_names_getopts(int argc, char **argv)
 	options.postgresql_restart_failure_timeout = -1;
 	options.postgresql_restart_failure_max_retries = -1;
 
-	strlcpy(options.formation, "default", NAMEDATALEN);
+	/* do not set a default formation, it should be found in the config file */
 
 	optind = 0;
 
@@ -667,6 +672,20 @@ cli_show_standby_names_getopts(int argc, char **argv)
 	}
 
 	cli_common_get_set_pgdata_or_exit(&(options.pgSetup));
+
+	if (!keeper_config_set_pathnames_from_pgdata(&(options.pathnames),
+												 options.pgSetup.pgdata))
+	{
+		/* errors have already been logged */
+		exit(EXIT_CODE_BAD_ARGS);
+	}
+
+	/* ensure --formation, or get it from the configuration file */
+	if (!cli_common_ensure_formation(&options))
+	{
+		/* errors have already been logged */
+		exit(EXIT_CODE_BAD_ARGS);
+	}
 
 	keeperOptions = options;
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -20,9 +20,13 @@ def test_000_create_monitor():
     monitor.wait_until_pg_is_running()
     monitor.set_user_password("autoctl_node", "autoctl_node_password")
 
+    monitor.create_formation("auth", kind="pgsql", secondary=True)
+
 def test_001_init_primary():
     global node1
-    node1 = cluster.create_datanode("/tmp/auth/node1", authMethod="md5")
+    node1 = cluster.create_datanode("/tmp/auth/node1",
+                                    authMethod="md5",
+                                    formation="auth")
     node1.create()
     node1.config_set("replication.password", "streaming_password")
     node1.run()
@@ -39,7 +43,9 @@ def test_002_create_t1():
 
 def test_003_init_secondary():
     global node2
-    node2 = cluster.create_datanode("/tmp/auth/node2", authMethod="md5")
+    node2 = cluster.create_datanode("/tmp/auth/node2",
+                                    authMethod="md5",
+                                    formation="auth")
 
     os.putenv('PGPASSWORD', "streaming_password")
     node2.create()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -60,8 +60,7 @@ def test_003_init_secondary():
 def test_004_failover():
     print()
     print("Calling pgautofailover.failover() on the monitor")
-    cluster.monitor.failover()
-
+    cluster.monitor.failover(formation="auth")
     assert node2.wait_until_state(target_state="primary")
     eq_(node2.get_synchronous_standby_names_local(), '*')
 


### PR DESCRIPTION
When we are supposed to read a configuration file, rather than creating one
for the first time, avoid setting a default formation in our command line
parsing structure. It's impossible to then distinguish between the user
saying --formation default to override what's in the configuration with the
case where we just want to use whatever is the default.
