### PR TITLE
Review when to assign catching-up on unhealthy secondary.

### DIFF
--- a/src/monitor/group_state_machine.c
+++ b/src/monitor/group_state_machine.c
@@ -810,7 +810,8 @@ ProceedGroupStateForPrimaryNode(AutoFailoverNode *primaryNode)
 		{
 			AutoFailoverNode *otherNode = (AutoFailoverNode *) lfirst(nodeCell);
 
-			if (IsCurrentState(otherNode, REPLICATION_STATE_SECONDARY) &&
+			/* even if the node is on its way to being a secondary... */
+			if (otherNode->goalState == REPLICATION_STATE_SECONDARY &&
 				IsUnhealthy(otherNode))
 			{
 				char message[BUFSIZE];


### PR DESCRIPTION
As soon as a node has been assigned secondary we may assign catching-up
instead if the monitor finds it unhealthy.

See #488 