### PR TITLE
Fix bug in monitor hostname discovery

### DIFF
--- a/src/bin/pg_autoctl/cli_common.h
+++ b/src/bin/pg_autoctl/cli_common.h
@@ -165,7 +165,7 @@ bool monitor_init_from_pgsetup(Monitor *monitor, PostgresSetup *pgSetup);
 void exit_unless_role_is_keeper(KeeperConfig *kconfig);
 
 /* cli_create_drop_node.c */
-bool cli_create_config(Keeper *keeper, KeeperConfig *config);
+bool cli_create_config(Keeper *keeper);
 void cli_create_pg(Keeper *keeper);
 bool check_or_discover_hostname(KeeperConfig *config);
 void keeper_cli_destroy_node(int argc, char **argv);

--- a/src/bin/pg_autoctl/cli_create_drop_node.c
+++ b/src/bin/pg_autoctl/cli_create_drop_node.c
@@ -130,8 +130,10 @@ CommandLine drop_node_command =
  * configuration file.
  */
 bool
-cli_create_config(Keeper *keeper, KeeperConfig *config)
+cli_create_config(Keeper *keeper)
 {
+	KeeperConfig *config = &(keeper->config);
+
 	bool missingPgdataIsOk = true;
 	bool pgIsNotRunningIsOk = true;
 	bool monitorDisabledIsOk = true;
@@ -327,17 +329,17 @@ cli_create_postgres(int argc, char **argv)
 
 	keeper.config = keeperOptions;
 
-	if (read_pidfile(keeper.config.pathnames.pid, &pid))
+	if (read_pidfile(config->pathnames.pid, &pid))
 	{
 		log_fatal("pg_autoctl is already running with pid %d", pid);
 		exit(EXIT_CODE_BAD_STATE);
 	}
 
-	if (!file_exists(keeper.config.pathnames.config))
+	if (!file_exists(config->pathnames.config))
 	{
 		/* pg_autoctl create postgres: mark ourselves as a standalone node */
-		keeper.config.pgSetup.pgKind = NODE_KIND_STANDALONE;
-		strlcpy(keeper.config.nodeKind, "standalone", NAMEDATALEN);
+		config->pgSetup.pgKind = NODE_KIND_STANDALONE;
+		strlcpy(config->nodeKind, "standalone", NAMEDATALEN);
 
 		if (!check_or_discover_hostname(config))
 		{
@@ -346,7 +348,7 @@ cli_create_postgres(int argc, char **argv)
 		}
 	}
 
-	if (!cli_create_config(&keeper, config))
+	if (!cli_create_config(&keeper))
 	{
 		log_error("Failed to initialize our configuration, see above.");
 		exit(EXIT_CODE_BAD_CONFIG);

--- a/src/bin/pg_autoctl/cli_create_drop_node.c
+++ b/src/bin/pg_autoctl/cli_create_drop_node.c
@@ -724,16 +724,16 @@ cli_create_monitor_config(Monitor *monitor)
 		/* Take care of the --hostname */
 		if (IS_EMPTY_STRING_BUFFER(config->hostname))
 		{
-			char monitorHostname[_POSIX_HOST_NAME_MAX] = { 0 };
-
-			if (!ipaddrGetLocalHostname(monitorHostname,
-										sizeof(monitorHostname)))
+			if (!ipaddrGetLocalHostname(config->hostname,
+										sizeof(config->hostname)))
 			{
+				char monitorHostname[_POSIX_HOST_NAME_MAX] = { 0 };
+
 				strlcpy(monitorHostname,
 						DEFAULT_INTERFACE_LOOKUP_SERVICE_NAME,
 						_POSIX_HOST_NAME_MAX);
 
-				if (!discover_hostname((char *) (&config->hostname),
+				if (!discover_hostname((char *) &(config->hostname),
 									   _POSIX_HOST_NAME_MAX,
 									   DEFAULT_INTERFACE_LOOKUP_SERVICE_NAME,
 									   DEFAULT_INTERFACE_LOOKUP_SERVICE_PORT))


### PR DESCRIPTION
Use our new function `ipaddrGetLocalHostname` directly on `config->hostname` so that we can continue with the hostname properly set.