### PR TITLE
Fix unhealthy nodes processing when wait_primary.

### DIFF
--- a/src/monitor/group_state_machine.c
+++ b/src/monitor/group_state_machine.c
@@ -219,7 +219,8 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 	 */
 	if (IsCurrentState(activeNode, REPLICATION_STATE_REPORT_LSN) &&
 		(IsCurrentState(primaryNode, REPLICATION_STATE_WAIT_PRIMARY) ||
-		 IsCurrentState(primaryNode, REPLICATION_STATE_JOIN_PRIMARY)))
+		 IsCurrentState(primaryNode, REPLICATION_STATE_JOIN_PRIMARY)) &&
+		IsHealthy(primaryNode))
 	{
 		char message[BUFSIZE];
 
@@ -243,7 +244,8 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 	 *
 	 */
 	if (IsCurrentState(activeNode, REPLICATION_STATE_REPORT_LSN) &&
-		IsCurrentState(primaryNode, REPLICATION_STATE_PRIMARY))
+		IsCurrentState(primaryNode, REPLICATION_STATE_PRIMARY) &&
+		IsHealthy(primaryNode))
 	{
 		char message[BUFSIZE];
 

--- a/src/monitor/group_state_machine.c
+++ b/src/monitor/group_state_machine.c
@@ -1107,7 +1107,6 @@ ProceedGroupStateForMSFailover(AutoFailoverNode *activeNode,
 			ReplicationStateGetName(nodeBeingPromoted->reportedState));
 
 		/*
-		 *
 		 * The currently selected node might not be marked healthy at this time
 		 * because in REPORT_LSN we shut Postgres down. We still should proceed
 		 * with the previously selected node in that case.

--- a/src/monitor/group_state_machine.c
+++ b/src/monitor/group_state_machine.c
@@ -1040,8 +1040,14 @@ ProceedGroupStateForMSFailover(AutoFailoverNode *activeNode,
 
 	/*
 	 * If a failover is in progress, continue driving it.
+	 *
+	 * The currently selected node might not be marked healthy at this time
+	 * because in REPORT_LSN we shut Postgres down. We still should proceed
+	 * with the previously selected node in that case.
 	 */
-	if (nodeBeingPromoted != NULL && IsHealthy(nodeBeingPromoted))
+	if (nodeBeingPromoted != NULL &&
+		(nodeBeingPromoted->reportedState == REPLICATION_STATE_REPORT_LSN ||
+		 IsHealthy(nodeBeingPromoted)))
 	{
 		elog(LOG, "Found candidate " NODE_FORMAT,
 			 NODE_FORMAT_ARGS(nodeBeingPromoted));

--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -286,14 +286,18 @@ class PGNode:
         Runs the given sql query with the given arguments in this postgres node
         and returns the results. Returns None if there are no results to fetch.
         """
-        with psycopg2.connect(self.connection_string()) as conn:
-            cur = conn.cursor()
-            cur.execute(query, args)
-            try:
-                result = cur.fetchall()
-                return result
-            except psycopg2.ProgrammingError:
-                return None
+        try:
+            with psycopg2.connect(self.connection_string()) as conn:
+                cur = conn.cursor()
+                cur.execute(query, args)
+                try:
+                    result = cur.fetchall()
+                    return result
+                except psycopg2.ProgrammingError:
+                    return None
+        except:
+             self.print_debug_logs()
+             raise
 
     def pg_config_get(self, settings):
         """

--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -1206,8 +1206,8 @@ SELECT reportedstate
         current_slots.sort()
 
         if set(expected_slots) == set(current_slots):
-            print("slots list on %s is %s, as expected" %
-                  (self.datadir, current_slots))
+            # print("slots list on %s is %s, as expected" %
+            #       (self.datadir, current_slots))
             return True
 
         self.print_debug_logs()

--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -286,18 +286,14 @@ class PGNode:
         Runs the given sql query with the given arguments in this postgres node
         and returns the results. Returns None if there are no results to fetch.
         """
-        try:
-            with psycopg2.connect(self.connection_string()) as conn:
-                cur = conn.cursor()
-                cur.execute(query, args)
-                try:
-                    result = cur.fetchall()
-                    return result
-                except psycopg2.ProgrammingError:
-                    return None
-        except:
-             self.print_debug_logs()
-             raise
+        with psycopg2.connect(self.connection_string()) as conn:
+            cur = conn.cursor()
+            cur.execute(query, args)
+            try:
+                result = cur.fetchall()
+                return result
+            except psycopg2.ProgrammingError:
+                return None
 
     def pg_config_get(self, settings):
         """
@@ -955,6 +951,7 @@ SELECT reportedstate
  WHERE nodeid=%s and groupid=%s
 """,
             self.nodeid, self.group)
+
         if len(results) == 0:
             raise Exception("node %s in group %s not found on the monitor" %
                             (self.nodeid, self.group))
@@ -1487,12 +1484,7 @@ class PGAutoCtl():
         Kills the keeper by sending a SIGTERM to keeper's process group.
         """
         if self.run_proc and self.run_proc.pid:
-            print("Terminating pg_autoctl process for %s [%d]" %
-                  (self.datadir, self.run_proc.pid))
-
             try:
-                # pgid = os.getpgid(self.run_proc.pid)
-                # os.killpg(pgid, signal.SIGTERM)
                 os.kill(self.run_proc.pid, signal.SIGTERM)
 
                 return self.pgnode.cluster.communicate(self, COMMAND_TIMEOUT)
@@ -1503,7 +1495,6 @@ class PGAutoCtl():
                       (self.datadir, e))
                 return None, None
         else:
-            print("pg_autoctl process for %s is not running" % self.datadir)
             return None, None
 
     def communicate(self, timeout=COMMAND_TIMEOUT):

--- a/tests/test_multi_async.py
+++ b/tests/test_multi_async.py
@@ -178,3 +178,45 @@ def test_012_ifup_node4():
     assert node4.wait_until_state(target_state="secondary")
     assert node1.wait_until_state(target_state="primary")
     assert node2.wait_until_state(target_state="secondary")
+
+def test_013_drop_node4():
+    node4.destroy()
+
+    print()
+    assert node1.wait_until_state(target_state="primary")
+    assert node2.wait_until_state(target_state="secondary")
+    assert node3.wait_until_state(target_state="secondary")
+
+def test_014_fail_node1():
+    node1.fail()
+
+    assert node2.wait_until_state(target_state="wait_primary")
+    assert node3.wait_until_state(target_state="secondary")
+
+    ssn = ""
+    eq_(node2.get_synchronous_standby_names(), ssn)
+    eq_(node2.get_synchronous_standby_names_local(), ssn)
+
+def test_015_stop_primary():
+    node2.fail()
+
+    print()
+    assert node3.wait_until_state(target_state="report_lsn")
+
+def test_016_restart_node1():
+    node1.run()
+
+    # node1 used to be primary, now demoted, and meanwhile node2 was primary
+    # so we can't decide to promote node1 now, it's stuck demoted
+    assert node1.wait_until_state(target_state="demoted")
+    assert node3.wait_until_state(target_state="report_lsn")
+
+def test_017_restart_node2():
+    node2.run()
+
+    assert node2.wait_until_state(target_state="wait_primary")
+
+    assert node3.wait_until_state(target_state="secondary")
+    assert node1.wait_until_state(target_state="secondary")
+
+    assert node2.wait_until_state(target_state="primary")

--- a/tests/test_multi_ifdown.py
+++ b/tests/test_multi_ifdown.py
@@ -221,6 +221,9 @@ def test_014_secondary_reports_lsn():
     # and the candidate for failover as accessible
     # which means that node2 will not be able to fetch wal
     # and blocked until the other secondary is up
+    assert node1.wait_until_state(target_state="secondary")
+    assert node3.wait_until_state(target_state="primary")
+
     node3.ifdown()    # primary
     node1.ifdown()    # most advanced standby
     node2.ifup()      # failover candidate
@@ -240,7 +243,7 @@ def test_015_finalize_failover_after_most_advanced_secondary_gets_back():
 
     # and, node2 should finally become the primary without losing any data
     print()
-    assert node2.wait_until_state(target_state="primary")
+    assert node2.wait_until_state(target_state="wait_primary")
 
     print("%s" % monitor.pg_autoctl.err)
 

--- a/tests/test_multi_ifdown.py
+++ b/tests/test_multi_ifdown.py
@@ -241,15 +241,9 @@ def test_015_finalize_failover_after_most_advanced_secondary_gets_back():
     node1.ifup()    # old most advanced secondary, now secondary
     node3.ifup()    # old primary, now secondary
 
-    # and, node2 should finally become the primary without losing any data
-    print()
-    assert node2.wait_until_state(target_state="wait_primary")
-
-    print("%s" % monitor.pg_autoctl.err)
-
-    results = node2.run_sql_query("SELECT count(*) FROM t1")
-    eq_(results, [(10006,)])
-
     assert node1.wait_until_state(target_state="secondary")
     assert node3.wait_until_state(target_state="secondary")
     assert node2.wait_until_state(target_state="primary")
+
+    results = node2.run_sql_query("SELECT count(*) FROM t1")
+    eq_(results, [(10006,)])


### PR DESCRIPTION
The FSM state wait_primary embeds the information that there is no solution
to failover, and as such there is no point in changing the state of the node
to draining or otherwise, as no failover process is going to kick-in.