### PR TITLE
Fix synchronous_standby_names when disabling maintenance.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,6 @@ matrix:
     - env: PGVERSION=11 TEST=multi
     - env: PGVERSION=12 TEST=multi
     - env: PGVERSION=13 TEST=multi
-    - env: PGVERSION=13 TEST=single
-    - env: PGVERSION=13 TEST=multi
     - env: LINTING=true
 before_install:
   - git clone -b v0.7.18 --depth 1 https://github.com/citusdata/tools.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,9 @@ matrix:
     - env: PGVERSION=11 TEST=multi
     - env: PGVERSION=12 TEST=multi
     - env: PGVERSION=13 TEST=multi
-    - env: LINTING=true
-  allow_failures:
     - env: PGVERSION=13 TEST=single
     - env: PGVERSION=13 TEST=multi
+    - env: LINTING=true
 before_install:
   - git clone -b v0.7.18 --depth 1 https://github.com/citusdata/tools.git
   - sudo make -C tools install

--- a/src/monitor/group_state_machine.c
+++ b/src/monitor/group_state_machine.c
@@ -847,8 +847,15 @@ ProceedGroupStateForPrimaryNode(AutoFailoverNode *primaryNode)
 		{
 			AutoFailoverNode *otherNode = (AutoFailoverNode *) lfirst(nodeCell);
 
-			/* even if the node is on its way to being a secondary... */
+			/*
+			 * We force secondary nodes to catching-up even if the node is on
+			 * its way to being a secondary... unless it is currently in the
+			 * join_secondary state, because reportLSN -> join_secondary
+			 * transition stops Postgres, waiting for the new primary to be
+			 * available.
+			 */
 			if (otherNode->goalState == REPLICATION_STATE_SECONDARY &&
+				otherNode->reportedState != REPLICATION_STATE_JOIN_SECONDARY &&
 				IsUnhealthy(otherNode))
 			{
 				char message[BUFSIZE];

--- a/src/monitor/group_state_machine.c
+++ b/src/monitor/group_state_machine.c
@@ -306,6 +306,13 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 	 * when secondary caught up:
 	 *      catchingup -> secondary
 	 *  + wait_primary -> primary
+	 *
+	 * When we have multiple standby nodes and one of them is joining, or
+	 * re-joining after maintenance, we have to edit the replication setting
+	 * synchronous_standby_names on the primary. The transition from another
+	 * state to PRIMARY includes that edit. If the primary already is in the
+	 * primary state, we assign APPLY_SETTINGS to it to make sure its
+	 * repication settings are updated now.
 	 */
 	if (IsCurrentState(activeNode, REPLICATION_STATE_CATCHINGUP) &&
 		(IsCurrentState(primaryNode, REPLICATION_STATE_WAIT_PRIMARY) ||

--- a/src/monitor/node_metadata.c
+++ b/src/monitor/node_metadata.c
@@ -213,7 +213,8 @@ AutoFailoverNodeGroup(char *formationId, int groupId)
 
 	const char *selectQuery =
 		SELECT_ALL_FROM_AUTO_FAILOVER_NODE_TABLE
-		" WHERE formationid = $1 AND groupid = $2";
+		" WHERE formationid = $1 AND groupid = $2"
+		" ORDER BY nodeid";
 
 	SPI_connect();
 

--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -1115,8 +1115,12 @@ SELECT reportedstate
             + "where slot_name ~ '^pgautofailover_standby_' " \
             + " and slot_type = 'physical'"
 
-        result = self.run_sql_query(query)
-        return [row[0] for row in result]
+        try:
+            result = self.run_sql_query(query)
+            return [row[0] for row in result]
+        except Exception as e:
+            self.print_debug_logs()
+            raise e
 
     def has_needed_replication_slots(self):
         """

--- a/tests/test_basic_operation.py
+++ b/tests/test_basic_operation.py
@@ -233,7 +233,7 @@ def test_021_ifdown_primary():
 
 def test_022_detect_network_partition():
     # wait for network partition detection to kick-in, allow some head-room
-    timeout = 60
+    timeout = 90
     demoted = False
 
     while not demoted and timeout > 0:
@@ -248,6 +248,7 @@ def test_022_detect_network_partition():
 
     if node2.pg_is_running() or timeout <= 0:
         node2.print_debug_logs()
+        raise Exception("test failed: node2 didn't stop running in 90s")
 
     print()
     assert not node2.pg_is_running()

--- a/tests/test_multi_ifdown.py
+++ b/tests/test_multi_ifdown.py
@@ -240,7 +240,7 @@ def test_015_finalize_failover_after_most_advanced_secondary_gets_back():
 
     # and, node2 should finally become the primary without losing any data
     print()
-    assert node2.wait_until_state(target_state="wait_primary")
+    assert node2.wait_until_state(target_state="primary")
 
     print("%s" % monitor.pg_autoctl.err)
 


### PR DESCRIPTION
When a node gets out of maintenance and back in the group, we might have to
change the syncrhonous_standby_names on the primary to include the node
again. For that, if the primary node is in a stable PRIMARY state, thanks to
other standby nodes being available, we need to assign APPLY_SETTINGS to the
current primary.