### PR TITLE
Fix pg_autoctl set formation number-sync-standbys log output.

### DIFF
--- a/src/bin/pg_autoctl/cli_get_set_properties.c
+++ b/src/bin/pg_autoctl/cli_get_set_properties.c
@@ -632,6 +632,12 @@ cli_set_formation_number_sync_standbys(int argc, char **argv)
 		exit(EXIT_CODE_BAD_CONFIG);
 	}
 
+	/* change the default group when it is still unknown */
+	if (config.groupId == -1)
+	{
+		config.groupId = 0;
+	}
+
 	if (!set_formation_number_sync_standbys(&monitor,
 											config.formation,
 											config.groupId,

--- a/src/bin/pg_autoctl/cli_show.c
+++ b/src/bin/pg_autoctl/cli_show.c
@@ -755,7 +755,8 @@ cli_show_standby_names(int argc, char **argv)
 	}
 	else
 	{
-		(void) fformat(stdout, "%s\n", synchronous_standby_names);
+		/* current synchronous_standby_names might be an empty string */
+		(void) fformat(stdout, "'%s'\n", synchronous_standby_names);
 	}
 }
 

--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -1193,8 +1193,8 @@ SELECT reportedstate, goalstate
         command = PGAutoCtl(self)
         out, err, ret = command.execute("get synchronous_standby_names",
                                         'show', 'standby-names')
-
-        return out.strip()
+        # strip spaces and single-quotes from the output
+        return out.strip("' \n\r\t")
 
     def get_synchronous_standby_names_local(self):
          """


### PR DESCRIPTION
The command logs at the INFO level the new synchronous_standby_names value
after having applied the given number-sync-standbys, and that was wrong due
to using the default groupId parsed to -1 at the getopts level.

Fixes #531 