### PR TITLE
Fix/debian stats temp directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,3 +44,4 @@ COPY ./tests/ ./tests
 
 USER docker
 ENV PATH $PATH:/usr/lib/postgresql/12/bin
+ENV PGVERSION 12

--- a/src/bin/pg_autoctl/debian.c
+++ b/src/bin/pg_autoctl/debian.c
@@ -605,7 +605,13 @@ comment_out_configuration_parameters(const char *srcConfPath,
 	 * need to check for patterns for NAME = VALUE and NAME=VALUE
 	 */
 	char *targetVariableExpression =
-		"(data_directory|hba_file|ident_file|include_dir)( *)=";
+		"("
+		"data_directory"
+		"|hba_file"
+		"|ident_file"
+		"|include_dir"
+		"|stats_temp_directory"
+		")( *)=";
 
 	/* open a file */
 	fileStream = fopen_read_only(srcConfPath);


### PR DESCRIPTION
Add stats_temp_directory to the list of GUCs to comment on debian.

When creating a Postgres cluster in debian, the stats_temp_directory is
rewrittent to a debian specific place, created by the debian init scripts at
boot time. As we unregister the debian Postgres clusters to the debian init
scripts, we can't rely on their setting and tricks for stats_temp_directory.

Fixes #484