### PR TITLE
Add support for running a pg_autoctl controlled pgbouncer instance

### DIFF
--- a/src/bin/pg_autoctl/cli_common.c
+++ b/src/bin/pg_autoctl/cli_common.c
@@ -391,6 +391,7 @@ cli_common_keeper_getopts(int argc, char **argv,
 				/* { "enable-pgbouncer", required_argument, NULL, 'B' }, */
 				strlcpy(LocalOptionConfig.pgbouncerUserConfig, optarg,
 						MAXPGPATH);
+				strlcpy(LocalOptionConfig.pgbouncer, "enabled", MAXPGPATH);
 				log_trace("--enable-pgbouncer %s",
 						  LocalOptionConfig.pgbouncerUserConfig);
 				break;
@@ -1639,11 +1640,11 @@ cli_pg_autoctl_reload(const char *pidfile)
 
 
 /*
- * cli_pg_autoctl_enable_services signals the pg_autoctl to enable any
- * services it has registered as enableable by sending it a SIGUSR1 signal.
+ * cli_pg_autoctl_handle_dynamic signals the pg_autoctl to handle any dynamic
+ * services based on its configuration
  */
 bool
-cli_pg_autoctl_enable_services(const char *pidfile)
+cli_pg_autoctl_handle_dynamic(const char *pidfile)
 {
 	pid_t pid;
 
@@ -1651,7 +1652,7 @@ cli_pg_autoctl_enable_services(const char *pidfile)
 	{
 		if (pid <= 0)
 		{
-			log_error("Failed to enable services pg_autoctl: "
+			log_error("Failed to handle dynamic services pg_autoctl: "
 					  "pid file \"%s\" contains negative-or-zero pid %d",
 					  pidfile, pid);
 			return false;
@@ -1660,38 +1661,6 @@ cli_pg_autoctl_enable_services(const char *pidfile)
 		if (kill(pid, SIGUSR1) != 0)
 		{
 			log_error("Failed to send SIGUSR1 to the pg_autoctl's pid %d: %m",
-					  pid);
-			return false;
-		}
-	}
-
-	return true;
-}
-
-
-/*
- * cli_pg_autoctl_disable_services signals the pg_autoctl to disable any
- * services it has registered as enableable and are enabled by sending it
- * a SIGUSR2 signal.
- */
-bool
-cli_pg_autoctl_disable_services(const char *pidfile)
-{
-	pid_t pid;
-
-	if (read_pidfile(pidfile, &pid))
-	{
-		if (pid <= 0)
-		{
-			log_error("Failed to disable services pg_autoctl: "
-					  "pid file \"%s\" contains negative-or-zero pid %d",
-					  pidfile, pid);
-			return false;
-		}
-
-		if (kill(pid, SIGUSR2) != 0)
-		{
-			log_error("Failed to send SIGUSR2 to the pg_autoctl's pid %d: %m",
 					  pid);
 			return false;
 		}

--- a/src/bin/pg_autoctl/cli_common.h
+++ b/src/bin/pg_autoctl/cli_common.h
@@ -183,8 +183,7 @@ bool cli_common_pgsetup_init(ConfigFilePaths *pathnames, PostgresSetup *pgSetup)
 bool cli_common_ensure_formation(KeeperConfig *options);
 
 bool cli_pg_autoctl_reload(const char *pidfile);
-bool cli_pg_autoctl_enable_services(const char *pidfile);
-bool cli_pg_autoctl_disable_services(const char *pidfile);
+bool cli_pg_autoctl_handle_dynamic(const char *pidfile);
 
 int cli_node_metadata_getopts(int argc, char **argv);
 int cli_get_name_getopts(int argc, char **argv);

--- a/src/bin/pg_autoctl/cli_common.h
+++ b/src/bin/pg_autoctl/cli_common.h
@@ -183,6 +183,8 @@ bool cli_common_pgsetup_init(ConfigFilePaths *pathnames, PostgresSetup *pgSetup)
 bool cli_common_ensure_formation(KeeperConfig *options);
 
 bool cli_pg_autoctl_reload(const char *pidfile);
+bool cli_pg_autoctl_enable_services(const char *pidfile);
+bool cli_pg_autoctl_disable_services(const char *pidfile);
 
 int cli_node_metadata_getopts(int argc, char **argv);
 int cli_get_name_getopts(int argc, char **argv);

--- a/src/bin/pg_autoctl/cli_do_service.c
+++ b/src/bin/pg_autoctl/cli_do_service.c
@@ -387,7 +387,7 @@ cli_do_service_pgcontroller(int argc, char **argv)
 		exit(EXIT_CODE_BAD_CONFIG);
 	}
 
-	if (!supervisor_start(subprocesses, subprocessesCount, pathnames.pid))
+	if (!supervisor_start(subprocesses, subprocessesCount, pathnames.pid, NULL, NULL))
 	{
 		log_fatal("Failed to start the supervisor, see above for details");
 		exit(EXIT_CODE_INTERNAL_ERROR);

--- a/src/bin/pg_autoctl/config.c
+++ b/src/bin/pg_autoctl/config.c
@@ -267,6 +267,57 @@ SetPidFilePath(ConfigFilePaths *pathnames, const char *pgdata)
 
 
 /*
+ * SetPgbouncerFilePath sets config.pathnames.pgbouncer
+ */
+bool
+SetPgbouncerFilePath(ConfigFilePaths *pathnames, const char *pgdata)
+{
+	if (IS_EMPTY_STRING_BUFFER(pathnames->pgbouncer))
+	{
+		if (!build_xdg_path(pathnames->pgbouncer,
+							XDG_CONFIG,
+							pgdata,
+							"pgbouncer.ini"))
+		{
+			log_error("Failed to build pgbouncer.ini file pathname, "
+					  "see above.");
+			return false;
+		}
+	}
+
+	log_trace("SetPgbouncerFilePath: \"%s\"", pathnames->pgbouncer);
+
+	return true;
+}
+
+
+/*
+ * SetPgbouncerRunTimeFilePath sets config.pathnames.pgbouncerRunTime
+ */
+bool
+SetPgbouncerRunTimeFilePath(ConfigFilePaths *pathnames, const char *pgdata)
+{
+	if (IS_EMPTY_STRING_BUFFER(pathnames->pgbouncerRunTime))
+	{
+		if (!build_xdg_path(pathnames->pgbouncerRunTime,
+							XDG_RUNTIME,
+							pgdata,
+							"pgbouncer.ini"))
+		{
+			log_error("Failed to build pgbouncer.ini file pathname, "
+					  "see above.");
+			return false;
+		}
+	}
+
+	log_trace("SetPgbouncerRunTimeFilePath: \"%s\"",
+			  pathnames->pgbouncerRunTime);
+
+	return true;
+}
+
+
+/*
  * ProbeConfigurationFileRole opens a configuration file at given filename and
  * probes the pg_autoctl role it belongs to: either a monitor or a keeper.
  *

--- a/src/bin/pg_autoctl/config.h
+++ b/src/bin/pg_autoctl/config.h
@@ -39,6 +39,8 @@ typedef struct ConfigFilePaths
 	char init[MAXPGPATH];   /* /tmp/${PGDATA}/pg_autoctl.init */
 	char nodes[MAXPGPATH];  /* ~/.local/share/pg_autoctl/${PGDATA}/nodes.json */
 	char systemd[MAXPGPATH];    /* ~/.config/systemd/user/pgautofailover.service */
+	char pgbouncer[MAXPGPATH];  /* ~/.config/pg_autoctl/${PGDATA}/pgbouncer.ini */
+	char pgbouncerRunTime[MAXPGPATH];  /* /tmp/${PGDATA}/pgbouncer.ini */
 } ConfigFilePaths;
 
 /*
@@ -72,6 +74,9 @@ bool SetConfigFilePath(ConfigFilePaths *pathnames, const char *pgdata);
 bool SetStateFilePath(ConfigFilePaths *pathnames, const char *pgdata);
 bool SetNodesFilePath(ConfigFilePaths *pathnames, const char *pgdata);
 bool SetPidFilePath(ConfigFilePaths *pathnames, const char *pgdata);
+bool SetPgbouncerFilePath(ConfigFilePaths *pathnames, const char *pgdata);
+bool SetPgbouncerRunTimeFilePath(ConfigFilePaths *pathnames,
+								 const char *pgdata);
 
 pgAutoCtlNodeRole ProbeConfigurationFileRole(const char *filename);
 

--- a/src/bin/pg_autoctl/defaults.h
+++ b/src/bin/pg_autoctl/defaults.h
@@ -101,6 +101,9 @@
 /* buffersize that is needed for results of ctime_r */
 #define MAXCTIMESIZE 26
 
+/* maximum number of dynamic services under supervision */
+#define MAXDYNSERVICES 8
+
 #define AWAIT_PROMOTION_SLEEP_TIME_MS 1000
 
 #define KEEPER_CONFIGURATION_FILENAME "pg_autoctl.cfg"

--- a/src/bin/pg_autoctl/ini_file.c
+++ b/src/bin/pg_autoctl/ini_file.c
@@ -362,14 +362,23 @@ write_ini_to_stream(FILE *stream, IniOption *optionList)
 			{
 				fformat(stream, "\n");
 			}
+
 			currentSection = (char *) option->section;
-			fformat(stream, "[%s]\n", currentSection);
+			if (currentSection)
+			{
+				fformat(stream, "[%s]\n", currentSection);
+			}
 		}
 
 		switch (option->type)
 		{
 			case INI_INT_T:
 			{
+				if (*option->intValue == -1)
+				{
+					break;
+				}
+
 				fformat(stream, "%s = %d\n",
 						option->name, *(option->intValue));
 				break;

--- a/src/bin/pg_autoctl/keeper.h
+++ b/src/bin/pg_autoctl/keeper.h
@@ -65,6 +65,8 @@ bool keeper_set_node_metadata(Keeper *keeper, KeeperConfig *oldConfig);
 bool keeper_update_nodename_from_monitor(Keeper *keeper);
 bool keeper_config_accept_new(Keeper *keeper, KeeperConfig *newConfig);
 
+bool keeper_reread_services(Keeper *keeper);
+
 
 /*
  * When receiving a SIGHUP signal, the keeper knows how to reload its current

--- a/src/bin/pg_autoctl/keeper_config.c
+++ b/src/bin/pg_autoctl/keeper_config.c
@@ -171,6 +171,11 @@
 							&(config->postgresql_restart_failure_max_retries), \
 							POSTGRESQL_FAILS_TO_START_RETRIES)
 
+#define OPTION_PGBOUNCER_SERVICE(config) \
+	make_strbuf_option_default("services", "pgbouncer", "enable-pgbouncer", \
+							   false, MAXPGPATH, \
+							   config->pgbouncer, "disabled")
+
 #define SET_INI_OPTIONS_ARRAY(config) \
 	{ \
 		OPTION_AUTOCTL_ROLE(config), \
@@ -204,6 +209,7 @@
 		OPTION_TIMEOUT_PREPARE_PROMOTION_WALRECEIVER(config), \
 		OPTION_TIMEOUT_POSTGRESQL_RESTART_FAILURE_TIMEOUT(config), \
 		OPTION_TIMEOUT_POSTGRESQL_RESTART_FAILURE_MAX_RETRIES(config), \
+		OPTION_PGBOUNCER_SERVICE(config), \
 		INI_OPTION_LAST \
 	}
 

--- a/src/bin/pg_autoctl/keeper_config.h
+++ b/src/bin/pg_autoctl/keeper_config.h
@@ -50,8 +50,11 @@ typedef struct KeeperConfig
 	int postgresql_restart_failure_timeout;
 	int postgresql_restart_failure_max_retries;
 
-	/* Enable pgbouncer */
+	/* pgbouncer transient value, not kept in state*/
 	char pgbouncerUserConfig[MAXPGPATH];
+
+	/* Services */
+	char pgbouncer[MAXPGPATH];
 } KeeperConfig;
 
 #define PG_AUTOCTL_MONITOR_IS_DISABLED(config) \

--- a/src/bin/pg_autoctl/keeper_config.h
+++ b/src/bin/pg_autoctl/keeper_config.h
@@ -49,6 +49,9 @@ typedef struct KeeperConfig
 	int prepare_promotion_walreceiver;
 	int postgresql_restart_failure_timeout;
 	int postgresql_restart_failure_max_retries;
+
+	/* Enable pgbouncer */
+	char pgbouncerUserConfig[MAXPGPATH];
 } KeeperConfig;
 
 #define PG_AUTOCTL_MONITOR_IS_DISABLED(config) \

--- a/src/bin/pg_autoctl/pgbouncer_config.c
+++ b/src/bin/pg_autoctl/pgbouncer_config.c
@@ -1,0 +1,950 @@
+/*
+ * src/bin/pg_autoctl/pgbouncer_config.c
+ *     Pgbouncer configuration functions
+ *
+ * Copyright (c) XXX: FIll in As requested
+ * Licensed under the PostgreSQL License.
+ *
+ */
+
+#include "pgbouncer_config.h"
+
+#include "ini_file.h"
+#include "log.h"
+#include "snprintf.h"
+
+/*
+ * We are intentionally not reading/writing the following values:
+ *
+ *	conffile: show location of current config file. Changing it will make
+ *		PgBouncer use another config file for next RELOAD / SIGHUP.
+ *  resolv_conf: The location of a custom resolv.conf file. This is to allow
+ *      specifying custom DNS servers and perhaps other name resolution options,
+ *      independent of the global operating system configuration.
+ *      The parsing of the file is done by the DNS backend library, not
+ *      PgBouncer, so see the library’s documentation for details on allowed
+ *      syntax and directives.
+ *	user: If set, specifies the Unix user to change to after startup. Works only
+ *		if PgBouncer is started as root or if it’s already running as given
+ *		user. Not supported on Windows.
+ *
+ * We are intentionally not reading the following values:
+ *	server_tls_ca_file, server_tls_cert_file, server_tls_key_file
+ *  unix_socket_dir: Specifies location for Unix sockets. Applies to both
+ *      listening socket and server connections. If set to an empty string, Unix
+ *      sockets are disabled.
+ *	unix_socket_group: Group name to use for Unix socket.
+ *	unix_socket_mode: File system mode for Unix socket
+ *	logfile: Specifies the log file
+ *	pidfile: Specifies the PID file
+ *
+ * We are intentionally overwritting the following values:
+ *	auth_hba_file, auth_file
+ *	client_tls_ca_file, client_tls_cert_file, client_tls_key_file
+ *
+ * We are intentionally not reading the entire databases section.
+ *
+ * If it is desired to not write/read a value, then simply remove the
+ * make_*_option macro corresponding to said value from the
+ * SET_PGBOUNCER_INI_OPTIONS_ARRAY macro. Also remove it from the PgbouncerIni
+ * struct.
+ *
+ * If it is desired to overwrite a value, then simply change its value. Usually
+ * handled in the call of pgbouncer_config_write_template, because we probably
+ * want to handle at the same time the any values that point to files that will
+ * be handled by us.
+ *
+ * If it is desired to not read a value, but handle it during the runtime,
+ * then do as above and then add the correspoding make_*_option in the
+ * SET_PGBOUNCER_RUNTIME_INI_OPTIONS_ARRAY macro. The values should be
+ * calculated in the call of pgbouncer_config_write_runtime.
+ */
+
+struct PgbouncerIni
+{
+	/* template sections */
+
+	/* users section */
+	int max_user_connections;
+
+	char *pool_mode;
+
+	/* pgbouncer section */
+	int application_name_add_host;
+	int autodb_idle_timeout;
+	int client_idle_timeout;
+	int client_login_timeout;
+	int default_pool_size;
+	int disable_pqexec;
+	int dns_max_ttl;
+	int dns_nxdomain_ttl;
+	int dns_zone_check_period;
+	int idle_transaction_timeout;
+	int listen_backlog;
+	int listen_port;
+	int log_connections;
+	int log_disconnections;
+	int log_pooler_errors;
+	int log_stats;
+	int max_client_conn;
+	int max_db_connections;
+	int max_packet_size;
+	int min_pool_size;
+	int pkt_buf;
+	int query_timeout;
+	int query_wait_timeout;
+	int reserve_pool_size;
+	int reserve_pool_timeout;
+	int sbuf_loopcnt;
+	int server_check_delay;
+	int server_connect_timeout;
+	int server_fast_close;
+	int server_idle_timeout;
+	int server_lifetime;
+	int server_login_retry;
+	int server_reset_query_always;
+	int server_round_robin;
+	int so_reuseport;
+	int stats_period;
+	int suspend_timeout;
+	int tcp_keepalive;
+	int tcp_keepcnt;
+	int tcp_keepidle;
+	int tcp_keepintvl;
+	int tcp_socket_buffer;
+	int tcp_user_timeout;
+	int verbose;
+
+	char *admin_users;
+	char *auth_file;
+	char *auth_query;
+	char *auth_type;
+	char *auth_user;
+	char *client_tls_ciphers;
+	char *client_tls_dheparams;
+	char *client_tls_ecdhcurve;
+	char *client_tls_protocols;
+	char *client_tls_sslmode;
+	char *ignore_startup_parameters;
+	char *job_name;
+	char *listen_addr;
+	char *server_check_query;
+	char *server_reset_query;
+	char *service_name;
+	char *stats_users;
+	char *syslog_facility;
+	char *syslog_ident;
+	char *tcp_defer_accept;
+
+	/* runtime sections */
+	/* pgbouncer section */
+	char *logfile;
+	char *pidfile;
+
+	char *server_tls_ciphers;
+	char *server_tls_protocols;
+	char *server_tls_sslmode;
+
+	/* database section */
+	char *connection;
+	char *dbname;
+};
+
+#define SET_PGBOUNCER_INI_OPTIONS_ARRAY(pgbouncerIni) \
+	{ \
+		make_int_option("users", "max_user_connections", \
+						NULL, false, \
+						&(pgbouncerIni->max_user_connections)), \
+		make_string_option("users", "pool_mode", \
+						   NULL, false, \
+						   &(pgbouncerIni->pool_mode)), \
+		make_string_option("pgbouncer", "admin_users", \
+						   NULL, false, \
+						   &(pgbouncerIni->admin_users)), \
+		make_int_option("pgbouncer", "application_name_add_host", \
+						NULL, false, \
+						&(pgbouncerIni->application_name_add_host)), \
+		make_string_option("pgbouncer", "auth_query", \
+						   NULL, false, \
+						   &(pgbouncerIni->auth_query)), \
+		make_string_option("pgbouncer", "auth_file", \
+						   NULL, false, \
+						   &(pgbouncerIni->auth_file)), \
+		make_string_option("pgbouncer", "auth_type", \
+						   NULL, false, \
+						   &(pgbouncerIni->auth_type)), \
+		make_string_option("pgbouncer", "auth_user", \
+						   NULL, false, \
+						   &(pgbouncerIni->auth_user)), \
+		make_int_option("pgbouncer", "autodb_idle_timeout", \
+						NULL, false, \
+						&(pgbouncerIni->autodb_idle_timeout)), \
+		make_int_option("pgbouncer", "client_idle_timeout", \
+						NULL, false, \
+						&(pgbouncerIni->client_idle_timeout)), \
+		make_int_option("pgbouncer", "client_login_timeout", \
+						NULL, false, \
+						&(pgbouncerIni->client_login_timeout)), \
+		make_string_option("pgbouncer", "client_tls_ciphers", \
+						   NULL, false, \
+						   &(pgbouncerIni->client_tls_ciphers)), \
+		make_string_option("pgbouncer", "client_tls_dheparams", \
+						   NULL, false, \
+						   &(pgbouncerIni->client_tls_dheparams)), \
+		make_string_option("pgbouncer", "client_tls_ecdhcurve", \
+						   NULL, false, \
+						   &(pgbouncerIni->client_tls_ecdhcurve)), \
+		make_string_option("pgbouncer", "client_tls_protocols", \
+						   NULL, false, \
+						   &(pgbouncerIni->client_tls_protocols)), \
+		make_string_option("pgbouncer", "client_tls_sslmode", \
+						   NULL, false, \
+						   &(pgbouncerIni->client_tls_sslmode)), \
+		make_int_option("pgbouncer", "default_pool_size", \
+						NULL, false, \
+						&(pgbouncerIni->default_pool_size)), \
+		make_int_option("pgbouncer", "disable_pqexec", \
+						NULL, false, \
+						&(pgbouncerIni->disable_pqexec)), \
+		make_int_option("pgbouncer", "dns_max_ttl", \
+						NULL, false, \
+						&(pgbouncerIni->dns_max_ttl)), \
+		make_int_option("pgbouncer", "dns_nxdomain_ttl", \
+						NULL, false, \
+						&(pgbouncerIni->dns_zone_check_period)), \
+		make_int_option("pgbouncer", "idle_transaction_timeout", \
+						NULL, false, \
+						&(pgbouncerIni->idle_transaction_timeout)), \
+		make_string_option("pgbouncer", "ignore_startup_parameters", \
+						   NULL, false, \
+						   &(pgbouncerIni->ignore_startup_parameters)), \
+		make_string_option("pgbouncer", "job_name", \
+						   NULL, false, \
+						   &(pgbouncerIni->job_name)), \
+		make_string_option("pgbouncer", "listen_addr", \
+						   NULL, false, \
+						   &(pgbouncerIni->listen_addr)), \
+		make_int_option("pgbouncer", "listen_backlog", \
+						NULL, false, \
+						&(pgbouncerIni->listen_backlog)), \
+		make_int_option("pgbouncer", "listen_port", \
+						NULL, false, \
+						&(pgbouncerIni->listen_port)), \
+		make_int_option("pgbouncer", "log_connections", \
+						NULL, false, \
+						&(pgbouncerIni->log_connections)), \
+		make_int_option("pgbouncer", "log_disconnections", \
+						NULL, false, \
+						&(pgbouncerIni->log_disconnections)), \
+		make_int_option("pgbouncer", "log_pooler_errors", \
+						NULL, false, \
+						&(pgbouncerIni->log_pooler_errors)), \
+		make_int_option("pgbouncer", "log_stats", \
+						NULL, false, \
+						&(pgbouncerIni->log_stats)), \
+		make_int_option("pgbouncer", "max_client_conn", \
+						NULL, false, \
+						&(pgbouncerIni->max_client_conn)), \
+		make_int_option("pgbouncer", "max_db_connections", \
+						NULL, false, \
+						&(pgbouncerIni->max_db_connections)), \
+		make_int_option("pgbouncer", "max_packet_size", \
+						NULL, false, \
+						&(pgbouncerIni->max_packet_size)), \
+		make_int_option("pgbouncer", "min_pool_size", \
+						NULL, false, \
+						&(pgbouncerIni->min_pool_size)), \
+		make_int_option("pgbouncer", "pkt_buf", \
+						NULL, false, \
+						&(pgbouncerIni->pkt_buf)), \
+		make_int_option("pgbouncer", "query_timeout", \
+						NULL, false, \
+						&(pgbouncerIni->query_timeout)), \
+		make_int_option("pgbouncer", "query_wait_timeout", \
+						NULL, false, \
+						&(pgbouncerIni->query_wait_timeout)), \
+		make_int_option("pgbouncer", "reserve_pool_size", \
+						NULL, false, \
+						&(pgbouncerIni->reserve_pool_size)), \
+		make_int_option("pgbouncer", "reserve_pool_timeout", \
+						NULL, false, \
+						&(pgbouncerIni->reserve_pool_timeout)), \
+		make_int_option("pgbouncer", "sbuf_loopcnt", \
+						NULL, false, \
+						&(pgbouncerIni->sbuf_loopcnt)), \
+		make_int_option("pgbouncer", "server_check_delay", \
+						NULL, false, \
+						&(pgbouncerIni->server_check_delay)), \
+		make_string_option("pgbouncer", "server_check_query", \
+						   NULL, false, \
+						   &(pgbouncerIni->server_check_query)), \
+		make_int_option("pgbouncer", "server_connect_timeout", \
+						NULL, false, \
+						&(pgbouncerIni->server_connect_timeout)), \
+		make_int_option("pgbouncer", "server_fast_close", \
+						NULL, false, \
+						&(pgbouncerIni->server_fast_close)), \
+		make_int_option("pgbouncer", "server_idle_timeout", \
+						NULL, false, \
+						&(pgbouncerIni->server_idle_timeout)), \
+		make_int_option("pgbouncer", "server_lifetime", \
+						NULL, false, \
+						&(pgbouncerIni->server_lifetime)), \
+		make_int_option("pgbouncer", "server_login_retry", \
+						NULL, false, \
+						&(pgbouncerIni->server_login_retry)), \
+		make_string_option("pgbouncer", "server_reset_query", \
+						   NULL, false, \
+						   &(pgbouncerIni->server_reset_query)), \
+		make_int_option("pgbouncer", "server_reset_query_always", \
+						NULL, false, \
+						&(pgbouncerIni->server_reset_query_always)), \
+		make_int_option("pgbouncer", "server_round_robin", \
+						NULL, false, \
+						&(pgbouncerIni->server_round_robin)), \
+		make_string_option("pgbouncer", "server_tls_ciphers", \
+						   NULL, false, \
+						   &(pgbouncerIni->server_tls_ciphers)), \
+		make_string_option("pgbouncer", "server_tls_protocols", \
+						   NULL, false, \
+						   &(pgbouncerIni->server_tls_protocols)), \
+		make_string_option("pgbouncer", "server_tls_sslmode", \
+						   NULL, false, \
+						   &(pgbouncerIni->server_tls_sslmode)), \
+		make_string_option("pgbouncer", "service_name", \
+						   NULL, false, \
+						   &(pgbouncerIni->service_name)), \
+		make_int_option("pgbouncer", "so_reuseport", \
+						NULL, false, \
+						&(pgbouncerIni->so_reuseport)), \
+		make_int_option("pgbouncer", "stats_period", \
+						NULL, false, \
+						&(pgbouncerIni->stats_period)), \
+		make_string_option("pgbouncer", "stats_users", \
+						   NULL, false, \
+						   &(pgbouncerIni->stats_users)), \
+		make_int_option("pgbouncer", "suspend_timeout", \
+						NULL, false, \
+						&(pgbouncerIni->suspend_timeout)), \
+		make_string_option("pgbouncer", "syslog_facility", \
+						   NULL, false, \
+						   &(pgbouncerIni->syslog_facility)), \
+		make_string_option("pgbouncer", "syslog_ident", \
+						   NULL, false, \
+						   &(pgbouncerIni->syslog_ident)), \
+		make_string_option("pgbouncer", "tcp_defer_accept", \
+						   NULL, false, \
+						   &(pgbouncerIni->tcp_defer_accept)), \
+		make_int_option("pgbouncer", "tcp_keepalive", \
+						NULL, false, \
+						&(pgbouncerIni->tcp_keepalive)), \
+		make_int_option("pgbouncer", "tcp_keepcnt", \
+						NULL, false, \
+						&(pgbouncerIni->tcp_keepcnt)), \
+		make_int_option("pgbouncer", "tcp_keepidle", \
+						NULL, false, \
+						&(pgbouncerIni->tcp_keepidle)), \
+		make_int_option("pgbouncer", "tcp_keepintvl", \
+						NULL, false, \
+						&(pgbouncerIni->tcp_keepintvl)), \
+		make_int_option("pgbouncer", "tcp_socket_buffer", \
+						NULL, false, \
+						&(pgbouncerIni->tcp_socket_buffer)), \
+		make_int_option("pgbouncer", "tcp_user_timeout", \
+						NULL, false, \
+						&(pgbouncerIni->tcp_user_timeout)), \
+		make_int_option("pgbouncer", "verbose", \
+						NULL, false, \
+						&(pgbouncerIni->verbose)), \
+		INI_OPTION_LAST \
+	}
+
+/*
+ * Order is important because pgbouncer does not fare well with multiple
+ * definition of sections. Start with [pgbouncer] section first that was
+ * mentioned above
+ */
+#define SET_PGBOUNCER_RUNTIME_INI_OPTIONS_ARRAY(pgbouncerIni) \
+	{ \
+		make_string_option(NULL, "logfile", \
+						   NULL, false, \
+						   &(pgbouncerIni->logfile)), \
+		make_string_option(NULL, "pidfile", \
+						   NULL, false, \
+						   &(pgbouncerIni->pidfile)), \
+		make_string_option("databases", pgbouncerIni->dbname, \
+						   NULL, false, \
+						   &(pgbouncerIni->connection)), \
+		INI_OPTION_LAST \
+	}
+
+static bool pgbouncer_config_handle_auth_file(struct PgbouncerIni *privateIni,
+											  const char *pgdata);
+static bool pgbouncer_runtime_logfile(struct PgbouncerIni *privateIni,
+									  const char *pgdata);
+static bool pgbouncer_runtime_pidfile(struct PgbouncerIni *privateIni,
+									  const char *pgdata);
+static bool pgbouncer_runtime_database(struct PgbouncerIni *privateIni,
+									   NodeAddress primary,
+									   const char *dbname);
+
+static bool pgbouncer_runtime_auth_file(struct PgbouncerIni *privateIni,
+										const char *pgdata);
+
+/*
+ * pgbouncer_config_init initializes a PgbouncerConfig with the default
+ * values.
+ */
+bool
+pgbouncer_config_init(PgbouncerConfig *config, const char *pgdata)
+{
+	if (!pgdata)
+	{
+		log_error("Failed to initialize pgbouncer configuration, "
+				  "pgdata not set");
+		return false;
+	}
+
+	/* setup config->pathnames.pid */
+	/* setup config->pathnames.pgbouncer */
+	/* setup config->pathnames.pgbouncerRunTime */
+	if (!SetPidFilePath(&(config->pathnames), pgdata) ||
+		!SetPgbouncerFilePath(&(config->pathnames), pgdata) ||
+		!SetPgbouncerRunTimeFilePath(&(config->pathnames), pgdata))
+	{
+		/* It has already logged why */
+		return false;
+	}
+
+	/* Find the absolute path of pgbouncer */
+	if (!search_path_first("pgbouncer", config->pgbouncerProg, LOG_ERROR))
+	{
+		log_fatal("Failed to find pgbouncer program in PATH");
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * pgbouncer_config_destroy frees any malloc'ed memory in PgbouncerConfig
+ */
+bool
+pgbouncer_config_destroy(PgbouncerConfig *config)
+{
+	struct PgbouncerIni *pgbouncerIni;
+
+	if (!config || !config->data)
+	{
+		return true;
+	}
+
+	pgbouncerIni = config->data;
+
+	if (pgbouncerIni->admin_users)
+	{
+		free(pgbouncerIni->admin_users);
+	}
+	if (pgbouncerIni->auth_file)
+	{
+		free(pgbouncerIni->auth_file);
+	}
+	if (pgbouncerIni->auth_query)
+	{
+		free(pgbouncerIni->auth_query);
+	}
+	if (pgbouncerIni->auth_type)
+	{
+		free(pgbouncerIni->auth_type);
+	}
+	if (pgbouncerIni->auth_user)
+	{
+		free(pgbouncerIni->auth_user);
+	}
+	if (pgbouncerIni->client_tls_ciphers)
+	{
+		free(pgbouncerIni->client_tls_ciphers);
+	}
+	if (pgbouncerIni->client_tls_dheparams)
+	{
+		free(pgbouncerIni->client_tls_dheparams);
+	}
+	if (pgbouncerIni->client_tls_ecdhcurve)
+	{
+		free(pgbouncerIni->client_tls_ecdhcurve);
+	}
+	if (pgbouncerIni->client_tls_protocols)
+	{
+		free(pgbouncerIni->client_tls_protocols);
+	}
+	if (pgbouncerIni->client_tls_sslmode)
+	{
+		free(pgbouncerIni->client_tls_sslmode);
+	}
+	if (pgbouncerIni->ignore_startup_parameters)
+	{
+		free(pgbouncerIni->ignore_startup_parameters);
+	}
+	if (pgbouncerIni->job_name)
+	{
+		free(pgbouncerIni->job_name);
+	}
+	if (pgbouncerIni->listen_addr)
+	{
+		free(pgbouncerIni->listen_addr);
+	}
+	if (pgbouncerIni->pool_mode)
+	{
+		free(pgbouncerIni->pool_mode);
+	}
+	if (pgbouncerIni->server_check_query)
+	{
+		free(pgbouncerIni->server_check_query);
+	}
+	if (pgbouncerIni->server_reset_query)
+	{
+		free(pgbouncerIni->server_reset_query);
+	}
+	if (pgbouncerIni->server_tls_ciphers)
+	{
+		free(pgbouncerIni->server_tls_ciphers);
+	}
+	if (pgbouncerIni->server_tls_protocols)
+	{
+		free(pgbouncerIni->server_tls_protocols);
+	}
+	if (pgbouncerIni->server_tls_sslmode)
+	{
+		free(pgbouncerIni->server_tls_sslmode);
+	}
+	if (pgbouncerIni->service_name)
+	{
+		free(pgbouncerIni->service_name);
+	}
+	if (pgbouncerIni->stats_users)
+	{
+		free(pgbouncerIni->stats_users);
+	}
+	if (pgbouncerIni->syslog_facility)
+	{
+		free(pgbouncerIni->syslog_facility);
+	}
+	if (pgbouncerIni->syslog_ident)
+	{
+		free(pgbouncerIni->syslog_ident);
+	}
+	if (pgbouncerIni->tcp_defer_accept)
+	{
+		free(pgbouncerIni->tcp_defer_accept);
+	}
+
+	if (pgbouncerIni->logfile)
+	{
+		free(pgbouncerIni->logfile);
+	}
+	if (pgbouncerIni->pidfile)
+	{
+		free(pgbouncerIni->pidfile);
+	}
+
+	if (pgbouncerIni->connection)
+	{
+		free(pgbouncerIni->connection);
+	}
+	if (pgbouncerIni->dbname)
+	{
+		free(pgbouncerIni->dbname);
+	}
+
+	free(config->data);
+	config->data = NULL;
+
+	return true;
+}
+
+
+/*
+ * pgbouncer_config_read_template reads the contents of the stored ini file. The
+ * contents have to match our hardcoded config or it errors.
+ *
+ * The template is found in the Pathname section and typically has been written
+ * by a call to pgbouncer_config_write_template()
+ *
+ * The contents of that configuration are held in a privately owned member in
+ * PgbouncerConfig.
+ */
+bool
+pgbouncer_config_read_template(PgbouncerConfig *config)
+{
+	struct PgbouncerIni pgbouncerIni = { 0 };
+	IniOption pgbouncerConfigIni[] =
+		SET_PGBOUNCER_INI_OPTIONS_ARRAY((&pgbouncerIni));
+
+	if (config->data)
+	{
+		log_error("Bad internal config state, "
+				  "failed to read template");
+		return false;
+	}
+
+	if (!read_ini_file(config->pathnames.pgbouncer, pgbouncerConfigIni))
+	{
+		log_error("Bad pgbouncer ini config %s", config->pathnames.pgbouncer);
+		return false;
+	}
+
+	config->data = malloc(sizeof(pgbouncerIni));
+	if (!config->data)
+	{
+		log_fatal("Bad internal state, malloc failed");
+		return false;
+	}
+
+	/*
+	 * IGNORE-BANNED fits here because we want to take ownershipt of the
+	 * stack allocated memory variable in the heap. The memory addresses are
+	 * guarranteed to not overlap and to be of the same size.
+	 */
+	memcpy(config->data, &pgbouncerIni, sizeof(pgbouncerIni)); /* IGNORE-BANNED */
+
+	return true;
+}
+
+
+/*
+ * pgbouncer_config_read_user_ini_file reads the contents of the user supplied
+ * ini file. The contents have to match our hardcoded config or it errors. Those
+ * values are then held in a privately owned member in PgbouncerConfig.
+ *
+ * There should be no loaded configuration in the struct prior to calling this
+ * function.
+ *
+ * Returns true when the configuration is successfully read.
+ */
+bool
+pgbouncer_config_read_user_supplied_ini(PgbouncerConfig *config)
+{
+	struct PgbouncerIni pgbouncerIni = { 0 };
+	IniOption pgbouncerConfigIni[] =
+		SET_PGBOUNCER_INI_OPTIONS_ARRAY((&pgbouncerIni));
+
+	if (config->data)
+	{
+		log_error("Bad internal config state, "
+				  "failed to read user supplied ini");
+		return false;
+	}
+
+	if (!read_ini_file(config->userSuppliedConfig, pgbouncerConfigIni))
+	{
+		log_error("Bad user supplied config %s", config->userSuppliedConfig);
+		return false;
+	}
+
+	config->data = malloc(sizeof(pgbouncerIni));
+	if (!config->data)
+	{
+		log_fatal("Bad internal state, malloc failed");
+		return false;
+	}
+
+	/*
+	 * IGNORE-BANNED fits here because we want to take ownershipt of the
+	 * stack allocated memory variable in the heap. The memory addresses are
+	 * guarranteed to not overlap and to be of the same size.
+	 */
+	memcpy(config->data, &pgbouncerIni, sizeof(pgbouncerIni)); /* IGNORE-BANNED */
+
+	return true;
+}
+
+
+/*
+ * pgbouncer_config_write_runtime writes an already loaded configuration to the
+ * runtime file.
+ *
+ * The function comprises of three parts:
+ *	Preparation of the runtime values of the config file
+ *	File management of the runtime config file, already calculated in Pathnames
+ *	Writing those values to the file
+ *
+ * It is also responsible for handling the runtime section of the PgbouncerIni
+ * struct.
+ *
+ */
+bool
+pgbouncer_config_write_runtime(PgbouncerConfig *config)
+{
+	FILE *fileStream = NULL;
+	struct PgbouncerIni privateIni = { 0 };
+	const char *filePath = config->pathnames.pgbouncerRunTime;
+	bool success;
+
+	if (!config->data)
+	{
+		log_error("Attempt to write file without loaded configuration");
+		return false;
+	}
+
+	/*
+	 * IGNORE-BANNED fits here because we are going to overwrite some values,
+	 * for example values pointing to files, so we operate on a stacked
+	 * allocated copy. Any overwritten values in the copy do not affect the
+	 * original values.
+	 */
+	memcpy(&privateIni, config->data, sizeof(privateIni)); /* IGNORE-BANNED */
+
+	/*
+	 * Handle the runtime values
+	 */
+	if (!pgbouncer_runtime_logfile(&privateIni, config->pgSetup.pgdata) ||
+		!pgbouncer_runtime_pidfile(&privateIni, config->pgSetup.pgdata) ||
+		!pgbouncer_runtime_auth_file(&privateIni, config->pgSetup.pgdata) ||
+		!pgbouncer_runtime_database(&privateIni, config->primary,
+									config->pgSetup.dbname))
+	{
+		/* It has already logged why */
+		return false;
+	}
+
+	log_trace("pgbouncer_config_write_runtime \"%s\"", filePath);
+	log_info("Will write to: %s", filePath);
+
+	fileStream = fopen_with_umask(filePath, "w", FOPEN_FLAGS_W, 0644);
+	if (fileStream == NULL)
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	success = write_ini_to_stream(fileStream,
+								  (IniOption []) SET_PGBOUNCER_INI_OPTIONS_ARRAY(
+									  (&privateIni)));
+
+	success &= write_ini_to_stream(fileStream,
+								   (IniOption []) SET_PGBOUNCER_RUNTIME_INI_OPTIONS_ARRAY(
+									   (&privateIni)));
+
+	free(privateIni.logfile);
+	free(privateIni.pidfile);
+	free(privateIni.auth_file);
+	free(privateIni.dbname);
+	free(privateIni.connection);
+
+	if (fclose(fileStream) == EOF)
+	{
+		log_error("Failed to write file \"%s\"", filePath);
+		return false;
+	}
+
+	return success;
+}
+
+
+/*
+ * pgbouncer_config_write_template writes loaded configuration to the file
+ * pointed by Pathnames
+ *
+ * This file will be used as our template. If there are any known values in the
+ * configuration that point to files, it is our responsibility to manage. In
+ * those cases the contents of those files are copied into files that are
+ * managed by us.
+ */
+bool
+pgbouncer_config_write_template(PgbouncerConfig *config)
+{
+	const char *filePath = config->pathnames.pgbouncer;
+	struct PgbouncerIni *loadedIni = config->data;
+	bool success = false;
+	FILE *fileStream = NULL;
+
+	if (!loadedIni)
+	{
+		log_error("Attempt to write file without loaded configuration");
+		return false;
+	}
+
+	if (!pgbouncer_config_handle_auth_file(loadedIni, config->pgSetup.pgdata))
+	{
+		/* It has already logged why */
+		return false;
+	}
+
+	log_trace("pgbouncer_config_write_template \"%s\"", filePath);
+
+	log_info("Will write to: %s", filePath);
+	fileStream = fopen_with_umask(filePath, "w", FOPEN_FLAGS_W, 0644);
+	if (fileStream == NULL)
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	success = write_ini_to_stream(fileStream,
+								  (IniOption []) SET_PGBOUNCER_INI_OPTIONS_ARRAY(
+									  loadedIni));
+
+	if (fclose(fileStream) == EOF)
+	{
+		log_error("Failed to write file \"%s\"", filePath);
+		return false;
+	}
+
+	return success;
+}
+
+
+/*
+ * pgbouncer_config_handle_auth_file overwrites the user provided value for
+ * auth_file with a new destination file path. It copies the contents of the
+ * user provided file to the new destination, overwritting any existing file.
+ *
+ * Returns true if all the above succeeded.
+ */
+static bool
+pgbouncer_config_handle_auth_file(struct PgbouncerIni *loadedIni,
+								  const char *pgdata)
+{
+	char authFilePath[MAXPGPATH];
+
+	if (!loadedIni->auth_file)
+	{
+		return true;
+	}
+
+	if (!build_xdg_path(authFilePath,
+						XDG_CONFIG,
+						pgdata, "pgbouncer_auth_file.txt"))
+	{
+		log_error("Failed to write auth_file");
+		return false;
+	}
+
+	if (file_exists(authFilePath) && !unlink_file(authFilePath))
+	{
+		log_error("Failed to remove previous auth_file");
+		return false;
+	}
+
+	if (!duplicate_file(loadedIni->auth_file, authFilePath))
+	{
+		log_error("Failed to write auth_file");
+		return false;
+	}
+
+	free(loadedIni->auth_file);
+	loadedIni->auth_file = strdup(authFilePath);
+
+	return true;
+}
+
+
+/* XXX: remember to unlink it on exit */
+static bool
+pgbouncer_runtime_auth_file(struct PgbouncerIni *privateIni,
+							const char *pgdata)
+{
+	char authFilePath[MAXPGPATH];
+
+	if (!privateIni->auth_file)
+	{
+		return true;
+	}
+
+	if (!build_xdg_path(authFilePath,
+						XDG_RUNTIME,
+						pgdata,
+						"pgbouncer_auth_file.txt"))
+	{
+		log_error("Failed to write auth_file");
+		return false;
+	}
+
+	if (!unlink_file(authFilePath))
+	{
+		log_error("Failed to remove previous auth_file");
+		return false;
+	}
+
+	if (!duplicate_file(privateIni->auth_file, authFilePath))
+	{
+		log_error("Failed to write auth_file");
+		return false;
+	}
+
+	/* Do not free the initial value */
+	privateIni->auth_file = strdup(authFilePath);
+
+	return true;
+}
+
+
+static bool
+pgbouncer_runtime_logfile(struct PgbouncerIni *privateIni,
+						  const char *pgdata)
+{
+	char logFilePath[MAXPGPATH];
+
+	if (!build_xdg_path(logFilePath,
+						XDG_RUNTIME,
+						pgdata,
+						"pgbouncer.log"))
+	{
+		log_error("Failed to build pgbouncer runtime logfile");
+		return false;
+	}
+
+	privateIni->logfile = strdup(logFilePath);
+	return true;
+}
+
+
+static bool
+pgbouncer_runtime_pidfile(struct PgbouncerIni *privateIni,
+						  const char *pgdata)
+{
+	char pidFilePath[MAXPGPATH];
+
+	if (!build_xdg_path(pidFilePath,
+						XDG_RUNTIME,
+						pgdata,
+						"pgbouncer.pid"))
+	{
+		log_error("Failed to build pgbouncer runtime pid");
+		return false;
+	}
+
+	privateIni->pidfile = strdup(pidFilePath);
+	return true;
+}
+
+
+static bool
+pgbouncer_runtime_database(struct PgbouncerIni *privateIni,
+						   NodeAddress primary,
+						   const char *dbname)
+{
+	char connection[MAXCONNINFO];
+
+	/* mydb = port=5002 host=there.com dbname=mydb */
+	pg_snprintf(connection, MAXCONNINFO, "port=%d host=%s dbname=%s",
+				primary.port,
+				primary.host,
+				dbname);
+
+	if (privateIni->dbname)
+	{
+		free(privateIni->dbname);
+	}
+
+	if (privateIni->connection)
+	{
+		free(privateIni->connection);
+	}
+
+	privateIni->dbname = strdup(dbname);
+	privateIni->connection = strdup(connection);
+
+	return true;
+}

--- a/src/bin/pg_autoctl/pgbouncer_config.h
+++ b/src/bin/pg_autoctl/pgbouncer_config.h
@@ -1,0 +1,53 @@
+/*
+ * src/bin/pg_autoctl/pbouncer_config.h
+ *     Keeper integration with pgbouncer configuration file
+ *
+ * Copyright (c) XXX: FIll in As requested
+ * Licensed under the PostgreSQL License.
+ *
+ */
+
+#ifndef PGBOUNCER_CONFIG_H
+#define PGBOUNCER_CONFIG_H
+
+#include <limits.h>
+#include <stdbool.h>
+
+#include "config.h"
+
+typedef struct PgbouncerConfig
+{
+	ConfigFilePaths pathnames;
+
+	/* UNIT */
+	char Description[BUFSIZE];
+
+	/* User Supplied options */
+	char userSuppliedConfig[MAXPGPATH];
+
+	/* Absolute Path of pgbouncer binary */
+	char pgbouncerProg[MAXPGPATH];
+
+	/* PostgreSQL setup */
+	PostgresSetup pgSetup;
+	NodeAddress primary;
+
+	/* Monitor uri to connect to */
+	char monitor_pguri[MAXCONNINFO];
+
+	/* Formation and group we belong to */
+	char formation[NAMEDATALEN];
+	int groupId;
+
+	/* Private member */
+	void *data;
+} PgbouncerConfig;
+
+bool pgbouncer_config_init(PgbouncerConfig *config, const char *pgdata);
+bool pgbouncer_config_destroy(PgbouncerConfig *config);
+bool pgbouncer_config_read_template(PgbouncerConfig *config);
+bool pgbouncer_config_read_user_supplied_ini(PgbouncerConfig *config);
+bool pgbouncer_config_write_runtime(PgbouncerConfig *config);
+bool pgbouncer_config_write_template(PgbouncerConfig *config);
+
+#endif /* PGBOUNCER_CONFIG_H */

--- a/src/bin/pg_autoctl/service_keeper.c
+++ b/src/bin/pg_autoctl/service_keeper.c
@@ -78,7 +78,7 @@ start_keeper(Keeper *keeper)
 
 	int subprocessesCount = sizeof(subprocesses) / sizeof(subprocesses[0]);
 
-	return supervisor_start(subprocesses, subprocessesCount, pidfile);
+	return supervisor_start(subprocesses, subprocessesCount, pidfile, NULL, NULL);
 }
 
 

--- a/src/bin/pg_autoctl/service_monitor.c
+++ b/src/bin/pg_autoctl/service_monitor.c
@@ -68,7 +68,8 @@ start_monitor(Monitor *monitor)
 
 	return supervisor_start(subprocesses,
 							subprocessesCount,
-							config->pathnames.pid);
+							config->pathnames.pid,
+							NULL, NULL);
 }
 
 

--- a/src/bin/pg_autoctl/service_monitor_init.c
+++ b/src/bin/pg_autoctl/service_monitor_init.c
@@ -79,7 +79,8 @@ service_monitor_init(Monitor *monitor)
 
 	if (!supervisor_start(subprocesses,
 						  subprocessesCount,
-						  config->pathnames.pid))
+						  config->pathnames.pid,
+						  NULL, NULL))
 	{
 		/* errors have already been logged */
 		return false;

--- a/src/bin/pg_autoctl/service_pgbouncer.c
+++ b/src/bin/pg_autoctl/service_pgbouncer.c
@@ -1,0 +1,437 @@
+/*
+ * src/bin/pg_autoctl/service_pgbouncer.c
+ *     Service that manages a pgbouncer instance.
+ *
+ * Copyright (c) XXX
+ */
+
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "cli_common.h"
+#include "cli_root.h"
+#include "monitor.h"
+#include "pgbouncer_config.h"
+#include "runprogram.h"
+#include "service_pgbouncer.h"
+#include "signals.h"
+#include "string_utils.h"
+
+
+/*
+ * We are called from the process tree something like this
+ *
+ * \_ pg_autoctl create postgres --pgdata ./data ---
+ *     \_ pg_autoctl: start/stop postgres
+ *     |   \_ /postgres/build/bin/postgres -D ./data -h *
+ *     |       \_ postgres: logger
+ *     |       \_ postgres: startup recovering 000000030000000000000003
+ *     |       \_ postgres: checkpointer
+ *     |       \_ postgres: background writer
+ *     |       \_ postgres: stats collector
+ *     |       \_ postgres: walreceiver streaming 0/305FB48
+ *     \_ pg_autoctl: node active
+ *
+ * We want to launch our service_pgbouncer_manager process which will listen for
+ * notifications and a pgbouncer as an indipendent child, like this:
+ * \_ pg_autoctl create postgres --pgdata ./data ---
+ *     \_ pg_autoctl: start/stop postgres
+ *     |   \_ /postgres -D ./data -h *
+ *     |       \_ postgres: logger
+ *     |       \_ postgres: startup recovering 000000030000000000000003
+ *     |       \_ postgres: checkpointer
+ *     |       \_ postgres: background writer
+ *     |       \_ postgres: stats collector
+ *     |       \_ postgres: walreceiver streaming 0/305FB48
+ *     \_ pg_autoctl: node active
+ *     \_ pg_autoctl: pgbouncer manager
+ *         \_ pgbouncer config.ini
+ *
+ * The pgbouncer manager will be be responsible for starting/stopping/reloading
+ * its child process, pgbouncer.
+ * Starting happens only once during startup, right after fork
+ * Stopping happens only once during asked to stop from supervisor
+ * Reloading happens when required:
+ *     asked to reload from supervisor
+ *     got notified from the monitor
+ * The pgbouncer manager process will waitpid() on the child and if the child is
+ * not running (SIGCONT?) then the manager simply exits and lets its supervisor
+ * decide what to do. Its supervisor (pg_autoctl) might decide to call start
+ * again or it might do nothing.
+ *
+ * The pgbouncer manager service when starts it should
+ *		Connect to the monitor and issue a LISTEN command
+ *      Set up the run time configuration for pgbouncer (cache reset)
+ *		Launch the child pgbouncer process via runprogram
+ *
+ * The pgbouncer manager service when it loops it should
+ *			cache invalidation: process notifications for state change
+ *			check that the child pgbouncer is still running,
+ *				if not exit the	process
+ *
+ * The whole service runs under the supervision protocol. It subscribes itself
+ * with a 'soft' restart policy. I.e. Best efford. If the supervisor fails to
+ * maintain the child running after MAX_RESTART_ATTEMPTS, then it simply
+ * deactivates the service. The 'hard' restart policy, shuts down the whole
+ * pg_autoctl process tree and is not desirable to loose the database simply
+ * because pgbouncer burfs.
+ */
+
+static pid_t service_pgbouncer_launch(void *context);
+static void service_pgbouncer_manager_loop(void *context, pid_t ppid);
+
+static PgbouncerConfig *
+service_pbouncer_setup_config(Keeper *keeper)
+{
+	KeeperConfig *keeperConfig = &(keeper->config);
+	PgbouncerConfig *pgbouncerConfig;
+	NodeAddress primary = { 0 };
+
+	pgbouncerConfig = calloc(1, sizeof(*pgbouncerConfig));
+	if (!pgbouncerConfig)
+	{
+		/* This is not recoverable */
+		log_fatal("malloc failed %m");
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+
+	/*
+	 * Verify as best as possible that we will not fail later in the process
+	 * tree. It should not be problem even if we fail, just a bit of waste.
+	 */
+	if (!pgbouncer_config_init(pgbouncerConfig, keeperConfig->pgSetup.pgdata) ||
+		!pgbouncer_config_read_template(pgbouncerConfig))
+	{
+		/* It has already logged why */
+		free(pgbouncerConfig);
+		return NULL;
+	}
+
+	strlcpy(pgbouncerConfig->monitor_pguri, keeperConfig->monitor_pguri,
+			sizeof(keeperConfig->monitor_pguri));
+	strlcpy(pgbouncerConfig->formation, keeperConfig->formation,
+			sizeof(keeperConfig->formation));
+	pgbouncerConfig->groupId = keeperConfig->groupId;
+
+	if (!keeper_get_primary(keeper, &primary))
+	{
+		log_error("Failed to get primary for current formation and group.");
+		free(pgbouncerConfig);
+		return NULL;
+	}
+	pgsql_finish(&(keeper->monitor.pgsql));
+	pgbouncerConfig->pgSetup = keeperConfig->pgSetup;
+	pgbouncerConfig->primary = primary;
+
+	return pgbouncerConfig;
+}
+
+
+/*
+ * service_pgbouncer_start starts pgbouncer, our manager, and pgbouncer in a
+ * subprocess. We do not want to run pgbouncer as a deamon, because we want to
+ * control the subprocess and maintain it as a child of the current process
+ * tree. We do not want to run our manager in the parent, because we want it to
+ * be a supervised service.
+ */
+bool
+service_pgbouncer_start(void *context, pid_t *pid)
+{
+	Keeper *keeper = (Keeper *) context;
+	PgbouncerConfig *pgbouncerConfig;
+	IntString semIdString;
+	pid_t fpid;
+
+	semIdString = intToString(log_semaphore.semId);
+	setenv(PG_AUTOCTL_DEBUG, "1", 1);
+	setenv(PG_AUTOCTL_LOG_SEMAPHORE, semIdString.strValue, 1);
+
+	/* Flush stdio channels just before fork, to avoid double-output problems */
+	fflush(stdout);
+	fflush(stderr);
+
+	/* time to create the pgbouncer manager sub-process */
+	fpid = fork();
+	switch (fpid)
+	{
+		case -1:
+		{
+			log_error("Failed to fork the pgbouncer manager process");
+			return false;
+		}
+
+		case 0:
+		{
+			pid_t pgbouncerPid;
+
+			pgbouncerConfig = service_pbouncer_setup_config(keeper);
+			if (!pgbouncerConfig)
+			{
+				/* It has already logged why */
+				return false;
+			}
+			if (!pgbouncer_config_write_runtime(pgbouncerConfig))
+			{
+				/* It has already logged why */
+				free(pgbouncerConfig);
+				return false;
+			}
+
+			pgbouncerPid = service_pgbouncer_launch(pgbouncerConfig);
+
+			service_pgbouncer_manager_loop(pgbouncerConfig, pgbouncerPid);
+			pgbouncer_config_destroy(pgbouncerConfig);
+			free(pgbouncerConfig);
+
+			if (asked_to_stop_fast || asked_to_stop ||
+				asked_to_quit || asked_to_disable)
+			{
+				log_info("Stopped pgbouncer manager service");
+				exit(EXIT_CODE_QUIT);
+			}
+
+			log_fatal("BUG: unexpected return from service_pgbouncer_loop()");
+			exit(EXIT_CODE_INTERNAL_ERROR);
+		}
+
+		default:
+		{
+			/* fork succeeded, in parent */
+			log_debug("pg_autoctl pgbouncer manager process started in subprocess %d",
+					  fpid);
+			*pid = fpid;
+			return true;
+		}
+	}
+
+	return false; /* Not reached, keep the compiler happy */
+}
+
+
+/*
+ * service_pgbouncer_launch executes pgbouncer in a child process.
+ * Returns the child's pid on success or Exits in failure.
+ */
+static pid_t
+service_pgbouncer_launch(void *context)
+{
+	PgbouncerConfig *config = (PgbouncerConfig *) context;
+	pid_t fpid;
+
+	IntString semIdString = intToString(log_semaphore.semId);
+
+	setenv(PG_AUTOCTL_DEBUG, "1", 1);
+	setenv(PG_AUTOCTL_LOG_SEMAPHORE, semIdString.strValue, 1);
+
+	fpid = fork();
+	switch (fpid)
+	{
+		case -1:
+		{
+			log_error("Failed to fork the pgbouncer process");
+			exit(EXIT_CODE_INTERNAL_ERROR);
+		}
+
+		case 0:
+		{
+			/* We are the child process that actually runs pgbouncer */
+			Program program;
+			char *args[] = {
+				config->pgbouncerProg,
+				"-q",   /* quiet output to logfile */
+				config->pathnames.pgbouncerRunTime,
+				NULL
+			};
+
+			/* We do not want to setsid() */
+			program = initialize_program(args, false);
+
+			program.capture = false; /* redirect output */
+			program.stdOutFd = STDOUT_FILENO;
+			program.stdErrFd = STDERR_FILENO;
+
+			/* It calls execv and should not return */
+			(void) execute_program(&program);
+
+			exit(EXIT_CODE_QUIT);
+		}
+
+		default:
+		{
+			/* Everything is ok */
+			break;
+		}
+	}
+
+	return fpid;
+}
+
+
+static bool
+pgbouncer_manager_ensure_child(pid_t pgbouncerPid)
+{
+	int status = 0;
+	int w;
+
+	w = waitpid(pgbouncerPid, &status, WNOHANG);
+	if (w == -1)
+	{
+		/* Cannot recover from this cleanly */
+		log_fatal("Failed to waitpid");
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+
+	if (w == pgbouncerPid)
+	{
+		if (WIFEXITED(status))
+		{
+			log_info("Child %d exited normaly", pgbouncerPid);
+		}
+		else if (WIFSIGNALED(status))
+		{
+			log_info("Child %d got signaled", pgbouncerPid);
+		}
+		else if (WIFSTOPPED(status))
+		{
+			log_info("Child %d stopped", pgbouncerPid);
+		}
+		else
+		{
+			log_fatal("Child %d exited abnormaly", pgbouncerPid);
+		}
+
+		return false;
+	}
+
+	return w == 0;
+}
+
+
+/*
+ * service_pgbouncer_loop is the manager process.
+ * It has has three tasks
+ *      Checks if the pgbouncer process is still running
+ *			handled by pgbouncer_manager_ensure_child()
+ *		Listens the monitor for notifications
+ *		Signals the pgbouncer process if asked
+ */
+static void
+service_pgbouncer_manager_loop(void *context, pid_t ppid)
+{
+	PgbouncerConfig *config = context;
+	Monitor monitor = { 0 };
+	int retries = 0;
+
+	(void) set_ps_title("pg_autoctl: manage pgbouncer");
+
+	if (!monitor_init(&monitor, config->monitor_pguri))
+	{
+		log_error("Failed to initialize monitor");
+		kill(ppid, SIGQUIT);
+		return;
+	}
+
+	/* setup our monitor client connection with our notification handler */
+	(void) monitor_setup_notifications(&monitor,
+									   config->groupId,
+									   config->primary.nodeId);
+
+	while (true)
+	{
+		bool groupStateHasChanged;
+		char *channels[] = { "state", NULL };
+
+		if (!pgbouncer_manager_ensure_child(ppid))
+		{
+			/* It has already logged why */
+			exit(EXIT_CODE_INTERNAL_ERROR);
+		}
+
+		if (asked_to_stop_fast || asked_to_stop || asked_to_quit)
+		{
+			kill(ppid, SIGQUIT);
+			break;
+		}
+
+		if (asked_to_disable)
+		{
+			log_info("Asked to disable the service");
+			kill(ppid, SIGINT);
+			break;
+		}
+
+		if (!pgsql_listen(&(monitor.pgsql), channels) ||
+			!monitor_wait_for_state_change(&monitor,
+										   config->formation,
+										   config->groupId,
+										   config->primary.nodeId,
+										   1000 /* Ms */,
+										   &groupStateHasChanged))
+		{
+			log_error("Failed to receive details from monitor %d", retries);
+			if (++retries < 10)
+			{
+				pg_usleep(100 * retries);
+				continue;
+			}
+			else
+			{
+				kill(ppid, SIGQUIT);
+				break;
+			}
+		}
+
+		/* Cache invalidation is needed */
+		if (groupStateHasChanged)
+		{
+			if (!pgbouncer_manager_ensure_child(ppid))
+			{
+				/* It has already logged why */
+				exit(EXIT_CODE_INTERNAL_ERROR);
+			}
+
+			if (asked_to_stop_fast || asked_to_stop || asked_to_quit)
+			{
+				kill(ppid, SIGQUIT);
+				break;
+			}
+
+			if (asked_to_disable)
+			{
+				log_info("Asked to disable the service");
+				kill(ppid, SIGINT);
+				break;
+			}
+
+			log_info("Primary changed pausing pgbouncer until a new primary elected");
+			kill(ppid, SIGUSR1 /* Pause */);
+
+			monitor_wait_until_some_node_reported_state(&monitor,
+														config->formation,
+														config->groupId,
+														NODE_KIND_UNKNOWN,
+														PRIMARY_STATE);
+
+
+			config->primary.isPrimary = false;
+			monitor_get_primary(&monitor,
+								config->formation,
+								config->groupId,
+								&config->primary);
+
+			if (!config->primary.isPrimary)
+			{
+				log_info("Failed to get primary");
+				kill(ppid, SIGINT);
+				pgsql_finish(&monitor.pgsql);
+				break;
+			}
+
+			(void) pgbouncer_config_write_runtime(config);
+			kill(ppid, SIGHUP /* Reload */);
+			kill(ppid, SIGUSR2 /* Continue */);
+		}
+
+		pgsql_finish(&monitor.pgsql);
+	}
+}

--- a/src/bin/pg_autoctl/service_pgbouncer.h
+++ b/src/bin/pg_autoctl/service_pgbouncer.h
@@ -1,0 +1,17 @@
+/*
+ * src/bin/pg_autoctl/service_pgbouncer.h
+ *   Utilities to start/stop a pgbouncer service in a node.
+ *
+ * Copyright (c) XXX.
+ * Licensed under the PostgreSQL License.
+ *
+ */
+#ifndef SERVICE_PGBOUNCER_H
+#define SERVICE_PPGBOUNCER_H
+
+#include "keeper.h"
+#include "keeper_config.h"
+
+bool service_pgbouncer_start(void *context, pid_t *pid);
+
+#endif /* SERVICE_POSTGRES_CTL_H */

--- a/src/bin/pg_autoctl/signals.h
+++ b/src/bin/pg_autoctl/signals.h
@@ -18,8 +18,7 @@ extern volatile sig_atomic_t asked_to_stop;      /* SIGTERM */
 extern volatile sig_atomic_t asked_to_stop_fast; /* SIGINT */
 extern volatile sig_atomic_t asked_to_reload;    /* SIGHUP */
 extern volatile sig_atomic_t asked_to_quit;      /* SIGQUIT */
-extern volatile sig_atomic_t asked_to_enable;    /* SIGUSR1 */
-extern volatile sig_atomic_t asked_to_disable;   /* SIGUSR2 */
+extern volatile sig_atomic_t asked_to_handle_dynamic;    /* SIGUSR1 */
 
 #define CHECK_FOR_FAST_SHUTDOWN { if (asked_to_stop_fast) { break; } \
 }
@@ -32,8 +31,7 @@ void catch_int(int sig);
 void catch_term(int sig);
 void catch_quit(int sig);
 void catch_quit_and_exit(int sig);
-void catch_enable(int sig);
-void catch_disable(int sig);
+void catch_dynamic(int sig);
 
 int get_current_signal(int defaultSignal);
 int pick_stronger_signal(int sig1, int sig2);

--- a/src/bin/pg_autoctl/signals.h
+++ b/src/bin/pg_autoctl/signals.h
@@ -18,6 +18,8 @@ extern volatile sig_atomic_t asked_to_stop;      /* SIGTERM */
 extern volatile sig_atomic_t asked_to_stop_fast; /* SIGINT */
 extern volatile sig_atomic_t asked_to_reload;    /* SIGHUP */
 extern volatile sig_atomic_t asked_to_quit;      /* SIGQUIT */
+extern volatile sig_atomic_t asked_to_enable;    /* SIGUSR1 */
+extern volatile sig_atomic_t asked_to_disable;   /* SIGUSR2 */
 
 #define CHECK_FOR_FAST_SHUTDOWN { if (asked_to_stop_fast) { break; } \
 }
@@ -30,6 +32,8 @@ void catch_int(int sig);
 void catch_term(int sig);
 void catch_quit(int sig);
 void catch_quit_and_exit(int sig);
+void catch_enable(int sig);
+void catch_disable(int sig);
 
 int get_current_signal(int defaultSignal);
 int pick_stronger_signal(int sig1, int sig2);

--- a/src/bin/pg_autoctl/supervisor.h
+++ b/src/bin/pg_autoctl/supervisor.h
@@ -50,6 +50,11 @@ typedef enum
 	RP_TRANSIENT
 } RestartPolicy;
 
+typedef enum
+{
+	SV_ENABLED = 0,
+	SV_DISABLED
+} ServiceEnabled;
 
 /*
  * Supervisor restart strategy.
@@ -93,6 +98,10 @@ typedef struct RestartCounters
  * seen by the supervisor.
  *
  * In particular, services may be started more than once when they fail.
+ *
+ * Also a service may get started or stopped at any point depending on the
+ * ServiceEnabled value.
+ * For a service to be disabled, it has to have the canDisable flag set.
  */
 typedef struct Service
 {
@@ -101,6 +110,8 @@ typedef struct Service
 	pid_t pid;                          /* Service PID */
 	bool (*startFunction)(void *context, pid_t *pid);
 	void *context;             /* Service Context (Monitor or Keeper struct) */
+	ServiceEnabled enabled;    /* Is the service enabled? Default yes */
+	bool canDisable;           /* Can we disable the service? Default no */
 	RestartCounters restartCounters;
 } Service;
 


### PR DESCRIPTION
As per discussion in previous PR [#508]. 

Thank you in advance for the comments and discussion. 

**Implements pg_autoctl [enable|disable] pgbouncer [options]**
**Implements pg_autoctl create postgres [--enable-pgbouncer <file>]**



**Intention**
	In a pg_autoctl managed environment, have a pgbouncer instance pointing to
the current primary. The instance can run in any postgres node but not in a
monitor node. The instance can start either when the postgres node does or at
any other moment. The instance can stop at any moment without affecting the
running node.

**Architecture**
***Process tree***

In essence we want to run pgbouncer as a subprocess of pg_autoctl. It will
be pg_autoctl's responsibility to manage the pgbouncer subprocess. In that
effect, pg_autoctl launches a 'pgbouncer manager' process and a pgbouncer
process under it. When running, the process tree may look like this:

	    pg_autoctl create postgres --pgdata ./data ---
	     \_ pg_autoctl: start/stop postgres
	     |   \_ /postgres -D ./data -h *
	     |       \_ postgres: logger
	     |       \_ postgres: startup recovering 000000030000000000000003
	     |       \_ postgres: checkpointer
	     |       \_ postgres: background writer
	     |       \_ postgres: stats collector
	     |       \_ postgres: walreceiver streaming 0/305FB48
	     \_ pg_autoctl: node active
	     \_ pg_autoctl: pgbouncer manager
	         \_ pgbouncer config.ini


The top-level pg_autoctl process needs not to know about the pgbouncer
process. It only needs to know about the 'pgbouncer manager' process. This
is equivelant with relation between top level pg_autoctl,  'start/stop
postgres' and postgres itself.

***Pgbouncer manager***

This service is responsible for starting,stoping,pausing and resuming
pgbouncer. Also, it listens to notifications from the monitor node regarding
the state of the nodes and upon a state change, it pauses pgbouncer, updates
its running configuration (more about configuration in the section
'Configuration') and finally resumes pgbouncer.

The service will exit either when asked to from the top-level pg_autoctl
process, or if pgbouncer fails. It is the top level's process responsibility
to restart the pgbouncer manager.

***Keeper***

Intentionally, keeper does not track any state regarding both pgbouncer
manager and pgbouncer itself. The rationale for it, is that pgbouncer
should be considered a 'best effort' service. One should explicitly point
that the service is required on every startup. If pgbouncer fails, one
should not lose failover requirements of the database. Of course, one can
enable/disable the pgbouncer service when one wishes.

**Configuration**

Pgbouncer is heavily configuration based. It is that no command line
arguments will be used and everything will be explicitly written in the
configuration file that is finally passed as an argument to pgbouncer.

When the user of pg_autoctl requires a pgbouncer service, then she has to
point to a pgbouncer configuration file. At that point, pg_autoctl takes control
of the configuration. It will only read the 'user' and 'pgbouncer' sections and
ignore the 'database' section. Also, it will not read all the keys from those
two sections, because the pgbouncer set up has to match the set up of the nodes.

Once the keys are read, then they are written to a special template file
handled by pg_autoctl entirely. Any keys that are known to point to files, will
be parsed and the contents of said files will be copied over to our template
directory. Whenever a pgbouncer process needs to read the configuration, the
template file will be copied over to a special run time configuration file. Then
any run time keys will be added, eg. logfile location, pid file location, etc,
along with the database section.

The database section contains a single entry only, pointing to the
currently running primary node.

All configuration file management is implemented following the XDG Base
Directory specification. See the structure ConfigFilePaths and
pgbouncer_config{.c,.h} for details.

Intentionally no template files are cleaned up at process exit. The same
applies for the runtime files although the last is more for debugging purposes
at the moment and should be addressed in the future.

***Implementation detail***

Given the extent of the configuration options of pgbouncer, the
structure that is holding all that info is best to not be kept in the stack. We
are not responsible for validation of the options, yet it is easier to map the
type of the options to either strings or integers. Since the ini api used in
pg_auto_failover codebase initializes integer values to -1, a section has been
added to skip integer keys with that value when writing ini files. In retrospect
having -1 as the default value seems not a great choice as it is not uncommon
for -1 to mean "explicitly disable something" as opposed to "use default value".
It might be better to use INT_MIN for the default initializer of integers and
skip that value if needed.

NOTE: At this point, not all keys are handled (e.g. ssl, auth_type etc) in order
to get the full picture first straight before adding those trivial issues.

**Supervisor**

It was desired to use the already extensive supervisor infrastructure of
pg_autoctl to run the pgbouncer manager process under. It was also desired to be
able to start or stop the pbouncer manager process without affecting any other
running core services, such as the database. Also, it was desired for the keeper
service to not track any state regarding pgbouncer, because as explained above,
a failing pgbouncer should not lead to any node stop.

For this, a new concept of 'enabled' and 'enableable' service is added. The
supervisor can include services that can be enabled during startup or at any
other point after the startup. Struct Service is expanded with two new members,
'enabled' to denote the current running state of service which defaults to yes,
and 'canDisable' to denote if we can ever disable that service which defaults to
'no'. See supervisor.h for details. When Service is declared with the
'canDisable' flag to 'true' it is possible to enable it or disable it.

Two new signals have been added to handle 'enable' and 'disable' cases,
'USR1' and 'USR2' respectively. Upon receipt of an 'enable' signal, the
supervisor goes round its services ring and looks for services that can be
enabled, if found, it's start_service function is called and on successfull
completion the service is marked as enabled. Upon receipt of a 'disable' signal,
the supervisor goes round its services ring and looks for enabled services that
can be disabled, if found then the supervisor sends the stop service signal to
it and marks it as 'disabled'.

A service that is marked as 'canDisable', can also have any policy defined.
If an enabled service fails the supervisor fails to restart it in case it is
permanent, the supervisor should not stop all the other services running.

For pgbouncer manager, the policy is set as PERMANENT as it is desired for
the service to keep running as long as possible.

**Enable/Disable**

It follows that `pg_autoctl [enable|disable] pgbouncer [options]` can be
implemented simply by writing the configuration template and signaling the
running node to enable or disable its services. If the command was 'enable', it
would be preferable and trivial to issue a 'select 1' command to pgbouncer to
ensure that it came up. This is left for a subsequent commit.

**Signaling**

At this point, the communication between pgbouncer manager and pgbouncer is
happening with signals. It will be preferable for this communication to happen
using psql commands. It is rather trivial but it adds quite a bit to the already
large diff footprint. For this, it is left for a subsequent commit.

If a more fine-grained control over which services are enabled (since now is
start everything/stop everything implementation) is desired, then signalling is
not the way to go. It is acceptable for now that only one such service exists.
