### PR TITLE
Fix Makefile under pg_autoctl when PGHOME doesn't contain pgsql or postgres

### DIFF
--- a/src/bin/pg_autoctl/Makefile
+++ b/src/bin/pg_autoctl/Makefile
@@ -46,7 +46,7 @@ DEFAULT_CFLAGS += $(COMMON_LIBS)
 
 override CFLAGS := $(DEFAULT_CFLAGS) $(CFLAGS)
 
-LIBS  = -L $(shell $(PG_CONFIG) --pkglibdir)
+LIBS  = -L $(shell $(PG_CONFIG) --libdir)
 LIBS += $(shell $(PG_CONFIG) --ldflags)
 LIBS += $(shell $(PG_CONFIG) --libs)
 LIBS += -lpq


### PR DESCRIPTION
When the PGHOME doesn't contain pgsql or postgres, the compiler fails
in linking pg_autoctl. Because the prefix affects the path $(pkglibdir).
However, all the libraries needed by pg_autoctl is under $(libdir).
See `postgresql/src/Makefile.global.in` :
```Makefile
pkglibdir = $(libdir)
ifeq "$(findstring pgsql, $(pkglibdir))" ""
ifeq "$(findstring postgres, $(pkglibdir))" ""
override pkglibdir := $(pkglibdir)/postgresql
endif
endif
```
Co-authored-by: Hubert Zhang <hzhang@pivotal.io>