### PR TITLE
Fix --disable-monitor to work with the parenting of Postgres model.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ PDF = ./docs/_build/latex/pg_auto_failover.pdf
 NOSETESTS = $(shell which nosetests3 || which nosetests)
 
 # Tests for multiple standbys
-MULTI_SB_TESTS = $(basename $(notdir $(wildcard tests/test*_multi*)))
+MULTI_SB_TESTS  = $(basename $(notdir $(wildcard tests/test*_multi*)))
+MULTI_SB_TESTS += $(basename $(notdir $(wildcard tests/test*_disabled*)))
 
 # TEST indicates the testfile to run
 TEST ?=
@@ -18,7 +19,7 @@ ifeq ($(TEST),)
 else ifeq ($(TEST),multi)
 	TEST_ARGUMENT = --where=tests --tests=$(MULTI_SB_TESTS)
 else ifeq ($(TEST),single)
-	TEST_ARGUMENT = --where=tests --exclude='_multi_'
+	TEST_ARGUMENT = --where=tests --exclude='_multi_' --exclude='disabled'
 else
 	TEST_ARGUMENT = $(TEST:%=tests/%.py)
 endif

--- a/src/bin/pg_autoctl/cli_common.h
+++ b/src/bin/pg_autoctl/cli_common.h
@@ -31,6 +31,8 @@ extern bool outputJSON;
 
 extern int ssl_flag;
 
+extern int monitorDisabledNodeId;
+
 #define KEEPER_CLI_SSL_OPTIONS \
 	"  --ssl-self-signed setup network encryption using self signed certificates (does NOT protect against MITM)\n" \
 	"  --ssl-mode        use that sslmode in connection strings\n" \

--- a/src/bin/pg_autoctl/cli_create_drop_node.c
+++ b/src/bin/pg_autoctl/cli_create_drop_node.c
@@ -986,7 +986,7 @@ cli_drop_node(int argc, char **argv)
 
 	bool missingPgdataIsOk = true;
 	bool pgIsNotRunningIsOk = true;
-	bool monitorDisabledIsOk = false;
+	bool monitorDisabledIsOk = true;
 
 	/*
 	 * The configuration file is the last bit we remove, so we don't have to

--- a/src/bin/pg_autoctl/cli_do_fsm.c
+++ b/src/bin/pg_autoctl/cli_do_fsm.c
@@ -320,13 +320,6 @@ cli_do_fsm_assign(int argc, char **argv)
 	/* assign the new state */
 	keeper.state.assigned_role = goalState;
 
-	/* roll the state machine */
-	if (!keeper_fsm_reach_assigned_state(&keeper))
-	{
-		/* errors have already been logged */
-		exit(EXIT_CODE_BAD_STATE);
-	}
-
 	if (!keeper_store_state(&keeper))
 	{
 		/* errors have already been logged */

--- a/src/bin/pg_autoctl/cli_do_fsm.c
+++ b/src/bin/pg_autoctl/cli_do_fsm.c
@@ -458,15 +458,13 @@ cli_do_fsm_get_nodes(int argc, char **argv)
 		exit(EXIT_CODE_BAD_CONFIG);
 	}
 
-	if (!keeper_read_nodes_from_file(&keeper))
+	if (!keeper_read_nodes_from_file(&keeper, &(keeper.otherNodes)))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);
 	}
 
 	(void) printNodeArray(&(keeper.otherNodes));
-
-	exit(EXIT_CODE_INTERNAL_ERROR);
 }
 
 
@@ -521,8 +519,17 @@ cli_do_fsm_set_nodes(int argc, char **argv)
 		exit(EXIT_CODE_BAD_ARGS);
 	}
 
+	/* now read keeper's state */
+	if (!keeper_init(&keeper, config))
+	{
+		/* errors have already been logged */
+		exit(EXIT_CODE_BAD_CONFIG);
+	}
+
 	/* now parse the nodes JSON file */
-	if (!parseNodesArray(contents, &(keeper.otherNodes)))
+	if (!parseNodesArray(contents,
+						 &(keeper.otherNodes),
+						 keeper.state.current_node_id))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);
@@ -538,6 +545,4 @@ cli_do_fsm_set_nodes(int argc, char **argv)
 	}
 
 	(void) printNodeArray(&(keeper.otherNodes));
-
-	exit(EXIT_CODE_INTERNAL_ERROR);
 }

--- a/src/bin/pg_autoctl/cli_service.c
+++ b/src/bin/pg_autoctl/cli_service.c
@@ -165,39 +165,42 @@ cli_keeper_run(int argc, char **argv)
 		exit(EXIT_CODE_BAD_CONFIG);
 	}
 
-	if (!monitor_init(monitor, config->monitor_pguri))
+	if (!config->monitorDisabled)
 	{
-		/* errors have already been logged */
-		exit(EXIT_CODE_BAD_ARGS);
-	}
+		if (!monitor_init(monitor, config->monitor_pguri))
+		{
+			/* errors have already been logged */
+			exit(EXIT_CODE_BAD_ARGS);
+		}
 
-	/*
-	 * Handle the pg_autoctl run options: --name, --hostname, --pgport.
-	 *
-	 * When those options have been used, then the configuration file has been
-	 * merged with the command line values, and we can update the metadata for
-	 * this node on the monitor.
-	 */
-	if (!keeper_set_node_metadata(&keeper, &oldConfig))
-	{
-		/* errors have already been logged */
-		exit(EXIT_CODE_MONITOR);
-	}
+		/*
+		 * Handle the pg_autoctl run options: --name, --hostname, --pgport.
+		 *
+		 * When those options have been used, then the configuration file has
+		 * been merged with the command line values, and we can update the
+		 * metadata for this node on the monitor.
+		 */
+		if (!keeper_set_node_metadata(&keeper, &oldConfig))
+		{
+			/* errors have already been logged */
+			exit(EXIT_CODE_MONITOR);
+		}
 
-	/*
-	 * Now, at 1.3 to 1.4 upgrade, the monitor assigns a new name to pg_autoctl
-	 * nodes, which did not use to have a name before. In that case, and then
-	 * pg_autoctl run has been used without options, our name might be empty
-	 * here. We then need to fetch it from the monitor.
-	 */
-	if (!keeper_update_nodename_from_monitor(&keeper))
-	{
-		/* errors have already been logged */
-		exit(EXIT_CODE_BAD_CONFIG);
-	}
+		/*
+		 * Now, at 1.3 to 1.4 upgrade, the monitor assigns a new name to
+		 * pg_autoctl nodes, which did not use to have a name before. In that
+		 * case, and then pg_autoctl run has been used without options, our
+		 * name might be empty here. We then need to fetch it from the monitor.
+		 */
+		if (!keeper_update_nodename_from_monitor(&keeper))
+		{
+			/* errors have already been logged */
+			exit(EXIT_CODE_BAD_CONFIG);
+		}
 
-	/* we don't keep a connection to the monitor in this process */
-	pgsql_finish(&(monitor->pgsql));
+		/* we don't keep a connection to the monitor in this process */
+		pgsql_finish(&(monitor->pgsql));
+	}
 
 	/* initialize our local Postgres instance representation */
 	(void) local_postgres_init(postgres, pgSetup);

--- a/src/bin/pg_autoctl/config.c
+++ b/src/bin/pg_autoctl/config.c
@@ -213,6 +213,34 @@ SetStateFilePath(ConfigFilePaths *pathnames, const char *pgdata)
 
 
 /*
+ * SetNodesFilePath sets config.pathnames.nodes from our PGDATA value, and
+ * using the XDG Base Directory Specification for a data file. Per specs at:
+ *
+ *   https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
+ *
+ */
+bool
+SetNodesFilePath(ConfigFilePaths *pathnames, const char *pgdata)
+{
+	if (IS_EMPTY_STRING_BUFFER(pathnames->nodes))
+	{
+		if (!build_xdg_path(pathnames->nodes,
+							XDG_DATA,
+							pgdata,
+							KEEPER_NODES_FILENAME))
+		{
+			log_error("Failed to build pg_autoctl state file pathname, "
+					  "see above.");
+			return false;
+		}
+	}
+	log_trace("SetNodesFilePath: \"%s\"", pathnames->nodes);
+
+	return true;
+}
+
+
+/*
  * SetPidFilePath sets config.pathnames.pidfile from our PGDATA value, and
  * using the XDG Base Directory Specification for a runtime file.
  */

--- a/src/bin/pg_autoctl/config.h
+++ b/src/bin/pg_autoctl/config.h
@@ -37,6 +37,7 @@ typedef struct ConfigFilePaths
 	char state[MAXPGPATH];  /* ~/.local/share/pg_autoctl/${PGDATA}/pg_autoctl.state */
 	char pid[MAXPGPATH];    /* /tmp/${PGDATA}/pg_autoctl.pid */
 	char init[MAXPGPATH];   /* /tmp/${PGDATA}/pg_autoctl.init */
+	char nodes[MAXPGPATH];  /* ~/.local/share/pg_autoctl/${PGDATA}/nodes.json */
 	char systemd[MAXPGPATH];    /* ~/.config/systemd/user/pgautofailover.service */
 } ConfigFilePaths;
 
@@ -69,6 +70,7 @@ bool build_xdg_path(char *dst, XDGResourceType xdgType,
 
 bool SetConfigFilePath(ConfigFilePaths *pathnames, const char *pgdata);
 bool SetStateFilePath(ConfigFilePaths *pathnames, const char *pgdata);
+bool SetNodesFilePath(ConfigFilePaths *pathnames, const char *pgdata);
 bool SetPidFilePath(ConfigFilePaths *pathnames, const char *pgdata);
 
 pgAutoCtlNodeRole ProbeConfigurationFileRole(const char *filename);

--- a/src/bin/pg_autoctl/defaults.h
+++ b/src/bin/pg_autoctl/defaults.h
@@ -108,6 +108,7 @@
 #define KEEPER_PID_FILENAME "pg_autoctl.pid"
 #define KEEPER_INIT_STATE_FILENAME "pg_autoctl.init"
 #define KEEPER_POSTGRES_STATE_FILENAME "pg_autoctl.pg"
+#define KEEPER_NODES_FILENAME "nodes.json"
 
 #define KEEPER_SYSTEMD_SERVICE "pgautofailover"
 #define KEEPER_SYSTEMD_FILENAME "pgautofailover.service"

--- a/src/bin/pg_autoctl/keeper.c
+++ b/src/bin/pg_autoctl/keeper.c
@@ -412,6 +412,12 @@ keeper_update_pg_state(Keeper *keeper)
 
 	log_debug("Update local PostgreSQL state");
 
+	/* when running with --disable-monitor, we might get here early */
+	if (keeperState->current_role == INIT_STATE)
+	{
+		return true;
+	}
+
 	*pgSetup = config->pgSetup;
 
 	/* reinitialize the replication state values each time we update */
@@ -2118,7 +2124,7 @@ keeper_reload_configuration(Keeper *keeper, bool firstLoop)
 
 		bool missingPgdataIsOk = true;
 		bool pgIsNotRunningIsOk = true;
-		bool monitorDisabledIsOk = false;
+		bool monitorDisabledIsOk = true;
 
 		/*
 		 * Set the same configuration and state file as the current config.

--- a/src/bin/pg_autoctl/keeper.c
+++ b/src/bin/pg_autoctl/keeper.c
@@ -2291,6 +2291,8 @@ keeper_get_primary(Keeper *keeper, NodeAddress *primaryNode)
 					  "see above for details");
 			return false;
 		}
+
+		return true;
 	}
 	else
 	{

--- a/src/bin/pg_autoctl/keeper.c
+++ b/src/bin/pg_autoctl/keeper.c
@@ -2343,6 +2343,8 @@ keeper_get_most_advanced_standby(Keeper *keeper, NodeAddress *upstreamNode)
 					  "from the monitor, see above for details");
 			return false;
 		}
+
+		return true;
 	}
 	else
 	{

--- a/src/bin/pg_autoctl/keeper.h
+++ b/src/bin/pg_autoctl/keeper.h
@@ -84,6 +84,8 @@ extern KeeperReloadFunction KeeperReloadHooks[];
 void keeper_call_reload_hooks(Keeper *keeper, bool firstLoop);
 bool keeper_reload_configuration(Keeper *keeper, bool firstLoop);
 
-bool keeper_read_nodes_from_file(Keeper *keeper);
+bool keeper_read_nodes_from_file(Keeper *keeper, NodeAddressArray *nodesArray);
+bool keeper_get_primary(Keeper *keeper, NodeAddress *primaryNode);
+bool keeper_get_most_advanced_standby(Keeper *keeper, NodeAddress *primaryNode);
 
 #endif /* KEEPER_H */

--- a/src/bin/pg_autoctl/keeper.h
+++ b/src/bin/pg_autoctl/keeper.h
@@ -84,4 +84,6 @@ extern KeeperReloadFunction KeeperReloadHooks[];
 void keeper_call_reload_hooks(Keeper *keeper, bool firstLoop);
 bool keeper_reload_configuration(Keeper *keeper, bool firstLoop);
 
+bool keeper_read_nodes_from_file(Keeper *keeper);
+
 #endif /* KEEPER_H */

--- a/src/bin/pg_autoctl/keeper_config.c
+++ b/src/bin/pg_autoctl/keeper_config.c
@@ -241,6 +241,13 @@ keeper_config_set_pathnames_from_pgdata(ConfigFilePaths *pathnames,
 		return false;
 	}
 
+	if (!SetNodesFilePath(pathnames, pgdata))
+	{
+		log_fatal("Failed to set pid filename from PGDATA \"%s\","
+				  " see above for details.", pgdata);
+		return false;
+	}
+
 	if (!SetPidFilePath(pathnames, pgdata))
 	{
 		log_fatal("Failed to set pid filename from PGDATA \"%s\","

--- a/src/bin/pg_autoctl/keeper_config.h
+++ b/src/bin/pg_autoctl/keeper_config.h
@@ -22,8 +22,8 @@ typedef struct KeeperConfig
 	/* in-memory configuration related variables */
 	ConfigFilePaths pathnames;
 
-	/* who's in charge? pg_auto_failover monitor, or HTTP API? */
-	bool monitorDisabled;       /* default is 0, which means enabled */
+	/* who's in charge? pg_auto_failover monitor, or a control plane? */
+	bool monitorDisabled;
 
 	/* pg_autoctl setup */
 	char role[NAMEDATALEN];

--- a/src/bin/pg_autoctl/monitor.c
+++ b/src/bin/pg_autoctl/monitor.c
@@ -91,7 +91,6 @@ typedef struct MonitorExtensionVersionParseContext
 } MonitorExtensionVersionParseContext;
 
 
-static int MaxHostNameSizeInNodesArray(NodeAddressArray *nodesArray);
 static bool parseNode(PGresult *result, int rowNumber, NodeAddress *node);
 static void parseNodeResult(void *ctx, PGresult *result);
 static void parseNodeArray(void *ctx, PGresult *result);
@@ -1499,90 +1498,6 @@ parseNodeArray(void *ctx, PGresult *result)
 	}
 
 	context->parsedOK = parsedOk;
-}
-
-
-/*
- * MaxHostNameSizeInNodesArray returns the greatest node name length in the
- * given array of nodes.
- */
-static int
-MaxHostNameSizeInNodesArray(NodeAddressArray *nodesArray)
-{
-	int maxHostNameSize = 0;
-	int i = 0;
-
-	for (i = 0; i < nodesArray->count; i++)
-	{
-		NodeAddress node = nodesArray->nodes[i];
-
-		if (strlen(node.host) > maxHostNameSize)
-		{
-			maxHostNameSize = strlen(node.host);
-		}
-	}
-
-	return maxHostNameSize;
-}
-
-
-/*
- * printCurrentState loops over pgautofailover.current_state() results and prints
- * them, one per line.
- */
-void
-printNodeArray(NodeAddressArray *nodesArray)
-{
-	int nodesArrayIndex = 0;
-	int maxHostNameSize = 5;    /* strlen("Name") + 1, the header */
-
-	/*
-	 * Dynamically adjust our display output to the length of the longer
-	 * hostname in the result set
-	 */
-	maxHostNameSize = MaxHostNameSizeInNodesArray(nodesArray);
-
-	(void) printNodeHeader(maxHostNameSize);
-
-	for (nodesArrayIndex = 0; nodesArrayIndex < nodesArray->count; nodesArrayIndex++)
-	{
-		NodeAddress *node = &(nodesArray->nodes[nodesArrayIndex]);
-
-		printNodeEntry(node);
-	}
-
-	fformat(stdout, "\n");
-}
-
-
-/*
- * printNodeHeader pretty prints a header for a node list.
- */
-void
-printNodeHeader(int maxHostNameSize)
-{
-	char nameSeparatorHeader[BUFSIZE] = { 0 };
-
-	(void) prepareHostNameSeparator(nameSeparatorHeader, maxHostNameSize);
-
-	fformat(stdout, "%3s | %*s | %6s | %18s | %8s\n",
-			"ID", maxHostNameSize, "Host", "Port", "LSN", "Primary?");
-
-	fformat(stdout, "%3s-+-%*s-+-%6s-+-%18s-+-%8s\n",
-			"---", maxHostNameSize, nameSeparatorHeader, "------",
-			"------------------", "--------");
-}
-
-
-/*
- * printNodeEntry pretty prints a node.
- */
-void
-printNodeEntry(NodeAddress *node)
-{
-	fformat(stdout, "%3d | %s | %6d | %18s | %8s\n",
-			node->nodeId, node->host, node->port, node->lsn,
-			node->isPrimary ? "yes" : "no");
 }
 
 

--- a/src/bin/pg_autoctl/monitor.h
+++ b/src/bin/pg_autoctl/monitor.h
@@ -63,9 +63,6 @@ void monitor_finish(Monitor *monitor);
 
 bool monitor_retryable_error(const char *sqlstate);
 
-void printNodeHeader(int maxHostNameSize);
-void printNodeEntry(NodeAddress *node);
-
 bool monitor_get_nodes(Monitor *monitor, char *formation, int groupId,
 					   NodeAddressArray *nodeArray);
 bool monitor_print_nodes(Monitor *monitor, char *formation, int groupId);
@@ -79,7 +76,6 @@ bool monitor_print_other_nodes(Monitor *monitor,
 bool monitor_print_other_nodes_as_json(Monitor *monitor,
 									   int myNodeId,
 									   NodeState currentState);
-void printNodeArray(NodeAddressArray *nodesArray);
 
 bool monitor_get_primary(Monitor *monitor, char *formation, int groupId,
 						 NodeAddress *node);

--- a/src/bin/pg_autoctl/nodestate_utils.h
+++ b/src/bin/pg_autoctl/nodestate_utils.h
@@ -91,4 +91,9 @@ bool nodestateAsJSON(CurrentNodeState *nodeState, JSON_Value *js);
 char * nodestateHealthToString(int health);
 void nodestate_log(CurrentNodeState *nodeState, int logLevel, int nodeId);
 
+int MaxHostNameSizeInNodesArray(NodeAddressArray *nodesArray);
+void printNodeHeader(int maxHostNameSize);
+void printNodeEntry(NodeAddress *node);
+void printNodeArray(NodeAddressArray *nodesArray);
+
 #endif /* NODESTATE_H */

--- a/src/bin/pg_autoctl/nodestate_utils.h
+++ b/src/bin/pg_autoctl/nodestate_utils.h
@@ -91,9 +91,8 @@ bool nodestateAsJSON(CurrentNodeState *nodeState, JSON_Value *js);
 char * nodestateHealthToString(int health);
 void nodestate_log(CurrentNodeState *nodeState, int logLevel, int nodeId);
 
-int MaxHostNameSizeInNodesArray(NodeAddressArray *nodesArray);
-void printNodeHeader(int maxHostNameSize);
-void printNodeEntry(NodeAddress *node);
 void printNodeArray(NodeAddressArray *nodesArray);
+void printNodeHeader(NodeAddressHeaders *headers);
+void printNodeEntry(NodeAddressHeaders *headers, NodeAddress *node);
 
 #endif /* NODESTATE_H */

--- a/src/bin/pg_autoctl/parsing.c
+++ b/src/bin/pg_autoctl/parsing.c
@@ -685,8 +685,8 @@ buildPostgresURIfromPieces(URIParams *uriParams, char *pguri)
 
 /*
  * nodeAddressCmpByNodeId sorts two given nodeAddress by comparing their
- * nodeId. We use this function to be able to qsort() an array of nodes, such
- * as when parsing from a JSON file.
+ * nodeId. We use this function to be able to pg_qsort() an array of nodes,
+ * such as when parsing from a JSON file.
  */
 static int
 nodeAddressCmpByNodeId(const void *a, const void *b)
@@ -771,10 +771,10 @@ parseNodesArray(const char *nodesJSON, NodeAddressArray *nodesArray)
 	}
 
 	/* now ensure the array is sorted by nodeId */
-	(void) qsort(nodesArray->nodes,
-				 len,
-				 sizeof(NodeAddress),
-				 nodeAddressCmpByNodeId);
+	(void) pg_qsort(nodesArray->nodes,
+					len,
+					sizeof(NodeAddress),
+					nodeAddressCmpByNodeId);
 
 	return true;
 }

--- a/src/bin/pg_autoctl/parsing.c
+++ b/src/bin/pg_autoctl/parsing.c
@@ -848,5 +848,20 @@ parseNodesArray(const char *nodesJSON,
 					sizeof(NodeAddress),
 					nodeAddressCmpByNodeId);
 
+	/* check that every node id is unique in our array */
+	for (int i = 0; i < (nodesArray->count - 1); i++)
+	{
+		int currentNodeId = nodesArray->nodes[i].nodeId;
+		int nextNodeId = nodesArray->nodes[i + 1].nodeId;
+
+		if (currentNodeId == nextNodeId)
+		{
+			log_error("Failed to parse nodes array: more than one node "
+					  "is listed with the same nodeId %d",
+					  currentNodeId);
+			return false;
+		}
+	}
+
 	return true;
 }

--- a/src/bin/pg_autoctl/parsing.h
+++ b/src/bin/pg_autoctl/parsing.h
@@ -76,6 +76,9 @@ bool parse_pguri_info_key_vals(const char *pguri,
 
 bool buildPostgresURIfromPieces(URIParams *uriParams, char *pguri);
 
-bool parseNodesArray(const char *nodesJSON, NodeAddressArray *nodesArray);
+bool parseLSN(const char *str, uint64_t *lsn);
+bool parseNodesArray(const char *nodesJSON,
+					 NodeAddressArray *nodesArray,
+					 int nodeId);
 
 #endif /* PARSING_H */

--- a/src/bin/pg_autoctl/parsing.h
+++ b/src/bin/pg_autoctl/parsing.h
@@ -76,4 +76,6 @@ bool parse_pguri_info_key_vals(const char *pguri,
 
 bool buildPostgresURIfromPieces(URIParams *uriParams, char *pguri);
 
+bool parseNodesArray(const char *nodesJSON, NodeAddressArray *nodesArray);
+
 #endif /* PARSING_H */

--- a/src/bin/pg_autoctl/primary_standby.c
+++ b/src/bin/pg_autoctl/primary_standby.c
@@ -244,7 +244,7 @@ local_postgres_update(LocalPostgresServer *postgres, bool postgresNotRunningIsOk
 {
 	PostgresSetup *pgSetup = &(postgres->postgresSetup);
 	PostgresSetup newPgSetup = { 0 };
-	bool missingPgdataIsOk = false;
+	bool missingPgdataIsOk = true;
 
 	/* in case a connection is still established, now is time to close */
 	(void) local_postgres_finish(postgres);

--- a/src/bin/pg_autoctl/service_keeper.c
+++ b/src/bin/pg_autoctl/service_keeper.c
@@ -296,9 +296,9 @@ keeper_node_active_loop(Keeper *keeper, pid_t start_pid)
 		}
 		else if (doSleep && config->monitorDisabled)
 		{
-			int timeoutMs = PG_AUTOCTL_KEEPER_SLEEP_TIME * 1000 * 1000;
+			int timeoutUs = PG_AUTOCTL_KEEPER_SLEEP_TIME * 1000 * 1000;
 
-			pg_usleep(timeoutMs);
+			pg_usleep(timeoutUs);
 		}
 
 		doSleep = true;

--- a/src/bin/pg_autoctl/service_keeper.c
+++ b/src/bin/pg_autoctl/service_keeper.c
@@ -196,7 +196,7 @@ service_keeper_node_active_init(Keeper *keeper)
 
 	bool missingPgdataIsOk = true;
 	bool pgIsNotRunningIsOk = true;
-	bool monitorDisabledIsOk = false;
+	bool monitorDisabledIsOk = true;
 
 	if (!keeper_config_read_file(config,
 								 missingPgdataIsOk,
@@ -228,16 +228,6 @@ service_keeper_node_active_init(Keeper *keeper)
 	{
 		log_fatal("Failed to initialize keeper, see above for details");
 		exit(EXIT_CODE_PGCTL);
-	}
-
-	if (config->monitorDisabled)
-	{
-		/*
-		 * At the moment, we have nothing to do here. Later we might want to
-		 * open an HTTPd service and wait for API calls.
-		 */
-		log_fatal("--disable-monitor disables pg_autoctl servives");
-		exit(EXIT_CODE_MONITOR);
 	}
 
 	return true;
@@ -285,7 +275,7 @@ keeper_node_active_loop(Keeper *keeper, pid_t start_pid)
 		 * sleep for a while. As the monitor notifies every state change, we
 		 * can also interrupt our sleep as soon as we get the hint.
 		 */
-		if (doSleep)
+		if (doSleep && !config->monitorDisabled)
 		{
 			int timeoutMs = PG_AUTOCTL_KEEPER_SLEEP_TIME * 1000;
 
@@ -303,6 +293,12 @@ keeper_node_active_loop(Keeper *keeper, pid_t start_pid)
 			{
 				pgsql_finish(&(keeper->monitor.pgsql));
 			}
+		}
+		else if (doSleep && config->monitorDisabled)
+		{
+			int timeoutMs = PG_AUTOCTL_KEEPER_SLEEP_TIME * 1000 * 1000;
+
+			pg_usleep(timeoutMs);
 		}
 
 		doSleep = true;
@@ -341,6 +337,9 @@ keeper_node_active_loop(Keeper *keeper, pid_t start_pid)
 		 * a subsequent crash of the keeper would cause the states to become
 		 * inconsistent. By re-reading the file, we make sure the state on disk
 		 * on the keeper is consistent with the state on the monitor
+		 *
+		 * Also, when --disable-monitor is used, then we get our assigned state
+		 * by reading the state file, which is edited by an external process.
 		 */
 		if (!keeper_load_state(keeper))
 		{
@@ -380,20 +379,26 @@ keeper_node_active_loop(Keeper *keeper, pid_t start_pid)
 		 * data structure accordingy, refreshing our cache of other nodes if
 		 * needed.
 		 */
-		couldContactMonitorThisRound = keeper_node_active(keeper, doInit);
-
-		if (!couldContactMonitor && couldContactMonitorThisRound && !firstLoop)
+		if (!config->monitorDisabled)
 		{
-			/*
-			 * Last message the user saw in the output is the following, and so
-			 * we should say that we're back to the expected situation:
-			 *
-			 * Failed to get the goal state from the monitor
-			 */
-			log_info("Successfully got the goal state from the monitor");
-		}
+			couldContactMonitorThisRound = keeper_node_active(keeper, doInit);
 
-		couldContactMonitor = couldContactMonitorThisRound;
+			if (!couldContactMonitor &&
+				couldContactMonitorThisRound &&
+				!firstLoop)
+			{
+				/*
+				 * Last message the user saw in the output is the following,
+				 * and so we should say that we're back to the expected
+				 * situation:
+				 *
+				 * Failed to get the goal state from the monitor
+				 */
+				log_info("Successfully got the goal state from the monitor");
+			}
+
+			couldContactMonitor = couldContactMonitorThisRound;
+		}
 
 		if (keeperState->assigned_role != keeperState->current_role)
 		{
@@ -464,7 +469,7 @@ keeper_node_active_loop(Keeper *keeper, pid_t start_pid)
 				transitionFailed = true;
 			}
 		}
-		else if (couldContactMonitor)
+		else if (couldContactMonitor || config->monitorDisabled)
 		{
 			if (!keeper_ensure_current_state(keeper))
 			{
@@ -497,7 +502,9 @@ keeper_node_active_loop(Keeper *keeper, pid_t start_pid)
 			transitionFailed = true;
 		}
 
-		if ((needStateChange || monitor_has_received_notifications(monitor)) &&
+		if ((needStateChange ||
+			 (!config->monitorDisabled &&
+			  monitor_has_received_notifications(monitor))) &&
 			!transitionFailed)
 		{
 			/* cycle faster if we made a state transition */

--- a/src/bin/pg_autoctl/service_keeper.c
+++ b/src/bin/pg_autoctl/service_keeper.c
@@ -375,11 +375,27 @@ keeper_node_active_loop(Keeper *keeper, pid_t start_pid)
 		CHECK_FOR_FAST_SHUTDOWN;
 
 		/*
-		 * Call the node_active function on the monitor and update the keeper
-		 * data structure accordingy, refreshing our cache of other nodes if
-		 * needed.
+		 * If the monitor is disabled, read the list of other nodes from our
+		 * file on-disk at config->pathnames.nodes. The following command can
+		 * be used to fill-in that file:
+		 *
+		 *  $ pg_autoctl do fsm nodes set nodes.json
 		 */
-		if (!config->monitorDisabled)
+		if (config->monitorDisabled)
+		{
+			if (!keeper_read_nodes_from_file(keeper))
+			{
+				/* errors have already been logged, pass */
+				(void) 0;
+			}
+		}
+
+		/*
+		 * If the monitor is not disabled, call the node_active function on the
+		 * monitor and update the keeper data structure accordingy, refreshing
+		 * our cache of other nodes if needed.
+		 */
+		else
 		{
 			couldContactMonitorThisRound = keeper_node_active(keeper, doInit);
 

--- a/src/bin/pg_autoctl/state.c
+++ b/src/bin/pg_autoctl/state.c
@@ -167,7 +167,11 @@ keeper_state_write(KeeperStateData *keeperState, const char *filename)
 		return false;
 	}
 
-	close(fd);
+	if (close(fd) != 0)
+	{
+		log_fatal("Failed to close file \"%s\": %m", tempFileName);
+		return false;
+	}
 
 	log_debug("rename \"%s\" to \"%s\"", tempFileName, filename);
 

--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -255,6 +255,8 @@ class PGNode:
         """
         Runs "pg_autoctl run"
         """
+        self.name = name
+
         self.pg_autoctl = PGAutoCtl(self)
         self.pg_autoctl.run(name=name, host=host, port=port)
 
@@ -564,7 +566,8 @@ class PGNode:
             logs += node.logs()
         print(logs)
 
-        if self.cluster.monitor.pg_autoctl:
+        # we might be running with the monitor disabled
+        if self.cluster.monitor and self.cluster.monitor.pg_autoctl:
             print("%s" % self.cluster.monitor.pg_autoctl.err)
 
     def enable_ssl(self, sslMode=None, sslSelfSigned=None,
@@ -722,7 +725,8 @@ class DataNode(PGNode):
         self.formation = formation
 
     def create(self, run=False, level='-v', name=None, host=None, port=None,
-               candidatePriority=None, replicationQuorum=None):
+               candidatePriority=None, replicationQuorum=None,
+               monitorDisabled=False, nodeId=None):
         """
         Runs "pg_autoctl create"
         """
@@ -735,6 +739,9 @@ class DataNode(PGNode):
         if sockdir and sockdir != "":
             pghost = sockdir
 
+        if monitorDisabled:
+            self.monitorDisabled = True
+
         # don't pass --hostname to Postgres nodes in order to exercise the
         # automatic detection of the hostname.
         create_args = ['create', self.role.command(), level,
@@ -742,8 +749,10 @@ class DataNode(PGNode):
                        '--pghost', pghost,
                        '--pgport', str(self.port),
                        '--pgctl', shutil.which('pg_ctl'),
-                       '--auth', self.authMethod,
-                       '--monitor', self.monitor.connection_string()]
+                       '--auth', self.authMethod]
+
+        if not self.monitorDisabled:
+            create_args += ['--monitor', self.monitor.connection_string()]
 
         if self.sslMode:
             create_args += ['--ssl-mode', self.sslMode]
@@ -770,6 +779,7 @@ class DataNode(PGNode):
             create_args += ['--formation', self.formation]
 
         if name:
+            self.name = name
             create_args += ["--name", name]
 
         if host:
@@ -783,6 +793,11 @@ class DataNode(PGNode):
 
         if replicationQuorum is not None:
             create_args += ["--replication-quorum", str(replicationQuorum)]
+
+        if self.monitorDisabled:
+            assert nodeId is not None
+            create_args += ["--disable-monitor"]
+            create_args += ["--node-id", str(nodeId)]
 
         if run:
             create_args += ['--run']
@@ -814,16 +829,64 @@ class DataNode(PGNode):
         self.state = json.loads(out)
         return self.state['state']['nodeId']
 
+    def jsDict(self, lsn="0/1", isPrimary=False):
+        """
+        Returns a python dict with the information to fill-in a JSON
+        representation of the node.
+        """
+        return {"node_id": self.get_nodeid(),
+                "node_name": self.name,
+                "node_host": str(self.vnode.address),
+                "node_port": self.port,
+                "node_lsn": lsn,
+                "node_is_primary": isPrimary}
+
     def get_local_state(self):
         """
         Fetch the assigned_state from the pg_autoctl state file.
         """
         command = PGAutoCtl(self)
-        out, err, ret = command.execute("get node id", 'do', 'fsm', 'state')
+        out, err, ret = command.execute("get node id", '-vv', 'do', 'fsm', 'state')
 
         self.state = json.loads(out)
         return (self.state['state']['current_role'],
                 self.state['state']['assigned_role'])
+
+    def wait_until_local_state(self, target_state,
+                               timeout=STATE_CHANGE_TIMEOUT,
+                               sleep_time=POLLING_INTERVAL):
+        """
+        Waits until this data node reaches the target state, and then
+        returns True. The target state is compared to the local state as
+        parsed from reading the FSM state file.
+        """
+        prev_state = None
+        wait_until = dt.datetime.now() + dt.timedelta(seconds=timeout)
+        while wait_until > dt.datetime.now():
+            self.cluster.sleep(sleep_time)
+
+            (current_state, assigned_state) = self.get_local_state()
+
+            # only log the state if it has changed
+            if current_state != prev_state:
+                if current_state == target_state:
+                    print("state of %s is '%s', done waiting" %
+                          (self.datadir, current_state))
+                else:
+                    print("state of %s is '%s', waiting for '%s' ..." %
+                          (self.datadir, current_state, target_state))
+
+            if current_state == target_state:
+                return True
+
+            prev_state = current_state
+
+        print("%s didn't reach %s after %d seconds" %
+              (self.datadir, target_state, timeout))
+        error_msg = (f"{self.datadir} failed to reach {target_state} "
+                     f"after {timeout} seconds\n")
+        self.print_debug_logs()
+        raise Exception(error_msg)
 
     def get_nodename(self, nodeId=None):
         """
@@ -919,11 +982,12 @@ SELECT reportedstate
         """
         Returns the current list of events from the monitor.
         """
-        last_events_query = "select eventtime, nodename, " \
-            "reportedstate, goalstate, " \
-            "reportedrepstate, reportedlsn, description " \
-            "from pgautofailover.last_events('default', count => 20)"
-        return self.monitor.get_events()
+        if self.monitor:
+            last_events_query = "select eventtime, nodename, " \
+                "reportedstate, goalstate, " \
+                "reportedrepstate, reportedlsn, description " \
+                "from pgautofailover.last_events('default', count => 20)"
+            return self.monitor.get_events()
 
     def enable_maintenance(self, allowFailover=False):
         """
@@ -971,7 +1035,28 @@ SELECT reportedstate
         :return:
         """
         command = PGAutoCtl(self)
-        command.execute("do fsm assign", 'do', 'fsm', 'assign', target_state)
+        command.execute("do fsm assign",
+                        '-vv', 'do', 'fsm', 'assign', target_state)
+        return True
+
+    def do_fsm_nodes_set(self, nodesArray):
+        """
+        Runs `pg_autoctl do fsm nodes set` on a node
+
+        :return:
+        """
+        filename = "/tmp/nodes.json"
+
+        with open(filename, "w") as nodesFile:
+            nodesFile.write(json.dumps(nodesArray))
+
+        print("%s: %s" % (filename, open(filename, "r").read()))
+
+        command = PGAutoCtl(self)
+        out, err, ret = command.execute("do fsm nodes set",
+                                        'do', 'fsm', 'nodes', 'set', filename)
+        print("%s" % out)
+
         return True
 
     def do_fsm_step(self):

--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -723,6 +723,7 @@ class DataNode(PGNode):
         self.group = group
         self.listen_flag = listen_flag
         self.formation = formation
+        self.monitorDisabled = None
 
     def create(self, run=False, level='-v', name=None, host=None, port=None,
                candidatePriority=None, replicationQuorum=None,

--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -1015,13 +1015,9 @@ SELECT reportedstate
         with open(filename, "w") as nodesFile:
             nodesFile.write(json.dumps(nodesArray))
 
-        print("%s: %s" % (filename, open(filename, "r").read()))
-
         command = PGAutoCtl(self)
         out, err, ret = command.execute("do fsm nodes set",
                                         'do', 'fsm', 'nodes', 'set', filename)
-        print("%s" % out)
-
         return True
 
     def do_fsm_step(self):

--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -853,42 +853,6 @@ class DataNode(PGNode):
         return (self.state['state']['current_role'],
                 self.state['state']['assigned_role'])
 
-    def wait_until_local_state(self, target_state,
-                               timeout=STATE_CHANGE_TIMEOUT,
-                               sleep_time=POLLING_INTERVAL):
-        """
-        Waits until this data node reaches the target state, and then
-        returns True. The target state is compared to the local state as
-        parsed from reading the FSM state file.
-        """
-        prev_state = None
-        wait_until = dt.datetime.now() + dt.timedelta(seconds=timeout)
-        while wait_until > dt.datetime.now():
-            self.cluster.sleep(sleep_time)
-
-            (current_state, assigned_state) = self.get_local_state()
-
-            # only log the state if it has changed
-            if current_state != prev_state:
-                if current_state == target_state:
-                    print("state of %s is '%s', done waiting" %
-                          (self.datadir, current_state))
-                else:
-                    print("state of %s is '%s', waiting for '%s' ..." %
-                          (self.datadir, current_state, target_state))
-
-            if current_state == target_state:
-                return True
-
-            prev_state = current_state
-
-        print("%s didn't reach %s after %d seconds" %
-              (self.datadir, target_state, timeout))
-        error_msg = (f"{self.datadir} failed to reach {target_state} "
-                     f"after {timeout} seconds\n")
-        self.print_debug_logs()
-        raise Exception(error_msg)
-
     def get_nodename(self, nodeId=None):
         """
         Fetch the node name from the monitor, given its nodeid

--- a/tests/test_monitor_disabled.py
+++ b/tests/test_monitor_disabled.py
@@ -1,0 +1,67 @@
+import pgautofailover_utils as pgautofailover
+from nose.tools import *
+
+import os
+import json
+
+cluster = None
+node1 = None
+node2 = None
+
+def setup_module():
+    global cluster
+    cluster = pgautofailover.Cluster()
+
+def teardown_module():
+    cluster.destroy()
+
+def test_001_init_primary():
+    global node1
+    node1 = cluster.create_datanode("/tmp/no-monitor/node1")
+    node1.create(monitorDisabled=True, host=str(node1.vnode.address), nodeId=1)
+    node1.run(name="a")
+
+def test_002_init_to_single():
+    print()
+    node1.do_fsm_assign("single")
+    node1.wait_until_local_state("single")
+
+def test_003_create_t1():
+    node1.run_sql_query("CREATE TABLE t1(a int)")
+    node1.run_sql_query("INSERT INTO t1 VALUES (1), (2)")
+
+def test_004_init_secondary():
+    global node2
+    node2 = cluster.create_datanode("/tmp/no-monitor/node2")
+    node2.create(monitorDisabled=True, host=str(node2.vnode.address), nodeId=2)
+    node2.run(name="b")
+
+def test_005_fsm_nodes_set():
+    nodesArray = [node1.jsDict("0/1", True), node2.jsDict("0/1", False)]
+
+    print()
+    node1.do_fsm_nodes_set(nodesArray)
+    node2.do_fsm_nodes_set(nodesArray)
+
+def test_006_init_to_wait_standby():
+    print()
+    node2.do_fsm_assign("wait_standby")
+    node2.wait_until_local_state("wait_standby")
+
+def test_007_catchingup():
+    print()
+    node1.do_fsm_assign("wait_primary")
+    node1.wait_until_local_state("wait_primary")
+
+    node2.do_fsm_assign("catchingup")
+    node2.wait_until_local_state("catchingup")
+
+def test_008_secondary():
+    print()
+    node1.do_fsm_assign("primary")
+    node2.do_fsm_assign("secondary")
+
+    node1.wait_until_local_state("primary")
+    node2.wait_until_local_state("secondary")
+
+    eq_(node1.get_synchronous_standby_names_local(), '*')

--- a/tests/test_monitor_disabled.py
+++ b/tests/test_monitor_disabled.py
@@ -24,7 +24,6 @@ def test_001_init_primary():
 def test_002_init_to_single():
     print()
     node1.do_fsm_assign("single")
-    node1.wait_until_local_state("single")
 
 def test_003_create_t1():
     node1.run_sql_query("CREATE TABLE t1(a int)")
@@ -46,22 +45,16 @@ def test_005_fsm_nodes_set():
 def test_006_init_to_wait_standby():
     print()
     node2.do_fsm_assign("wait_standby")
-    node2.wait_until_local_state("wait_standby")
 
 def test_007_catchingup():
     print()
     node1.do_fsm_assign("wait_primary")
-    node1.wait_until_local_state("wait_primary")
 
     node2.do_fsm_assign("catchingup")
-    node2.wait_until_local_state("catchingup")
 
 def test_008_secondary():
     print()
     node1.do_fsm_assign("primary")
     node2.do_fsm_assign("secondary")
-
-    node1.wait_until_local_state("primary")
-    node2.wait_until_local_state("secondary")
 
     eq_(node1.get_synchronous_standby_names_local(), '*')

--- a/tests/test_multi_standbys.py
+++ b/tests/test_multi_standbys.py
@@ -225,22 +225,3 @@ def test_013_remove_old_primary():
 
     assert node1.wait_until_state(target_state="primary")
     assert node3.wait_until_state(target_state="secondary")
-
-def test_014_update_standby_names_when_adding_and_removing_a_standby():
-    global node5
-    global node6
-
-    node5 = cluster.create_datanode("/tmp/multi_standby/node5")
-    node6 = cluster.create_datanode("/tmp/multi_standby/node6")
-
-    node1.do_fsm_assign(target_state="join_primary")
-    node1.do_fsm_step()
-
-    print(monitor.get_other_nodes(node1.nodeid))
-
-    # assert node1.wait_until_state(target_state="join_primary")
-    node3.drop()
-
-    # assert node1.wait_until_state(target_state="primary")
-    eq_(node1.get_synchronous_standby_names(),
-        node1.get_synchronous_standby_names_local())


### PR DESCRIPTION
In the current version the pg_autoctl process is the parent process of the
Postgres main process. Except when using --disable-monitor, which makes no
sense, so here we fix that.

It is now possible to control and run a Postgres process under a pg_autoctl
process without using a monitor, as in the following example:

  $ pg_autoctl create postgres --auth trust --no-ssl --disable-monitor --run
  $ PG_AUTOCTL_DEBUG=1 pg_autoctl do fsm assign single

The `pg_autoctl do fsm assign` command now edits the keeper state file, and
the FSM transition that is necessary is then implemented in the keeper loop
as usual.