### PR TITLE
Fix race conditions in multiple-standby Group FSM for failover.

### DIFF
--- a/src/bin/pg_autoctl/fsm.c
+++ b/src/bin/pg_autoctl/fsm.c
@@ -261,6 +261,7 @@ KeeperFSMTransition KeeperFSM[] = {
 	{ PRIMARY_STATE, JOIN_PRIMARY_STATE, COMMENT_PRIMARY_TO_JOIN_PRIMARY, &fsm_prepare_replication },
 	{ PRIMARY_STATE, WAIT_PRIMARY_STATE, COMMENT_PRIMARY_TO_WAIT_PRIMARY, &fsm_disable_sync_rep },
 	{ JOIN_PRIMARY_STATE, WAIT_PRIMARY_STATE, COMMENT_PRIMARY_TO_WAIT_PRIMARY, &fsm_disable_sync_rep },
+	{ WAIT_PRIMARY_STATE, JOIN_PRIMARY_STATE, COMMENT_PRIMARY_TO_JOIN_PRIMARY, &fsm_prepare_replication },
 
 	/*
 	 * Situation is getting back to normal on the primary

--- a/src/monitor/group_state_machine.c
+++ b/src/monitor/group_state_machine.c
@@ -669,6 +669,11 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 	 * The primary could be in one of those states:
 	 *  - wait_primary/wait_primary
 	 *  - wait_primary/primary
+	 *
+	 * This transition also happens when a former primary node has been
+	 * demoted, and a multiple standbys has taken effect, we have a new primary
+	 * being promoted, and several standby nodes following the new primary.
+	 *
 	 */
 	if (IsCurrentState(activeNode, REPLICATION_STATE_JOIN_SECONDARY) &&
 		primaryNode->reportedState == REPLICATION_STATE_WAIT_PRIMARY &&

--- a/tests/test_multi_ifdown.py
+++ b/tests/test_multi_ifdown.py
@@ -135,10 +135,15 @@ def test_008_failover():
 
     assert node3.wait_until_state(target_state="wait_primary", timeout=120)
     assert node2.wait_until_state(target_state="secondary")
-    assert node3.wait_until_state(target_state="primary")
+
+    # node 2 has candidate priority of 0, can't be used to reach primary
+    #assert node3.wait_until_state(target_state="primary")
 
     assert node3.has_needed_replication_slots()
     assert node2.has_needed_replication_slots()
+
+    # as we don't have
+    eq_(node3.get_synchronous_standby_names_local(), '')
 
 def test_009_read_from_new_primary():
     results = node3.run_sql_query("SELECT count(*) FROM t1")

--- a/tests/test_multi_maintenance.py
+++ b/tests/test_multi_maintenance.py
@@ -185,6 +185,8 @@ def test_011_all_to_maintenance():
     print("Node 3:  '%s'" %
           node3.run_sql_query("show synchronous_standby_names")[0][0])
 
+    eq_(node3.get_synchronous_standby_names_local(), '')
+
 def test_012_can_write_during_maintenance():
     node3.run_sql_query("INSERT INTO t1 VALUES (5), (6)")
     node3.run_sql_query("CHECKPOINT")


### PR DESCRIPTION
When handling a group with multiple standby nodes but only one of them is a
candidate for failover, some adjustments are needed in order for the FSM to
coorectly move forward when the non-candidates are showing first.

In practice, we should:

  - refrain from assigning PRIMARY to a WAIT_PRIMARY node when a standby is
    reaching SECONDARY if that standby has a candidatePriority = 0,

  - start the re-join process of a demoted primary even when the new primary
    is still transitioning between wait_primary and primary, we don't need a
	stable state there,

  - and as a consequence of the first item, allow a transition from
    wait_primary to join_primary when adding a secondary to the new primary
    node, if the secondary being added has candidatePriority = 0.

See https://github.com/citusdata/pg_auto_failover/pull/439 which missed those cases.