### PR TITLE
Use pg_config from the PATH when we can't find a pg_ctl.

### DIFF
--- a/src/bin/pg_autoctl/cli_common.c
+++ b/src/bin/pg_autoctl/cli_common.c
@@ -949,7 +949,7 @@ set_first_pgctl(PostgresSetup *pgSetup)
 	}
 
 	/* then, use PATH and fetch the first entry there for the monitor */
-	if (search_path_first("pg_ctl", pgSetup->pg_ctl))
+	if (search_path_first("pg_ctl", pgSetup->pg_ctl, LOG_WARN))
 	{
 		if (!pg_ctl_version(pgSetup))
 		{

--- a/src/bin/pg_autoctl/cli_common.c
+++ b/src/bin/pg_autoctl/cli_common.c
@@ -949,17 +949,25 @@ set_first_pgctl(PostgresSetup *pgSetup)
 	}
 
 	/* then, use PATH and fetch the first entry there for the monitor */
-	if (!search_path_first("pg_ctl", pgSetup->pg_ctl))
+	if (search_path_first("pg_ctl", pgSetup->pg_ctl))
 	{
-		/* errors have already been logged */
-		exit(EXIT_CODE_BAD_ARGS);
+		if (!pg_ctl_version(pgSetup))
+		{
+			/* errors have been logged in pg_ctl_version */
+			exit(EXIT_CODE_PGCTL);
+		}
+
+		return;
 	}
 
-	if (!pg_ctl_version(pgSetup))
+	/* then, use PATH and fetch pg_config --bindir from there */
+	if (set_pg_ctl_from_pg_config(pgSetup))
 	{
-		/* errors have been logged in pg_ctl_version */
-		exit(EXIT_CODE_PGCTL);
+		return;
 	}
+
+	/* at this point we don't have any other ways to find a pg_ctl */
+	exit(EXIT_CODE_PGCTL);
 }
 
 

--- a/src/bin/pg_autoctl/cli_do_root.c
+++ b/src/bin/pg_autoctl/cli_do_root.c
@@ -176,6 +176,14 @@ CommandLine do_standby_ =
 					 "Manage a PostgreSQL standby server", NULL, NULL,
 					 NULL, do_standby);
 
+CommandLine do_pgsetup_pg_ctl =
+	make_command("pg_ctl",
+				 "Find a non-ambiguous pg_ctl program and Postgres version",
+				 "[option ...]",
+				 KEEPER_CLI_WORKER_SETUP_OPTIONS,
+				 keeper_cli_keeper_setup_getopts,
+				 keeper_cli_pgsetup_pg_ctl);
+
 CommandLine do_pgsetup_discover =
 	make_command("discover",
 				 "Discover local PostgreSQL instance, if any",
@@ -217,6 +225,7 @@ CommandLine do_pgsetup_tune =
 				 keeper_cli_pgsetup_tune);
 
 CommandLine *do_pgsetup[] = {
+	&do_pgsetup_pg_ctl,
 	&do_pgsetup_discover,
 	&do_pgsetup_is_ready,
 	&do_pgsetup_wait_until_ready,

--- a/src/bin/pg_autoctl/cli_do_root.h
+++ b/src/bin/pg_autoctl/cli_do_root.h
@@ -72,6 +72,7 @@ void keeper_cli_drop_replication_slot(int argc, char **argv);
 void keeper_cli_enable_synchronous_replication(int argc, char **argv);
 void keeper_cli_disable_synchronous_replication(int argc, char **argv);
 
+void keeper_cli_pgsetup_pg_ctl(int argc, char **argv);
 void keeper_cli_pgsetup_discover(int argc, char **argv);
 void keeper_cli_pgsetup_is_ready(int argc, char **argv);
 void keeper_cli_pgsetup_wait_until_ready(int argc, char **argv);

--- a/src/bin/pg_autoctl/cli_do_tmux.c
+++ b/src/bin/pg_autoctl/cli_do_tmux.c
@@ -580,7 +580,7 @@ tmux_start_server(const char *root, const char *scriptName)
 		return false;
 	}
 
-	if (!search_path_first("tmux", tmux))
+	if (!search_path_first("tmux", tmux, LOG_ERROR))
 	{
 		log_fatal("Failed to find program tmux in PATH");
 		return false;
@@ -775,7 +775,7 @@ tmux_kill_session(TmuxOptions *options)
 
 	sformat(sessionName, BUFSIZE, "pgautofailover-%d", options->firstPort);
 
-	if (!search_path_first("tmux", tmux))
+	if (!search_path_first("tmux", tmux, LOG_ERROR))
 	{
 		log_fatal("Failed to find program tmux in PATH");
 		return false;

--- a/src/bin/pg_autoctl/file_utils.c
+++ b/src/bin/pg_autoctl/file_utils.c
@@ -540,7 +540,7 @@ search_path_first(const char *filename, char *result)
 {
 	SearchPath paths = { 0 };
 
-	if (!search_path(filename, &paths))
+	if (!search_path(filename, &paths) || paths.found == 0)
 	{
 		log_error("Failed to find %s command in your PATH", filename);
 		return false;

--- a/src/bin/pg_autoctl/file_utils.c
+++ b/src/bin/pg_autoctl/file_utils.c
@@ -536,13 +536,13 @@ path_in_same_directory(const char *basePath, const char *fileName,
  * in PATH.
  */
 bool
-search_path_first(const char *filename, char *result)
+search_path_first(const char *filename, char *result, int logLevel)
 {
 	SearchPath paths = { 0 };
 
 	if (!search_path(filename, &paths) || paths.found == 0)
 	{
-		log_error("Failed to find %s command in your PATH", filename);
+		log_level(logLevel, "Failed to find %s command in your PATH", filename);
 		return false;
 	}
 
@@ -553,14 +553,10 @@ search_path_first(const char *filename, char *result)
 
 
 /*
- * Searches all the directories in the PATH environment variable for
- * the given filename. Returns number of occurrences, and allocates
- * and returns the path for each of the occurrences in the given result
- * pointer.
- *
- * If the result size is 0, then *result is set to NULL.
- *
- * The caller should free the result by calling search_path_destroy_result().
+ * Searches all the directories in the PATH environment variable for the given
+ * filename. Returns number of occurrences and each match found with its
+ * fullname, including the given filename, in the given pre-allocated
+ * SearchPath result.
  */
 bool
 search_path(const char *filename, SearchPath *result)
@@ -569,7 +565,6 @@ search_path(const char *filename, SearchPath *result)
 	char pathlist[MAXPATHSIZE] = { 0 };
 
 	/* we didn't count nor find anything yet */
-	result->total = 0;
 	result->found = 0;
 
 	/* Create a copy of pathlist, because we modify it here. */
@@ -591,8 +586,6 @@ search_path(const char *filename, SearchPath *result)
 		{
 			*sep = '\0';
 		}
-
-		strlcpy(result->entries[result->total++], path, MAXPGPATH);
 
 		(void) join_path_components(candidate, path, filename);
 		(void) canonicalize_path(candidate);

--- a/src/bin/pg_autoctl/file_utils.c
+++ b/src/bin/pg_autoctl/file_utils.c
@@ -700,7 +700,7 @@ set_program_absolute_path(char *program, int size)
 			return true;
 		}
 
-		if (!search_path(pg_autoctl_argv0, &paths))
+		if (!search_path(pg_autoctl_argv0, &paths) || paths.found == 0)
 		{
 			log_error("Failed to find \"%s\" in PATH environment",
 					  pg_autoctl_argv0);

--- a/src/bin/pg_autoctl/file_utils.h
+++ b/src/bin/pg_autoctl/file_utils.h
@@ -32,9 +32,7 @@
  */
 typedef struct SearchPath
 {
-	int total;
 	int found;
-	char entries[1024][MAXPGPATH];
 	char matches[1024][MAXPGPATH];
 } SearchPath;
 
@@ -56,7 +54,7 @@ void path_in_same_directory(const char *basePath,
 							const char *fileName,
 							char *destinationPath);
 
-bool search_path_first(const char *filename, char *result);
+bool search_path_first(const char *filename, char *result, int logLevel);
 bool search_path(const char *filename, SearchPath *result);
 bool unlink_file(const char *filename);
 bool set_program_absolute_path(char *program, int size);

--- a/src/bin/pg_autoctl/file_utils.h
+++ b/src/bin/pg_autoctl/file_utils.h
@@ -24,6 +24,21 @@
 #endif
 
 
+/*
+ * In order to avoid dynamic memory allocations and tracking when searching the
+ * PATH environment, we pre-allocate 1024 paths entries. That should be way
+ * more than enough for all situations, and only costs 1024*1024 = 1MB of
+ * memory.
+ */
+typedef struct SearchPath
+{
+	int total;
+	int found;
+	char entries[1024][MAXPGPATH];
+	char matches[1024][MAXPGPATH];
+} SearchPath;
+
+
 bool file_exists(const char *filename);
 bool directory_exists(const char *path);
 bool ensure_empty_dir(const char *dirname, int mode);
@@ -42,8 +57,7 @@ void path_in_same_directory(const char *basePath,
 							char *destinationPath);
 
 bool search_path_first(const char *filename, char *result);
-int search_path(const char *filename, char ***result);
-void search_path_destroy_result(char **result);
+bool search_path(const char *filename, SearchPath *result);
 bool unlink_file(const char *filename);
 bool set_program_absolute_path(char *program, int size);
 bool normalize_filename(const char *filename, char *dst, int size);

--- a/src/bin/pg_autoctl/pgctl.c
+++ b/src/bin/pg_autoctl/pgctl.c
@@ -267,6 +267,13 @@ set_pg_ctl_from_PG_CONFIG(PostgresSetup *pgSetup)
 		return false;
 	}
 
+	if (!file_exists(PG_CONFIG))
+	{
+		log_error("Failed to find a file for PG_CONFIG environment value \"%s\"",
+				  PG_CONFIG);
+		return false;
+	}
+
 	if (!set_pg_ctl_from_config_bindir(pgSetup, PG_CONFIG))
 	{
 		/* errors have already been logged */
@@ -302,71 +309,86 @@ set_pg_ctl_from_PG_CONFIG(PostgresSetup *pgSetup)
 bool
 set_pg_ctl_from_pg_config(PostgresSetup *pgSetup)
 {
-	char **pg_configs = NULL;
-	int pg_configs_count = search_path("pg_config", &pg_configs);
+	SearchPath pg_configs = { 0 };
 
-	bool success = false;
-
-	if (pg_configs_count == 0)
+	if (!search_path("pg_config", &pg_configs))
 	{
-		if (!set_pg_ctl_from_config_bindir(pgSetup, pg_configs[0]))
+		return false;
+	}
+
+	switch (pg_configs.found)
+	{
+		case 0:
 		{
-			/* errors have already been logged */
+			log_warn("Failed to find either pg_ctl or pg_config in PATH");
 			return false;
 		}
 
-		if (!pg_ctl_version(pgSetup))
+		case 1:
 		{
-			log_fatal("Failed to get version info from %s --version",
-					  pgSetup->pg_ctl);
-			return false;
-		}
-
-		log_debug("Found pg_ctl for PostgreSQL %s at %s from pg_config "
-				  "found in PATH at \"%s\"",
-				  pgSetup->pg_version, pgSetup->pg_ctl, pg_configs[0]);
-
-		success = true;
-	}
-	else if (pg_configs_count == 0)
-	{
-		log_warn("Failed to find either pg_ctl pg_config in PATH");
-	}
-	else
-	{
-		for (int i = 0; i < pg_configs_count; i++)
-		{
-			PostgresSetup currentPgSetup = { 0 };
-
-			strlcpy(currentPgSetup.pg_ctl, pg_configs[i], MAXPGPATH);
-
-			if (!pg_ctl_version(&currentPgSetup))
+			if (!set_pg_ctl_from_config_bindir(pgSetup, pg_configs.matches[0]))
 			{
-				/*
-				 * Because of this it's possible that there's now only a single
-				 * working version of pg_ctl found in PATH. If that's the case
-				 * we will still not use that by default, since the users
-				 * intention is unclear. They might have wanted to use the
-				 * version of pg_ctl that we could not parse the version string
-				 * for. So we warn and continue, the user should make their
-				 * intention clear by using the --pg_ctl option (or changing
-				 * PATH).
-				 */
-				log_warn("Failed to get version info from %s --version",
-						 currentPgSetup.pg_ctl);
-				continue;
+				/* errors have already been logged */
+				return false;
 			}
 
-			log_info("Found %s for pg version %s",
-					 currentPgSetup.pg_ctl,
-					 currentPgSetup.pg_version);
+			if (!pg_ctl_version(pgSetup))
+			{
+				log_fatal("Failed to get version info from %s --version",
+						  pgSetup->pg_ctl);
+				return false;
+			}
+
+			log_debug("Found pg_ctl for PostgreSQL %s at %s from pg_config "
+					  "found in PATH at \"%s\"",
+					  pgSetup->pg_version,
+					  pgSetup->pg_ctl,
+					  pg_configs.matches[0]);
+
+			return true;
 		}
-		log_info("HINT: export PG_CONFIG to a specific pg_config entry");
+
+		default:
+		{
+			log_info("Found more than one pg_config entry in current PATH:");
+
+			for (int i = 0; i < pg_configs.found; i++)
+			{
+				PostgresSetup currentPgSetup = { 0 };
+
+				strlcpy(currentPgSetup.pg_ctl,
+						pg_configs.matches[i],
+						sizeof(currentPgSetup.pg_ctl));
+
+				if (!pg_ctl_version(&currentPgSetup))
+				{
+					/*
+					 * Because of this it's possible that there's now only a
+					 * single working version of pg_ctl found in PATH. If
+					 * that's the case we will still not use that by default,
+					 * since the users intention is unclear. They might have
+					 * wanted to use the version of pg_ctl that we could not
+					 * parse the version string for. So we warn and continue,
+					 * the user should make their intention clear by using the
+					 * --pg_ctl option (or changing PATH).
+					 */
+					log_warn("Failed to get version info from %s --version",
+							 currentPgSetup.pg_ctl);
+					continue;
+				}
+
+				log_info("Found \"%s\" for pg version %s",
+						 currentPgSetup.pg_ctl,
+						 currentPgSetup.pg_version);
+			}
+
+			log_info("HINT: export PG_CONFIG to a specific pg_config entry");
+
+			return false;
+		}
 	}
 
-	search_path_destroy_result(pg_configs);
-
-	return success;
+	return false;
 }
 
 
@@ -379,10 +401,7 @@ set_pg_ctl_from_pg_config(PostgresSetup *pgSetup)
 bool
 config_find_pg_ctl(PostgresSetup *pgSetup)
 {
-	char **pg_ctls = NULL;
-	int n = -1;
-
-	bool success = false;
+	SearchPath pg_ctls = { 0 };
 
 	pgSetup->pg_ctl[0] = '\0';
 	pgSetup->pg_version[0] = '\0';
@@ -398,71 +417,95 @@ config_find_pg_ctl(PostgresSetup *pgSetup)
 	}
 
 	/* no PG_CONFIG. let's use the more classic approach with PATH instead */
-	n = search_path("pg_ctl", &pg_ctls);
-
-	if (n == 1)
+	if (!search_path("pg_ctl", &pg_ctls))
 	{
-		char *program = pg_ctls[0];
+		return false;
+	}
+
+	if (pg_ctls.found == 1)
+	{
+		char *program = pg_ctls.matches[0];
 
 		strlcpy(pgSetup->pg_ctl, program, MAXPGPATH);
 
 		if (!pg_ctl_version(pgSetup))
 		{
-			log_fatal("Failed to get version info from %s --version",
+			log_fatal("Failed to get version info from \"%s\" --version",
 					  pgSetup->pg_ctl);
 			return 0;
 		}
 
-		log_debug("Found pg_ctl for PostgreSQL %s at %s",
+		log_debug("Found pg_ctl for PostgreSQL %s at \"%s\"",
 				  pgSetup->pg_version,
 				  pgSetup->pg_ctl);
 
-		success = true;
-	}
-	else if (n == 0)
-	{
-		log_debug("Failed to find pg_ctl in PATH, now looking for pg_config");
-
-		if (set_pg_ctl_from_pg_config(pgSetup))
-		{
-			success = true;
-		}
+		return true;
 	}
 	else
 	{
-		for (int i = 0; i < n; i++)
+		/*
+		 * Then, first look for pg_config --bindir with pg_config in PATH,
+		 * we might have a single entry there, as is the case on a typical
+		 * debian/ubuntu packaging, in /usr/bin/pg_config installed from
+		 * the postgresql-common package.
+		 */
+		PostgresSetup pgSetupFromPgConfig = { 0 };
+
+		log_debug("Failed to find pg_ctl in PATH, looking for pg_config");
+
+		if (set_pg_ctl_from_pg_config(&pgSetupFromPgConfig))
+		{
+			strlcpy(pgSetup->pg_ctl,
+					pgSetupFromPgConfig.pg_ctl,
+					sizeof(pgSetup->pg_ctl));
+
+			strlcpy(pgSetup->pg_version,
+					pgSetupFromPgConfig.pg_version,
+					sizeof(pgSetup->pg_version));
+			return true;
+		}
+
+		/*
+		 * We failed to find a single pg_config in $PATH, error out and
+		 * complain about the situation with enough details that the user
+		 * can understand our struggle in picking a Postgres major version
+		 * for them.
+		 */
+		log_info("Found more than one pg_ctl entry in current PATH, "
+				 "and failed to find a single pg_config entry in current PATH");
+
+		for (int i = 0; i < pg_ctls.found; i++)
 		{
 			PostgresSetup currentPgSetup = { 0 };
 
-			strlcpy(currentPgSetup.pg_ctl, pg_ctls[i], MAXPGPATH);
+			strlcpy(currentPgSetup.pg_ctl, pg_ctls.matches[i], MAXPGPATH);
 
 			if (!pg_ctl_version(&currentPgSetup))
 			{
 				/*
-				 * Because of this it's possible that there's now only a single
-				 * working version of pg_ctl found in PATH. If that's the case
-				 * we will still not use that by default, since the users
-				 * intention is unclear. They might have wanted to use the
-				 * version of pg_ctl that we could not parse the version string
-				 * for. So we warn and continue, the user should make their
-				 * intention clear by using the --pg_ctl option (or changing
-				 * PATH).
+				 * Because of this it's possible that there's now only a
+				 * single working version of pg_ctl found in PATH. If
+				 * that's the case we will still not use that by default,
+				 * since the users intention is unclear. They might have
+				 * wanted to use the version of pg_ctl that we could not
+				 * parse the version string for. So we warn and continue,
+				 * the user should make their intention clear by using the
+				 * --pg_ctl option (or setting PG_CONFIG, or PATH).
 				 */
-				log_warn("Failed to get version info from %s --version",
+				log_warn("Failed to get version info from \"%s\" --version",
 						 currentPgSetup.pg_ctl);
 				continue;
 			}
 
-			log_info("Found %s for pg version %s",
+			log_info("Found \"%s\" for pg version %s",
 					 currentPgSetup.pg_ctl,
 					 currentPgSetup.pg_version);
 		}
+
 		log_error("Found several pg_ctl in PATH, please provide --pgctl");
+
+		return false;
 	}
-
-	search_path_destroy_result(pg_ctls);
-
-	return success;
 }
 
 

--- a/src/bin/pg_autoctl/pgctl.c
+++ b/src/bin/pg_autoctl/pgctl.c
@@ -2342,8 +2342,9 @@ pg_create_self_signed_cert(PostgresSetup *pgSetup, const char *hostname)
 	Program program;
 	char subject[BUFSIZE] = { 0 };
 	int size = 0;
-	char openssl[MAXPGPATH];
-	if (!search_path_first("openssl", openssl))
+	char openssl[MAXPGPATH] = { 0 };
+
+	if (!search_path_first("openssl", openssl, LOG_ERROR))
 	{
 		/* errors have already been logged */
 		return false;

--- a/src/bin/pg_autoctl/pgctl.c
+++ b/src/bin/pg_autoctl/pgctl.c
@@ -432,7 +432,7 @@ config_find_pg_ctl(PostgresSetup *pgSetup)
 		{
 			log_fatal("Failed to get version info from \"%s\" --version",
 					  pgSetup->pg_ctl);
-			return 0;
+			return false;
 		}
 
 		log_debug("Found pg_ctl for PostgreSQL %s at \"%s\"",

--- a/src/bin/pg_autoctl/pgctl.h
+++ b/src/bin/pg_autoctl/pgctl.h
@@ -30,7 +30,8 @@
 
 bool pg_controldata(PostgresSetup *pgSetup, bool missing_ok);
 bool set_pg_ctl_from_PG_CONFIG(PostgresSetup *pgSetup);
-int config_find_pg_ctl(PostgresSetup *pgSetup);
+bool set_pg_ctl_from_pg_config(PostgresSetup *pgSetup);
+bool config_find_pg_ctl(PostgresSetup *pgSetup);
 bool find_extension_control_file(const char *pg_ctl, const char *extName);
 bool pg_ctl_version(PostgresSetup *pgSetup);
 bool set_pg_ctl_from_config_bindir(PostgresSetup *pgSetup, const char *pg_config);

--- a/src/bin/pg_autoctl/pgsetup.c
+++ b/src/bin/pg_autoctl/pgsetup.c
@@ -106,17 +106,10 @@ pg_setup_init(PostgresSetup *pgSetup,
 		}
 		else
 		{
-			int count_of_pg_ctl = config_find_pg_ctl(pgSetup);
-
-			if (count_of_pg_ctl != 1)
+			if (!config_find_pg_ctl(pgSetup))
 			{
 				/* config_find_pg_ctl already logged errors */
 				errors++;
-			}
-
-			if (count_of_pg_ctl > 1)
-			{
-				log_error("Found several pg_ctl in PATH, please provide --pgctl");
 			}
 		}
 	}


### PR DESCRIPTION
This improves default integration with debian/ubuntu packaging system for
Postgres where the postgresql-common package installs a pg_config version in
the main PATH and keeps major-dependent versions of pg_ctl in their specific
directories, that are not automatically added to PATH.

Fixes #514 