### PR TITLE
Use PG_CONFIG has a hint to choose one of multiple Postgres versions.

### DIFF
--- a/src/bin/pg_autoctl/cli_common.c
+++ b/src/bin/pg_autoctl/cli_common.c
@@ -942,23 +942,24 @@ prepare_keeper_options(KeeperConfig *options)
 void
 set_first_pgctl(PostgresSetup *pgSetup)
 {
-	char *version = NULL;
+	/* first, use PG_CONFIG when it exists in the environment */
+	if (set_pg_ctl_from_PG_CONFIG(pgSetup))
+	{
+		return;
+	}
+
+	/* then, use PATH and fetch the first entry there for the monitor */
 	if (!search_path_first("pg_ctl", pgSetup->pg_ctl))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_BAD_ARGS);
 	}
-	version = pg_ctl_version(pgSetup->pg_ctl);
 
-	if (version == NULL)
+	if (!pg_ctl_version(pgSetup))
 	{
 		/* errors have been logged in pg_ctl_version */
 		exit(EXIT_CODE_PGCTL);
 	}
-
-	strlcpy(pgSetup->pg_version, version, PG_VERSION_STRING_MAX);
-
-	free(version);
 }
 
 

--- a/src/bin/pg_autoctl/pgctl.c
+++ b/src/bin/pg_autoctl/pgctl.c
@@ -82,29 +82,35 @@ static bool pg_write_standby_signal(const char *pgdata,
 
 
 /*
- * Get pg_ctl --version output.
- *
- * The caller should free the return value if not NULL.
+ * Get pg_ctl --version output in pgSetup->pg_version.
  */
-char *
-pg_ctl_version(const char *pg_ctl_path)
+bool
+pg_ctl_version(PostgresSetup *pgSetup)
 {
 	char *version;
-	Program prog = run_program(pg_ctl_path, "--version", NULL);
+	Program prog = run_program(pgSetup->pg_ctl, "--version", NULL);
 
 	if (prog.returnCode != 0)
 	{
 		errno = prog.error;
 		log_error("Failed to run \"pg_ctl --version\" using program \"%s\": %m",
-				  pg_ctl_path);
+				  pgSetup->pg_ctl);
 		free_program(&prog);
-		return NULL;
+		return false;
 	}
 
 	version = parse_version_number(prog.stdOut);
 	free_program(&prog);
 
-	return version;
+	if (version == NULL)
+	{
+		return false;
+	}
+
+	strlcpy(pgSetup->pg_version, version, PG_VERSION_STRING_MAX);
+	free(version);
+
+	return true;
 }
 
 
@@ -186,6 +192,47 @@ pg_controldata(PostgresSetup *pgSetup, bool missing_ok)
 
 
 /*
+ * set_pg_ctl_from_PG_CONFIG sets the path to pg_ctl following the exported
+ * environment variable PG_CONFIG, when it is found in the environment.
+ *
+ * Postgres developer environments often define PG_CONFIG in the environment to
+ * build extensions for a specific version of Postgres. Let's use the hint here
+ * too.
+ */
+bool
+set_pg_ctl_from_PG_CONFIG(PostgresSetup *pgSetup)
+{
+	char PG_CONFIG[MAXPGPATH] = { 0 };
+
+	if (!env_exists("PG_CONFIG"))
+	{
+		/* then we don't use PG_CONFIG to find pg_ctl */
+		return false;
+	}
+
+	if (!get_env_copy("PG_CONFIG", PG_CONFIG, sizeof(PG_CONFIG)))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	(void) path_in_same_directory(PG_CONFIG, "pg_ctl", pgSetup->pg_ctl);
+
+	if (!pg_ctl_version(pgSetup))
+	{
+		log_fatal("Failed to get version info from %s --version",
+				  pgSetup->pg_ctl);
+		return false;
+	}
+
+	log_debug("Found pg_ctl for PostgreSQL %s at %s following PG_CONFIG",
+			  pgSetup->pg_version, pgSetup->pg_ctl);
+
+	return true;
+}
+
+
+/*
  * Find "pg_ctl" programs in the PATH. If a single one exists, set its absolute
  * location in pg_ctl, and the PostgreSQL version number in pg_version.
  *
@@ -195,27 +242,40 @@ int
 config_find_pg_ctl(PostgresSetup *pgSetup)
 {
 	char **pg_ctls = NULL;
-	int n = search_path("pg_ctl", &pg_ctls);
+	int n = -1;
 
 	pgSetup->pg_ctl[0] = '\0';
 	pgSetup->pg_version[0] = '\0';
 
+	/*
+	 * Postgres developer environments often define PG_CONFIG in the
+	 * environment to build extensions for a specific version of Postgres.
+	 * Let's use the hint here too.
+	 */
+	if (set_pg_ctl_from_PG_CONFIG(pgSetup))
+	{
+		return 1;
+	}
+
+	/* no PG_CONFIG. let's use the more classic approach with PATH instead */
+	n = search_path("pg_ctl", &pg_ctls);
+
 	if (n == 1)
 	{
 		char *program = pg_ctls[0];
-		char *version = pg_ctl_version(program);
-		if (version == NULL)
+
+		strlcpy(pgSetup->pg_ctl, program, MAXPGPATH);
+
+		if (!pg_ctl_version(pgSetup))
 		{
-			log_fatal("Failed to get version info from %s --version", program);
+			log_fatal("Failed to get version info from %s --version",
+					  pgSetup->pg_ctl);
 			return 0;
 		}
 
-		log_debug("Found pg_ctl for PostgreSQL %s at %s", version, program);
-
-		strlcpy(pgSetup->pg_ctl, program, MAXPGPATH);
-		strlcpy(pgSetup->pg_version, version, PG_VERSION_STRING_MAX);
-
-		free(version);
+		log_debug("Found pg_ctl for PostgreSQL %s at %s",
+				  pgSetup->pg_version,
+				  pgSetup->pg_ctl);
 	}
 	else if (n == 0)
 	{
@@ -225,9 +285,11 @@ config_find_pg_ctl(PostgresSetup *pgSetup)
 	{
 		for (int i = 0; i < n; i++)
 		{
-			char *program = pg_ctls[i];
-			char *version = pg_ctl_version(program);
-			if (version == NULL)
+			PostgresSetup currentPgSetup = { 0 };
+
+			strlcpy(currentPgSetup.pg_ctl, pg_ctls[i], MAXPGPATH);
+
+			if (!pg_ctl_version(&currentPgSetup))
 			{
 				/*
 				 * Because of this it's possible that there's now only a single
@@ -239,12 +301,14 @@ config_find_pg_ctl(PostgresSetup *pgSetup)
 				 * intention clear by using the --pg_ctl option (or changing
 				 * PATH).
 				 */
-				log_warn("Failed to get version info from %s --version", program);
+				log_warn("Failed to get version info from %s --version",
+						 currentPgSetup.pg_ctl);
 				continue;
 			}
 
-			log_info("Found %s for pg version %s", program, version);
-			free(version);
+			log_info("Found %s for pg version %s",
+					 currentPgSetup.pg_ctl,
+					 currentPgSetup.pg_version);
 		}
 	}
 

--- a/src/bin/pg_autoctl/pgctl.c
+++ b/src/bin/pg_autoctl/pgctl.c
@@ -148,6 +148,9 @@ set_pg_ctl_from_config_bindir(PostgresSetup *pgSetup, const char *pg_config)
 	bindir = lines[0];
 	join_path_components(pg_ctl, bindir, "pg_ctl");
 
+	/* we're now done with the Program and its output */
+	free_program(&prog);
+
 	if (!file_exists(pg_ctl))
 	{
 		log_error("Failed to find pg_ctl at \"%s\" from PG_CONFIG at \"%s\"",

--- a/src/bin/pg_autoctl/pgctl.c
+++ b/src/bin/pg_autoctl/pgctl.c
@@ -115,6 +115,54 @@ pg_ctl_version(PostgresSetup *pgSetup)
 
 
 /*
+ * set_pg_ctl_from_PG_CONFIG sets given pgSetup->pg_ctl to the pg_ctl binary
+ * installed in the bindir of the target Postgres installation:
+ *
+ *  $(${PG_CONFIG} --bindir)/pg_ctl
+ */
+bool
+set_pg_ctl_from_config_bindir(PostgresSetup *pgSetup, const char *pg_config)
+{
+	char pg_ctl[MAXPGPATH] = { 0 };
+	Program prog = run_program(pg_config, "--bindir", NULL);
+
+	char *bindir;
+	char *lines[1];
+
+	if (prog.returnCode != 0)
+	{
+		errno = prog.error;
+		log_error("Failed to run \"pg_config --bindir\" using program \"%s\": %m",
+				  pg_config);
+		free_program(&prog);
+		return false;
+	}
+
+	if (splitLines(prog.stdOut, lines, 1) != 1)
+	{
+		log_error("Unable to parse output from pg_config --bindir");
+		free_program(&prog);
+		return false;
+	}
+
+	bindir = lines[0];
+	join_path_components(pg_ctl, bindir, "pg_ctl");
+
+	if (!file_exists(pg_ctl))
+	{
+		log_error("Failed to find pg_ctl at \"%s\" from PG_CONFIG at \"%s\"",
+				  pgSetup->pg_ctl,
+				  pg_config);
+		return false;
+	}
+
+	strlcpy(pgSetup->pg_ctl, pg_ctl, sizeof(pgSetup->pg_ctl));
+
+	return true;
+}
+
+
+/*
  * Read some of the information from pg_controldata output.
  */
 bool
@@ -216,7 +264,11 @@ set_pg_ctl_from_PG_CONFIG(PostgresSetup *pgSetup)
 		return false;
 	}
 
-	(void) path_in_same_directory(PG_CONFIG, "pg_ctl", pgSetup->pg_ctl);
+	if (!set_pg_ctl_from_config_bindir(pgSetup, PG_CONFIG))
+	{
+		/* errors have already been logged */
+		return false;
+	}
 
 	if (!pg_ctl_version(pgSetup))
 	{

--- a/src/bin/pg_autoctl/pgctl.h
+++ b/src/bin/pg_autoctl/pgctl.h
@@ -29,9 +29,10 @@
 #define PG_CTL_STATUS_NOT_RUNNING 3
 
 bool pg_controldata(PostgresSetup *pgSetup, bool missing_ok);
+bool set_pg_ctl_from_PG_CONFIG(PostgresSetup *pgSetup);
 int config_find_pg_ctl(PostgresSetup *pgSetup);
 bool find_extension_control_file(const char *pg_ctl, const char *extName);
-char * pg_ctl_version(const char *pg_ctl_path);
+bool pg_ctl_version(PostgresSetup *pgSetup);
 
 bool pg_add_auto_failover_default_settings(PostgresSetup *pgSetup,
 										   char *configFilePath,

--- a/src/bin/pg_autoctl/pgctl.h
+++ b/src/bin/pg_autoctl/pgctl.h
@@ -33,6 +33,7 @@ bool set_pg_ctl_from_PG_CONFIG(PostgresSetup *pgSetup);
 int config_find_pg_ctl(PostgresSetup *pgSetup);
 bool find_extension_control_file(const char *pg_ctl, const char *extName);
 bool pg_ctl_version(PostgresSetup *pgSetup);
+bool set_pg_ctl_from_config_bindir(PostgresSetup *pgSetup, const char *pg_config);
 
 bool pg_add_auto_failover_default_settings(PostgresSetup *pgSetup,
 										   char *configFilePath,

--- a/src/bin/pg_autoctl/pgsetup.c
+++ b/src/bin/pg_autoctl/pgsetup.c
@@ -89,18 +89,16 @@ pg_setup_init(PostgresSetup *pgSetup,
 			/* we might not have fetched the version yet */
 			if (IS_EMPTY_STRING_BUFFER(pgSetup->pg_version))
 			{
-				char *version = pg_ctl_version(options->pg_ctl);
-
-				if (version == NULL)
+				/* also cache the version in options */
+				if (!pg_ctl_version(options))
 				{
 					/* we already logged about it */
 					return false;
 				}
 
-				/* also cache the version in options */
-				strlcpy(options->pg_version, version, PG_VERSION_STRING_MAX);
-				strlcpy(pgSetup->pg_version, version, PG_VERSION_STRING_MAX);
-				free(version);
+				strlcpy(pgSetup->pg_version,
+						options->pg_version,
+						sizeof(pgSetup->pg_version));
 
 				log_debug("pg_setup_init: %s version %s",
 						  pgSetup->pg_ctl, pgSetup->pg_version);

--- a/src/monitor/group_state_machine.c
+++ b/src/monitor/group_state_machine.c
@@ -1375,7 +1375,7 @@ SelectFailoverCandidateNode(CandidateList *candidateList,
 			(uint32) (primaryNode->reportedLSN >> 32),
 			(uint32) primaryNode->reportedLSN);
 
-		return false;
+		return NULL;
 	}
 
 	/*


### PR DESCRIPTION
When more than one Postgres version is found in $PATH a classic way to
target a specific one, for Postgres contributors and extension authors,
consists of using PG_CONFIG.

With this PR we make it so that pg_autoctl also follows PG_CONFIG and use
the pg_ctl PATH in the same directory as the pg_config setup that way in the
environment.

In passing, cleanup the pg_ctl_version() API to stop leaking memory out of
its local stack/heap.