### PR TITLE
Fix build for *BSD

### DIFF
--- a/src/bin/pg_autoctl/lock_utils.c
+++ b/src/bin/pg_autoctl/lock_utils.c
@@ -27,7 +27,7 @@
 /*
  * See man semctl(2)
  */
-#if !defined(__APPLE__)
+#if defined(__linux__)
 union semun
 {
 	int val;


### PR DESCRIPTION
Only define `union semun` on Linux. Tested building pg_auto_failover with this change on

- Fedora 33
- Alpine 3.12.0
- Mac OS 10.14.6
- OpenBSD 6.8