### PR TITLE
Implement pg_autoctl do azure commands.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,12 +150,17 @@ cluster: install
          --sync-standbys $(NODES_SYNC_SB) \
          --layout $(TMUX_LAYOUT)
 
+
 azcluster: all
 	$(PG_AUTOCTL) do azure create         \
          --prefix $(AZURE_PREFIX)         \
          --region $(AZURE_REGION)         \
          --location $(AZURE_LOCATION)     \
          --nodes $(NODES)
+
+# make azcluster has been done before, just re-attach
+az: all
+	$(PG_AUTOCTL) do azure tmux session
 
 azdrop: all
 	$(PG_AUTOCTL) do azure drop
@@ -165,4 +170,4 @@ azdrop: all
 .PHONY: bin clean-bin install-bin
 .PHONY: build-test run-test
 .PHONY: tmux-clean cluster
-.PHONY: azcluster azdrop
+.PHONY: azcluster azdrop az

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,10 @@ TMUX_LAYOUT ?= even-vertical	# could be "tiled"
 TMUX_TOP_DIR = ./tmux
 TMUX_SCRIPT = ./tmux/script-$(FIRST_PGPORT).tmux
 
+AZURE_PREFIX ?= ha-demo-$(shell whoami)
+AZURE_REGION ?= paris
+AZURE_LOCATION ?= francecentral
+
 all: monitor bin ;
 
 install: install-monitor install-bin ;
@@ -133,8 +137,19 @@ cluster: install
          --sync-standbys $(NODES_SYNC_SB) \
          --layout $(TMUX_LAYOUT)
 
+azcluster: all
+	$(PG_AUTOCTL) do azure create         \
+         --prefix $(AZURE_PREFIX)         \
+         --region $(AZURE_REGION)         \
+         --location $(AZURE_LOCATION)     \
+         --nodes $(NODES)
+
+azdrop: all
+	$(PG_AUTOCTL) do azure drop
+
 .PHONY: all clean check install docs
 .PHONY: monitor clean-monitor check-monitor install-monitor
 .PHONY: bin clean-bin install-bin
 .PHONY: build-test run-test
 .PHONY: tmux-clean cluster
+.PHONY: azcluster azdrop

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,19 @@ AZURE_PREFIX ?= ha-demo-$(shell whoami)
 AZURE_REGION ?= paris
 AZURE_LOCATION ?= francecentral
 
+# Pick a version of Postgres and pg_auto_failover packages to install
+# in our target Azure VMs when provisionning
+#
+#  sudo apt-get install -q -y postgresql-13-auto-failover-1.4=1.4.1
+#  postgresql-${AZ_PG_VERSION}-auto-failover-${AZ_PGAF_DEB_VERSION}=${AZ_PGAF_VERSION}
+AZ_PG_VERSION ?= 13
+AZ_PGAF_VERSION ?= 1.4.1
+AZ_PGAF_DEB_VERSION ?= 1.4
+
+export AZURE_PG_VERSION
+export AZURE_PGAF_VERSION
+export AZURE_PGAF_DEB_VERSION
+
 all: monitor bin ;
 
 install: install-monitor install-bin ;

--- a/Makefile
+++ b/Makefile
@@ -46,12 +46,12 @@ AZURE_LOCATION ?= francecentral
 #  sudo apt-get install -q -y postgresql-13-auto-failover-1.4=1.4.1
 #  postgresql-${AZ_PG_VERSION}-auto-failover-${AZ_PGAF_DEB_VERSION}=${AZ_PGAF_VERSION}
 AZ_PG_VERSION ?= 13
-AZ_PGAF_VERSION ?= 1.4.1
 AZ_PGAF_DEB_VERSION ?= 1.4
+AZ_PGAF_DEB_REVISION ?= 1.4.1-1
 
-export AZURE_PG_VERSION
-export AZURE_PGAF_VERSION
-export AZURE_PGAF_DEB_VERSION
+export AZ_PG_VERSION
+export AZ_PGAF_DEB_VERSION
+export AZ_PGAF_DEB_REVISION
 
 all: monitor bin ;
 

--- a/src/bin/pg_autoctl/azure.c
+++ b/src/bin/pg_autoctl/azure.c
@@ -100,9 +100,9 @@ log_program_output(Program *prog, int outLogLevel, int errorLogLevel)
 
 
 /*
- * run_az_command runs a command line using the azure CLI command, and when
- * azureScript is true instead of running the command it only shows the command
- * it would run as the output of the pg_autoctl command.
+ * azure_run_command runs a command line using the azure CLI command, and when
+ * dryRun is true instead of running the command it only shows the command it
+ * would run as the output of the pg_autoctl command.
  */
 static int
 azure_run_command(Program *program)

--- a/src/bin/pg_autoctl/azure.c
+++ b/src/bin/pg_autoctl/azure.c
@@ -589,6 +589,33 @@ azure_create_subnet(const char *group,
 
 
 /*
+ * az_group_delete runs the command az group delete.
+ */
+bool
+az_group_delete(const char *group)
+{
+	char *args[16];
+	int argsIndex = 0;
+
+	Program program;
+
+	args[argsIndex++] = azureCLI;
+	args[argsIndex++] = "group";
+	args[argsIndex++] = "delete";
+	args[argsIndex++] = "--name";
+	args[argsIndex++] = (char *) group;
+	args[argsIndex++] = "--yes";
+	args[argsIndex++] = NULL;
+
+	program = initialize_program(args, false);
+
+	log_info("Deleting azure resource group \"%s\"", group);
+
+	return azure_run_command(&program) == 0;
+}
+
+
+/*
  * azure_prepare_node_name is a utility function that prepares a node name to
  * use for a VM in our pg_auto_failover deployment in a target Azure region.
  *
@@ -1927,6 +1954,16 @@ azure_create_region(AzureRegionResources *azRegion)
 	 * Now is time to create the virtual machines.
 	 */
 	return azure_provision_nodes(azRegion);
+}
+
+
+/*
+ * azure_drop_region runs the command az group delete --name ... --yes
+ */
+bool
+azure_drop_region(AzureRegionResources *azRegion)
+{
+	return az_group_delete(azRegion->group);
 }
 
 

--- a/src/bin/pg_autoctl/azure.c
+++ b/src/bin/pg_autoctl/azure.c
@@ -1134,7 +1134,7 @@ azure_build_pg_autoctl(AzureRegionResources *azRegion)
  *   AZ_PGAF_DEB_VERSION ?= 1.4
  *   AZ_PGAF_DEB_REVISION ?= 1.4.1-1
  */
-static bool
+bool
 azure_prepare_target_versions(KeyVal *env)
 {
 	char *keywords[] = {

--- a/src/bin/pg_autoctl/azure.c
+++ b/src/bin/pg_autoctl/azure.c
@@ -1131,14 +1131,14 @@ azure_build_pg_autoctl(AzureRegionResources *azRegion)
  * environment variables:
  *
  *   AZ_PG_VERSION ?= 13
- *   AZ_PGAF_VERSION ?= 1.4.1
  *   AZ_PGAF_DEB_VERSION ?= 1.4
+ *   AZ_PGAF_DEB_REVISION ?= 1.4.1-1
  */
 static bool
 azure_prepare_target_versions(KeyVal *env)
 {
 	char *keywords[] = {
-		"AZ_PG_VERSION", "AZ_PGAF_VERSION", "AZ_PGAF_DEB_VERSION"
+		"AZ_PG_VERSION", "AZ_PGAF_DEB_VERSION", "AZ_PGAF_DEB_REVISION"
 	};
 
 	/* set our static set of 3 variables from the environment */
@@ -1146,8 +1146,8 @@ azure_prepare_target_versions(KeyVal *env)
 
 	/* default values */
 	sformat(env->values[0], MAXCONNINFO, "13");   /* AZ_PG_VERSION */
-	sformat(env->values[1], MAXCONNINFO, "1.4.1"); /* AZ_PGAF_VERSION */
-	sformat(env->values[2], MAXCONNINFO, "1.4");      /* AZ_PGAF_DEB_VERSION */
+	sformat(env->values[1], MAXCONNINFO, "1.4"); /* AZ_PGAF_DEB_VERSION */
+	sformat(env->values[2], MAXCONNINFO, "1.4.1-1"); /* AZ_PGAF_DEB_REVISION */
 
 	for (int i = 0; i < 3; i++)
 	{
@@ -1173,7 +1173,7 @@ azure_prepare_target_versions(KeyVal *env)
  * azure_prepare_debian_command prepares the debian command to install our
  * target pg_auto_failover package on the Azure VMs.
  *
- *   sudo apt-get install -q -y postgresql-13-auto-failover-1.4=1.4.1
+ *   sudo apt-get install -q -y postgresql-13-auto-failover-1.4=1.4.1-1
  *
  * We are using environment variables to fill in the actual version numbers,
  * and we hard-code some defaults in case the environment has not be provided
@@ -1194,8 +1194,8 @@ azure_prepare_debian_install_command(char *command, size_t size)
 	sformat(command, size,
 			"sudo apt-get install -q -y postgresql-%s-auto-failover-%s=%s",
 			env.values[0],      /* AZ_PG_VERSION */
-			env.values[2],      /* AZ_PGAF_DEB_VERSION */
-			env.values[1]);     /* AZ_PGAF_VERSION */
+			env.values[1],      /* AZ_PGAF_DEB_VERSION */
+			env.values[2]);     /* AZ_PGAF_DEB_REVISION */
 
 	return true;
 }

--- a/src/bin/pg_autoctl/azure.c
+++ b/src/bin/pg_autoctl/azure.c
@@ -1,0 +1,2299 @@
+/*
+ * src/bin/pg_autoctl/azure.c
+ *     Implementation of a CLI which lets you call `az` cli commands to prepare
+ *     a pg_auto_failover demo or QA environment.
+ *
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the PostgreSQL License.
+ *
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <getopt.h>
+#include <inttypes.h>
+#include <termios.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "postgres_fe.h"
+#include "pqexpbuffer.h"
+#include "snprintf.h"
+
+#include "azure.h"
+#include "cli_common.h"
+#include "cli_do_root.h"
+#include "cli_root.h"
+#include "commandline.h"
+#include "config.h"
+#include "env_utils.h"
+#include "log.h"
+#include "pidfile.h"
+#include "signals.h"
+#include "string_utils.h"
+
+#include "runprogram.h"
+
+char azureCLI[MAXPGPATH] = { 0 };
+
+static void azure_prepare_region(const char *prefix, const char *region,
+								 bool monitor, bool appNode, int nodes,
+								 AzureRegionResources *azRegion);
+
+static int azure_run_command(Program *program);
+static pid_t azure_start_command(Program *program);
+static bool azure_wait_for_commands(int count, pid_t pidArray[]);
+
+static bool run_ssh(const char *username, const char *ip);
+
+static bool run_ssh_command(const char *username,
+							const char *ip,
+							bool tty,
+							const char *command);
+
+static bool start_ssh_command(const char *username,
+							  const char *ip,
+							  const char *command);
+
+static bool azure_git_toplevel(char *srcDir, size_t size);
+
+static bool start_rsync_command(const char *username,
+								const char *ip,
+								const char *srcDir);
+
+static bool azure_fetch_ip_addresses(const char *group,
+									 AzureVMipAddresses *vmArray);
+
+static bool azure_rsync_vms(AzureRegionResources *azRegion);
+
+static bool azure_fetch_resource_list(const char *group,
+									  AzureRegionResources *azRegion);
+
+static bool azure_fetch_vm_addresses(const char *group, const char *vm,
+									 AzureVMipAddresses *addresses);
+
+
+/* log_program_output logs the output of the given program. */
+static void
+log_program_output(Program *prog, int outLogLevel, int errorLogLevel)
+{
+	if (prog->stdOut != NULL)
+	{
+		char *outLines[BUFSIZE];
+		int lineCount = splitLines(prog->stdOut, outLines, BUFSIZE);
+		int lineNumber = 0;
+
+		for (lineNumber = 0; lineNumber < lineCount; lineNumber++)
+		{
+			log_level(outLogLevel, "%s", outLines[lineNumber]);
+		}
+	}
+
+	if (prog->stdErr != NULL)
+	{
+		char *errorLines[BUFSIZE];
+		int lineCount = splitLines(prog->stdErr, errorLines, BUFSIZE);
+		int lineNumber = 0;
+
+		for (lineNumber = 0; lineNumber < lineCount; lineNumber++)
+		{
+			log_level(errorLogLevel, "%s", errorLines[lineNumber]);
+		}
+	}
+}
+
+
+/*
+ * run_az_command runs a command line using the azure CLI command, and when
+ * azureScript is true instead of running the command it only shows the command
+ * it would run as the output of the pg_autoctl command.
+ */
+static int
+azure_run_command(Program *program)
+{
+	int returnCode;
+	char command[BUFSIZE] = { 0 };
+
+	(void) snprintf_program_command_line(program, command, sizeof(command));
+
+	if (dryRun)
+	{
+		appendPQExpBuffer(azureScript, "\n%s", command);
+
+		/* fake successful execution */
+		return 0;
+	}
+
+	log_debug("%s", command);
+
+	(void) execute_subprogram(program);
+
+	returnCode = program->returnCode;
+
+	if (returnCode != 0)
+	{
+		(void) log_program_output(program, LOG_INFO, LOG_ERROR);
+	}
+
+	free_program(program);
+
+	return returnCode;
+}
+
+
+/*
+ * azure_start_command starts a command in the background, as a subprocess of
+ * the current process, and returns the sub-process pid as soon as the
+ * sub-process is started. It's the responsibility of the caller to then
+ * implement waitpid() on the returned pid.
+ *
+ * This allows running several commands in parallel, as in the shell sequence:
+ *
+ *   $ az vm create &
+ *   $ az vm create &
+ *   $ az vm create &
+ *   $ wait
+ */
+static pid_t
+azure_start_command(Program *program)
+{
+	pid_t fpid;
+	char command[BUFSIZE] = { 0 };
+
+	IntString semIdString = intToString(log_semaphore.semId);
+
+	(void) snprintf_program_command_line(program, command, sizeof(command));
+
+	if (dryRun)
+	{
+		appendPQExpBuffer(azureScript, "\n%s &", command);
+
+		/* fake successful execution */
+		return 0;
+	}
+
+	log_debug("%s", command);
+
+	/* Flush stdio channels just before fork, to avoid double-output problems */
+	fflush(stdout);
+	fflush(stderr);
+
+	/* we want to use the same logs semaphore in the sub-processes */
+	setenv(PG_AUTOCTL_LOG_SEMAPHORE, semIdString.strValue, 1);
+
+	/* time to create the node_active sub-process */
+	fpid = fork();
+
+	switch (fpid)
+	{
+		case -1:
+		{
+			log_error("Failed to fork a process for command: %s", command);
+			return -1;
+		}
+
+		case 0:
+		{
+			/* child process runs the command */
+			int returnCode;
+
+			/* initialize the semaphore used for locking log output */
+			if (!semaphore_init(&log_semaphore))
+			{
+				exit(EXIT_CODE_INTERNAL_ERROR);
+			}
+
+			/* set our logging facility to use our semaphore as a lock */
+			(void) log_set_udata(&log_semaphore);
+			(void) log_set_lock(&semaphore_log_lock_function);
+
+			(void) execute_subprogram(program);
+			returnCode = program->returnCode;
+
+			log_debug("Command %s exited with return code %d",
+					  program->args[0],
+					  returnCode);
+
+			if (returnCode != 0)
+			{
+				(void) log_program_output(program, LOG_INFO, LOG_ERROR);
+				free_program(program);
+
+				/* the parent will have to use exit status */
+				(void) semaphore_finish(&log_semaphore);
+				exit(EXIT_CODE_INTERNAL_ERROR);
+			}
+
+			free_program(program);
+			(void) semaphore_finish(&log_semaphore);
+			exit(EXIT_CODE_QUIT);
+		}
+
+		default:
+		{
+			/* fork succeeded, in parent */
+			return fpid;
+		}
+	}
+}
+
+
+/*
+ * azure_wait_for_commands waits until all processes with pids from the array
+ * are done.
+ */
+static bool
+azure_wait_for_commands(int count, pid_t pidArray[])
+{
+	int subprocessCount = count;
+	bool allReturnCodeAreZero = true;
+
+	while (subprocessCount > 0)
+	{
+		pid_t pid;
+		int status;
+
+		/* ignore errors */
+		pid = waitpid(-1, &status, WNOHANG);
+
+		switch (pid)
+		{
+			case -1:
+			{
+				if (errno == ECHILD)
+				{
+					/* no more childrens */
+					return subprocessCount == 0;
+				}
+
+				pg_usleep(100 * 1000); /* 100 ms */
+				break;
+			}
+
+			case 0:
+			{
+				/*
+				 * We're using WNOHANG, 0 means there are no stopped or
+				 * exited children, it's all good. It's the expected case
+				 * when everything is running smoothly, so enjoy and sleep
+				 * for awhile.
+				 */
+				pg_usleep(100 * 1000); /* 100 ms */
+				break;
+			}
+
+			default:
+			{
+				/*
+				 * One of the az vm create sub-commands has finished, find
+				 * which and if it went all okay.
+				 */
+				int returnCode = WEXITSTATUS(status);
+
+				/* find which VM is done now */
+				for (int index = 0; index < count; index++)
+				{
+					if (pidArray[index] == pid)
+					{
+						if (returnCode == 0)
+						{
+							log_debug("Process %d exited successfully",
+									  pid);
+						}
+						else
+						{
+							log_error("Process %d exited with code %d",
+									  pid, returnCode);
+
+							allReturnCodeAreZero = false;
+						}
+					}
+				}
+
+				--subprocessCount;
+				break;
+			}
+		}
+	}
+
+	return allReturnCodeAreZero;
+}
+
+
+/*
+ * azure_psleep runs count parallel sleep process at the same time.
+ */
+bool
+azure_psleep(int count, bool force)
+{
+	char sleep[MAXPGPATH] = { 0 };
+	pid_t pidArray[26] = { 0 };
+
+	bool saveDryRun = dryRun;
+
+	if (!search_path_first("sleep", sleep, LOG_ERROR))
+	{
+		log_fatal("Failed to find program sleep in PATH");
+		return false;
+	}
+
+	if (force)
+	{
+		dryRun = false;
+	}
+
+	for (int i = 0; i < count; i++)
+	{
+		char *args[3];
+		int argsIndex = 0;
+
+		Program program;
+
+		args[argsIndex++] = sleep;
+		args[argsIndex++] = "5";
+		args[argsIndex++] = NULL;
+
+		program = initialize_program(args, false);
+
+		pidArray[i] = azure_start_command(&program);
+	}
+
+	if (force)
+	{
+		dryRun = saveDryRun;
+	}
+
+	if (!azure_wait_for_commands(count, pidArray))
+	{
+		log_fatal("Failed to sleep concurrently with %d processes", count);
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * azure_get_remote_ip gets the local IP address by using the command `curl
+ * ifconfig.me`
+ */
+bool
+azure_get_remote_ip(char *ipAddress, size_t ipAddressSize)
+{
+	Program program;
+	char curl[MAXPGPATH] = { 0 };
+
+	if (!search_path_first("curl", curl, LOG_ERROR))
+	{
+		log_fatal("Failed to find program curl in PATH");
+		return false;
+	}
+
+	program = run_program(curl, "ifconfig.me", NULL);
+
+	if (program.returnCode != 0)
+	{
+		(void) log_program_output(&program, LOG_INFO, LOG_ERROR);
+		free_program(&program);
+		return false;
+	}
+	else
+	{
+		/* we expect a single line of output, no end-of-line */
+		strlcpy(ipAddress, program.stdOut, ipAddressSize);
+		free_program(&program);
+
+		return true;
+	}
+}
+
+
+/*
+ * azure_create_group creates a new resource group on Azure.
+ */
+bool
+azure_create_group(const char *name, const char *location)
+{
+	char *args[16];
+	int argsIndex = 0;
+
+	Program program;
+
+	args[argsIndex++] = azureCLI;
+	args[argsIndex++] = "group";
+	args[argsIndex++] = "create";
+	args[argsIndex++] = "--name";
+	args[argsIndex++] = (char *) name;
+	args[argsIndex++] = "--location";
+	args[argsIndex++] = (char *) location;
+	args[argsIndex++] = NULL;
+
+	program = initialize_program(args, false);
+
+	log_info("Creating group \"%s\" in location \"%s\"", name, location);
+
+	return azure_run_command(&program) == 0;
+}
+
+
+/*
+ * azure_create_vnet creates a new vnet on Azure.
+ */
+bool
+azure_create_vnet(const char *group, const char *name, const char *prefix)
+{
+	char *args[16];
+	int argsIndex = 0;
+
+	Program program;
+
+	args[argsIndex++] = azureCLI;
+	args[argsIndex++] = "network";
+	args[argsIndex++] = "vnet";
+	args[argsIndex++] = "create";
+	args[argsIndex++] = "--resource-group";
+	args[argsIndex++] = (char *) group;
+	args[argsIndex++] = "--name";
+	args[argsIndex++] = (char *) name;
+	args[argsIndex++] = "--address-prefix";
+	args[argsIndex++] = (char *) prefix;
+	args[argsIndex++] = NULL;
+
+	program = initialize_program(args, false);
+
+	log_info("Creating network vnet \"%s\" using address prefix \"%s\"",
+			 name, prefix);
+
+	return azure_run_command(&program) == 0;
+}
+
+
+/*
+ * azure_create_vnet creates a new vnet on Azure.
+ */
+bool
+azure_create_nsg(const char *group, const char *name)
+{
+	char *args[16];
+	int argsIndex = 0;
+
+	Program program;
+
+	args[argsIndex++] = azureCLI;
+	args[argsIndex++] = "network";
+	args[argsIndex++] = "nsg";
+	args[argsIndex++] = "create";
+	args[argsIndex++] = "--resource-group";
+	args[argsIndex++] = (char *) group;
+	args[argsIndex++] = "--name";
+	args[argsIndex++] = (char *) name;
+	args[argsIndex++] = NULL;
+
+	program = initialize_program(args, false);
+
+	log_info("Creating network nsg \"%s\"", name);
+
+	return azure_run_command(&program) == 0;
+}
+
+
+/*
+ * azure_create_vnet creates a new network security rule.
+ */
+bool
+azure_create_nsg_rule(const char *group,
+					  const char *nsgName,
+					  const char *name,
+					  const char *ipAddress)
+{
+	char *args[38];
+	int argsIndex = 0;
+
+	Program program;
+
+	args[argsIndex++] = azureCLI;
+	args[argsIndex++] = "network";
+	args[argsIndex++] = "nsg";
+	args[argsIndex++] = "rule";
+	args[argsIndex++] = "create";
+	args[argsIndex++] = "--resource-group";
+	args[argsIndex++] = (char *) group;
+	args[argsIndex++] = "--nsg-name";
+	args[argsIndex++] = (char *) nsgName;
+	args[argsIndex++] = "--name";
+	args[argsIndex++] = (char *) name;
+	args[argsIndex++] = "--access";
+	args[argsIndex++] = "allow";
+	args[argsIndex++] = "--protocol";
+	args[argsIndex++] = "Tcp";
+	args[argsIndex++] = "--direction";
+	args[argsIndex++] = "Inbound";
+	args[argsIndex++] = "--priority";
+	args[argsIndex++] = "100";
+	args[argsIndex++] = "--source-address-prefixes";
+	args[argsIndex++] = (char *) ipAddress;
+	args[argsIndex++] = "--source-port-range";
+	args[argsIndex++] = dryRun ? "\"*\"" : "*";
+	args[argsIndex++] = "--destination-address-prefix";
+	args[argsIndex++] = dryRun ? "\"*\"" : "*";
+	args[argsIndex++] = "--destination-port-ranges";
+	args[argsIndex++] = "22";
+	args[argsIndex++] = "5432";
+	args[argsIndex++] = NULL;
+
+	program = initialize_program(args, false);
+
+	log_info("Creating network nsg rules \"%s\" for our IP address \"%s\" "
+			 "for ports 22 and 5432", name, ipAddress);
+
+	return azure_run_command(&program) == 0;
+}
+
+
+/*
+ * azure_create_subnet creates a new subnet on Azure.
+ */
+bool
+azure_create_subnet(const char *group,
+					const char *vnet,
+					const char *name,
+					const char *prefixes,
+					const char *nsg)
+{
+	char *args[16];
+	int argsIndex = 0;
+
+	Program program;
+
+	args[argsIndex++] = azureCLI;
+	args[argsIndex++] = "network";
+	args[argsIndex++] = "vnet";
+	args[argsIndex++] = "subnet";
+	args[argsIndex++] = "create";
+	args[argsIndex++] = "--resource-group";
+	args[argsIndex++] = (char *) group;
+	args[argsIndex++] = "--vnet-name";
+	args[argsIndex++] = (char *) vnet;
+	args[argsIndex++] = "--name";
+	args[argsIndex++] = (char *) name;
+	args[argsIndex++] = "--address-prefixes";
+	args[argsIndex++] = (char *) prefixes;
+	args[argsIndex++] = "--network-security-group";
+	args[argsIndex++] = (char *) nsg;
+	args[argsIndex++] = NULL;
+
+	program = initialize_program(args, false);
+
+	log_info("Creating network subnet \"%s\" using address prefix \"%s\"",
+			 name, prefixes);
+
+	return azure_run_command(&program) == 0;
+}
+
+
+/*
+ * azure_prepare_network_names prepares the names we use for the different
+ * Azure network objects that we need: vnet, nsg, nsgrule, subnet.
+ */
+static void
+azure_prepare_region(const char *prefix, const char *region,
+					 bool monitor, bool appNode, int nodes,
+					 AzureRegionResources *azRegion)
+{
+	/*
+	 * First create the resource group in the target location.
+	 */
+	strlcpy(azRegion->prefix, prefix, sizeof(azRegion->prefix));
+	strlcpy(azRegion->region, region, sizeof(azRegion->region));
+	sformat(azRegion->group, sizeof(azRegion->group), "%s-%s", prefix, region);
+
+	/*
+	 * Prepare our Azure object names from the group objects: vnet, subnet,
+	 * nsg, nsg rule.
+	 */
+	sformat(azRegion->vnet, sizeof(azRegion->vnet), "%s-net", azRegion->group);
+	sformat(azRegion->nsg, sizeof(azRegion->nsg), "%s-nsg", azRegion->group);
+
+	sformat(azRegion->rule, sizeof(azRegion->rule),
+			"%s-ssh-and-pg", azRegion->group);
+
+	sformat(azRegion->subnet, sizeof(azRegion->subnet),
+			"%s-subnet", azRegion->group);
+
+	azRegion->monitor = monitor;
+	azRegion->appNode = appNode;
+	azRegion->nodes = nodes;
+}
+
+
+/*
+ * azure_prepare_node_name is a utility function that prepares a node name to
+ * use for a VM in our pg_auto_failover deployment in a target Azure region.
+ *
+ * In the resource group "ha-demo-dim-paris" when creating a monitor (index 0),
+ * an app VM (index 27), and 2 pg nodes VMs we would have the following names:
+ *
+ *   -  [0] ha-demo-dim-paris-monitor
+ *   -  [1] ha-demo-dim-paris-a
+ *   -  [2] ha-demo-dim-paris-b
+ *   - [27] ha-demo-dim-paris-app
+ */
+static void
+azure_prepare_node(AzureRegionResources *azRegion, int index)
+{
+	char vmsuffix[] = "abcdefghijklmnopqrstuvwxyz";
+
+	if (index == 0)
+	{
+		sformat(azRegion->vmArray[index].name,
+				sizeof(azRegion->vmArray[index].name),
+				"%s-monitor",
+				azRegion->group);
+	}
+	else if (index == MAX_VMS_PER_REGION - 1)
+	{
+		sformat(azRegion->vmArray[index].name,
+				sizeof(azRegion->vmArray[index].name),
+				"%s-app",
+				azRegion->group);
+	}
+	else
+	{
+		sformat(azRegion->vmArray[index].name,
+				sizeof(azRegion->vmArray[index].name),
+				"%s-%c",
+				azRegion->group,
+				vmsuffix[index - 1]);
+	}
+}
+
+
+/*
+ * azure_node_index_from_name is the complement to azure_prepare_node.
+ * Given a VM name such as ha-demo-dim-paris-monitor or ha-demo-dim-paris-a,
+ * the function returns respectively 0 and 1, which is the array index where we
+ * want to find information about the VM (name, IP addresses, etc) in an array
+ * of VMs.
+ */
+static int
+azure_node_index_from_name(const char *group, const char *name)
+{
+	int groupNameLen = strlen(group);
+	char *ptr;
+
+	if (strncmp(name, group, groupNameLen) != 0 ||
+		strlen(name) < (groupNameLen + 1))
+	{
+		log_error("VM name \"%s\" does not start with group name \"%s\"",
+				  name, group);
+		return -1;
+	}
+
+	/* skip group name and dash: ha-demo-dim-paris- */
+	ptr = (char *) name + groupNameLen + 1;
+
+	/*
+	 * ha-demo-dim-paris-monitor is always index 0
+	 * ha-demo-dim-paris-app     is always index 27 (last in the array)
+	 * ha-demo-dim-paris-a       is index 1
+	 * ha-demo-dim-paris-b       is index 2
+	 * ...
+	 * ha-demo-dim-paris-z       is index 26
+	 */
+	if (strcmp(ptr, "monitor") == 0)
+	{
+		return 0;
+	}
+	else if (strcmp(ptr, "app") == 0)
+	{
+		return MAX_VMS_PER_REGION - 1;
+	}
+	else
+	{
+		if (strlen(ptr) != 1)
+		{
+			log_error("Failed to parse VM index from name \"%s\"", name);
+			return -1;
+		}
+
+		/* 'a' is 1, 'b' is 2, etc */
+		return *ptr - 'a' + 1;
+	}
+}
+
+
+/*
+ * azure_create_vm creates a Virtual Machine in our azure resource group.
+ */
+bool
+azure_create_vm(AzureRegionResources *azRegion,
+				const char *name,
+				const char *image,
+				const char *username)
+{
+	char *args[26];
+	int argsIndex = 0;
+
+	Program program;
+
+	char publicIpAddressName[BUFSIZE] = { 0 };
+
+	sformat(publicIpAddressName, BUFSIZE, "%s-ip", name);
+
+	args[argsIndex++] = azureCLI;
+	args[argsIndex++] = "vm";
+	args[argsIndex++] = "create";
+	args[argsIndex++] = "--resource-group";
+	args[argsIndex++] = (char *) azRegion->group;
+	args[argsIndex++] = "--name";
+	args[argsIndex++] = (char *) name;
+	args[argsIndex++] = "--vnet-name";
+	args[argsIndex++] = (char *) azRegion->vnet;
+	args[argsIndex++] = "--subnet";
+	args[argsIndex++] = (char *) azRegion->subnet;
+	args[argsIndex++] = "--nsg";
+	args[argsIndex++] = (char *) azRegion->nsg;
+	args[argsIndex++] = "--public-ip-address";
+	args[argsIndex++] = (char *) publicIpAddressName;
+	args[argsIndex++] = "--image";
+	args[argsIndex++] = (char *) image;
+	args[argsIndex++] = "--admin-username";
+	args[argsIndex++] = (char *) username;
+	args[argsIndex++] = "--generate-ssh-keys";
+	args[argsIndex++] = NULL;
+
+	program = initialize_program(args, false);
+
+	log_info("Creating %s virtual machine \"%s\" with user \"%s\"",
+			 image, name, username);
+
+	return azure_start_command(&program);
+}
+
+
+/*
+ * azure_create_vms creates several azure virtual machine in parallel and waits
+ * until all the commands have finished.
+ */
+bool
+azure_create_vms(AzureRegionResources *azRegion,
+				 const char *image,
+				 const char *username)
+{
+	int pending = 0;
+	pid_t pidArray[MAX_VMS_PER_REGION] = { 0 };
+
+	/* we read from left to right, have the smaller number on the left */
+	if (26 < azRegion->nodes)
+	{
+		log_error("pg_autoctl only supports up to 26 VMs per region");
+		return false;
+	}
+
+	log_info("Creating Virtual Machines for %s%d Postgres nodes, in parallel",
+			 azRegion->monitor ? "a monitor and " : " ",
+			 azRegion->nodes);
+
+	/* index == 0 for the monitor, then 1..count for the other nodes */
+	for (int index = 0; index <= azRegion->nodes; index++)
+	{
+		/* skip index 0 when we're not creating a monitor */
+		if (index == 0 && !azRegion->monitor)
+		{
+			continue;
+		}
+
+		/* skip VMs that already exist, unless --script is used */
+		if (!dryRun &&
+			!IS_EMPTY_STRING_BUFFER(azRegion->vmArray[index].name) &&
+			!IS_EMPTY_STRING_BUFFER(azRegion->vmArray[index].public) &&
+			!IS_EMPTY_STRING_BUFFER(azRegion->vmArray[index].private))
+		{
+			log_info("Skipping creation of VM \"%s\", "
+					 "which already exists with public IP address %s",
+					 azRegion->vmArray[index].name,
+					 azRegion->vmArray[index].public);
+			continue;
+		}
+
+		(void) azure_prepare_node(azRegion, index);
+
+		pidArray[index] = azure_create_vm(azRegion,
+										  azRegion->vmArray[index].name,
+										  image,
+										  username);
+		++pending;
+	}
+
+	/* also create the application node VM when asked to */
+	if (azRegion->appNode)
+	{
+		int index = MAX_VMS_PER_REGION - 1;
+
+		if (!dryRun &&
+			!IS_EMPTY_STRING_BUFFER(azRegion->vmArray[index].name) &&
+			!IS_EMPTY_STRING_BUFFER(azRegion->vmArray[index].public) &&
+			!IS_EMPTY_STRING_BUFFER(azRegion->vmArray[index].private))
+		{
+			log_info("Skipping creation of VM \"%s\", "
+					 "which already exists with public IP address %s",
+					 azRegion->vmArray[index].name,
+					 azRegion->vmArray[index].public);
+		}
+		else
+		{
+			(void) azure_prepare_node(azRegion, index);
+
+			pidArray[index] = azure_create_vm(azRegion,
+											  azRegion->vmArray[index].name,
+											  image,
+											  username);
+			++pending;
+		}
+	}
+
+	/* now wait for the child processes to be done */
+	if (dryRun && pending > 0)
+	{
+		appendPQExpBuffer(azureScript, "\nwait");
+	}
+	else
+	{
+		if (!azure_wait_for_commands(pending, pidArray))
+		{
+			log_fatal("Failed to create all %d azure VMs, "
+					  "see above for details",
+					  pending);
+			return false;
+		}
+	}
+
+	return true;
+}
+
+
+/*
+ * azure_git_toplevel calls `git rev-parse --show-toplevel` and uses the result
+ * as the directory to rsync to our VMs when provisionning from sources.
+ */
+static bool
+azure_git_toplevel(char *srcDir, size_t size)
+{
+	Program program;
+	char git[MAXPGPATH] = { 0 };
+
+	if (!search_path_first("git", git, LOG_ERROR))
+	{
+		log_fatal("Failed to find program git in PATH");
+		return false;
+	}
+
+	program = run_program(git, "rev-parse", "--show-toplevel", NULL);
+
+	if (program.returnCode != 0)
+	{
+		(void) log_program_output(&program, LOG_INFO, LOG_ERROR);
+		free_program(&program);
+		return false;
+	}
+	else
+	{
+		char *outLines[BUFSIZE];
+
+		/* git rev-parse --show-toplevel outputs a single line */
+		splitLines(program.stdOut, outLines, BUFSIZE);
+		strlcpy(srcDir, outLines[0], size);
+
+		free_program(&program);
+
+		return true;
+	}
+}
+
+
+/*
+ * start_rsync_command is used to sync our local source directory with a remote
+ * place on a target VM.
+ */
+static bool
+start_rsync_command(const char *username,
+					const char *ip,
+					const char *srcDir)
+{
+	char *args[16];
+	int argsIndex = 0;
+
+	Program program;
+
+	char ssh[MAXPGPATH] = { 0 };
+	char essh[MAXPGPATH] = { 0 };
+	char rsync[MAXPGPATH] = { 0 };
+	char sourceDir[MAXPGPATH] = { 0 };
+	char rsync_remote[MAXPGPATH] = { 0 };
+
+	if (!search_path_first("rsync", rsync, LOG_ERROR))
+	{
+		log_fatal("Failed to find program rsync in PATH");
+		return false;
+	}
+
+	if (!search_path_first("ssh", ssh, LOG_ERROR))
+	{
+		log_fatal("Failed to find program ssh in PATH");
+		return false;
+	}
+
+	/* use our usual ssh options even when using it through rsync */
+	sformat(essh, sizeof(essh),
+			"%s -o '%s' -o '%s' -o '%s'",
+			ssh,
+			"StrictHostKeyChecking=no",
+			"UserKnownHostsFile /dev/null",
+			"LogLevel=quiet");
+
+	/* we need the rsync remote as one string */
+	sformat(rsync_remote, sizeof(rsync_remote),
+			"%s@%s:/home/%s/pg_auto_failover/",
+			username, ip, username);
+
+	/* we need to ensure that the source directory terminates with a "/" */
+	if (strcmp(strrchr(srcDir, '/'), "/") != 0)
+	{
+		sformat(sourceDir, sizeof(sourceDir), "%s/", srcDir);
+	}
+	else
+	{
+		strlcpy(sourceDir, srcDir, sizeof(sourceDir));
+	}
+
+	args[argsIndex++] = rsync;
+	args[argsIndex++] = "-a";
+	args[argsIndex++] = "-e";
+	args[argsIndex++] = essh;
+	args[argsIndex++] = "--exclude='.git'";
+	args[argsIndex++] = "--exclude='*.o'";
+	args[argsIndex++] = "--exclude='*.deps'";
+	args[argsIndex++] = "--exclude='./src/bin/pg_autoctl/pg_autoctl'";
+	args[argsIndex++] = sourceDir;
+	args[argsIndex++] = rsync_remote;
+	args[argsIndex++] = NULL;
+
+	program = initialize_program(args, false);
+
+	return azure_start_command(&program);
+}
+
+
+/*
+ * azure_rsync_vms runs the rsync command for target VMs in parallel.
+ */
+static bool
+azure_rsync_vms(AzureRegionResources *azRegion)
+{
+	int pending = 0;
+	pid_t pidArray[MAX_VMS_PER_REGION] = { 0 };
+
+	char srcDir[MAXPGPATH] = { 0 };
+
+	if (!azure_git_toplevel(srcDir, sizeof(srcDir)))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	log_info("Syncing local directory \"%s\" to %d Azure VMs",
+			 srcDir,
+			 azRegion->nodes +
+			 (azRegion->monitor ? 1 : 0) +
+			 (azRegion->appNode ? 1 : 0));
+
+	/* index == 0 for the monitor, then 1..count for the other nodes */
+	for (int index = 0; index <= azRegion->nodes; index++)
+	{
+		/* skip index 0 when we're not creating a monitor */
+		if (index == 0 && !azRegion->monitor)
+		{
+			continue;
+		}
+
+		(void) azure_prepare_node(azRegion, index);
+
+		pidArray[index] =
+			start_rsync_command("ha-admin",
+								azRegion->vmArray[index].public,
+								srcDir);
+
+		++pending;
+	}
+
+	/* also provision the application node VM when asked to */
+	if (azRegion->appNode)
+	{
+		int index = MAX_VMS_PER_REGION - 1;
+
+		(void) azure_prepare_node(azRegion, index);
+
+		pidArray[index] =
+			start_rsync_command("ha-admin",
+								azRegion->vmArray[index].public,
+								srcDir);
+
+		++pending;
+	}
+
+	/* now wait for the child processes to be done */
+	if (dryRun)
+	{
+		appendPQExpBuffer(azureScript, "\nwait");
+	}
+	else
+	{
+		if (!azure_wait_for_commands(pending, pidArray))
+		{
+			log_fatal("Failed to provision all %d azure VMs, "
+					  "see above for details",
+					  pending);
+			return false;
+		}
+	}
+
+	return true;
+}
+
+
+/*
+ * azure_build_pg_autoctl runs `make all` then `make install` on all the target
+ * VMs in parallel, using an ssh command line.
+ */
+static bool
+azure_build_pg_autoctl(AzureRegionResources *azRegion)
+{
+	int pending = 0;
+	pid_t pidArray[MAX_VMS_PER_REGION] = { 0 };
+
+	char *buildCommand =
+		"make PG_CONFIG=/usr/lib/postgresql/11/bin/pg_config "
+		"-C pg_auto_failover -s clean all "
+		" && "
+		"sudo make PG_CONFIG=/usr/lib/postgresql/11/bin/pg_config "
+		"BINDIR=/usr/local/bin -C pg_auto_failover install";
+
+	log_info("Building pg_auto_failover from sources on %d Azure VMs",
+			 azRegion->nodes +
+			 (azRegion->monitor ? 1 : 0) +
+			 (azRegion->appNode ? 1 : 0));
+
+	log_info("%s", buildCommand);
+
+	/* index == 0 for the monitor, then 1..count for the other nodes */
+	for (int index = 0; index <= azRegion->nodes; index++)
+	{
+		/* skip index 0 when we're not creating a monitor */
+		if (index == 0 && !azRegion->monitor)
+		{
+			continue;
+		}
+
+		(void) azure_prepare_node(azRegion, index);
+
+		pidArray[index] =
+			start_ssh_command("ha-admin",
+							  azRegion->vmArray[index].public,
+							  buildCommand);
+		++pending;
+	}
+
+	/* also provision the application node VM when asked to */
+	if (azRegion->appNode)
+	{
+		int index = MAX_VMS_PER_REGION - 1;
+
+		(void) azure_prepare_node(azRegion, index);
+
+		pidArray[index] =
+			start_ssh_command("ha-admin",
+							  azRegion->vmArray[index].public,
+							  buildCommand);
+		++pending;
+	}
+
+	/* now wait for the child processes to be done */
+	if (dryRun)
+	{
+		appendPQExpBuffer(azureScript, "\nwait");
+	}
+	else
+	{
+		if (!azure_wait_for_commands(pending, pidArray))
+		{
+			log_fatal("Failed to provision all %d azure VMs, "
+					  "see above for details",
+					  pending);
+			return false;
+		}
+	}
+
+	return true;
+}
+
+
+/*
+ * azure_provision_vm runs the command `az vm run-command invoke` with our
+ * provisioning script.
+ */
+bool
+azure_provision_vm(const char *group, const char *name, bool fromSource)
+{
+	char *args[26];
+	int argsIndex = 0;
+
+	Program program;
+
+	const char *scriptsFromPackage[] =
+	{
+		"curl https://install.citusdata.com/community/deb.sh | sudo bash",
+		"sudo apt-get install -q -y postgresql-common",
+		"echo 'create_main_cluster = false' "
+		"| sudo tee -a /etc/postgresql-common/createcluster.conf",
+		"sudo apt-get install -q -y postgresql-11-auto-failover-1.4",
+		"sudo usermod -a -G postgres ha-admin",
+		NULL
+	};
+
+	const char *scriptsFromSource[] =
+	{
+		"curl https://install.citusdata.com/community/deb.sh | sudo bash",
+		"sudo apt-get install -q -y postgresql-common",
+		"echo 'create_main_cluster = false' "
+		"| sudo tee -a /etc/postgresql-common/createcluster.conf",
+		"sudo apt-get build-dep -q -y postgresql-11",
+
+		/* we don't have deb-src for pg_auto_failover packages */
+		"sudo apt-get install -q -y postgresql-server-dev-all libkrb5-dev",
+		"sudo apt-get install -q -y postgresql-11 rsync",
+		"sudo usermod -a -G postgres ha-admin",
+		NULL
+	};
+
+	char **scripts =
+		fromSource ? (char **) scriptsFromSource : (char **) scriptsFromPackage;
+
+	char *quotedScripts[10][BUFSIZE] = { 0 };
+
+	args[argsIndex++] = azureCLI;
+	args[argsIndex++] = "vm";
+	args[argsIndex++] = "run-command";
+	args[argsIndex++] = "invoke";
+	args[argsIndex++] = "--resource-group";
+	args[argsIndex++] = (char *) group;
+	args[argsIndex++] = "--name";
+	args[argsIndex++] = (char *) name;
+	args[argsIndex++] = "--command-id";
+	args[argsIndex++] = "RunShellScript";
+	args[argsIndex++] = "--scripts";
+
+	if (dryRun)
+	{
+		for (int i = 0; scripts[i] != NULL; i++)
+		{
+			sformat((char *) quotedScripts[i], BUFSIZE, "\"%s\"", scripts[i]);
+			args[argsIndex++] = (char *) quotedScripts[i];
+		}
+	}
+	else
+	{
+		for (int i = 0; scripts[i] != NULL; i++)
+		{
+			args[argsIndex++] = (char *) scripts[i];
+		}
+	}
+
+	args[argsIndex++] = NULL;
+
+	program = initialize_program(args, false);
+
+	log_info("Provisioning Virtual Machine \"%s\"", name);
+
+	return azure_start_command(&program);
+}
+
+
+/*
+ * azure_provision_vms provisions several azure virtual machine in parallel and
+ * waits until all the commands have finished.
+ */
+bool
+azure_provision_vms(AzureRegionResources *azRegion, bool fromSource)
+{
+	int pending = 0;
+	pid_t pidArray[MAX_VMS_PER_REGION] = { 0 };
+
+	/* we read from left to right, have the smaller number on the left */
+	if (26 < azRegion->nodes)
+	{
+		log_error("pg_autoctl only supports up to 26 VMs per region");
+		return false;
+	}
+
+	log_info("Provisioning %d Virtual Machines in parallel",
+			 azRegion->nodes +
+			 (azRegion->monitor ? 1 : 0) +
+			 (azRegion->appNode ? 1 : 0));
+
+	/* index == 0 for the monitor, then 1..count for the other nodes */
+	for (int index = 0; index <= azRegion->nodes; index++)
+	{
+		/* skip index 0 when we're not creating a monitor */
+		if (index == 0 && !azRegion->monitor)
+		{
+			continue;
+		}
+
+		(void) azure_prepare_node(azRegion, index);
+
+		pidArray[index] = azure_provision_vm(azRegion->group,
+											 azRegion->vmArray[index].name,
+											 fromSource);
+
+		++pending;
+	}
+
+	/* also provision the application node VM when asked to */
+	if (azRegion->appNode)
+	{
+		int index = MAX_VMS_PER_REGION - 1;
+
+		(void) azure_prepare_node(azRegion, index);
+
+		pidArray[index] = azure_provision_vm(azRegion->group,
+											 azRegion->vmArray[index].name,
+											 fromSource);
+		++pending;
+	}
+
+	/* now wait for the child processes to be done */
+	if (dryRun)
+	{
+		appendPQExpBuffer(azureScript, "\nwait");
+	}
+	else
+	{
+		if (!azure_wait_for_commands(pending, pidArray))
+		{
+			log_fatal("Failed to provision all %d azure VMs, "
+					  "see above for details",
+					  pending);
+			return false;
+		}
+	}
+
+	return true;
+}
+
+
+/*
+ * azure_resource_list runs the command azure resource list.
+ *
+ *  az resource list --output table --query  "[?resourceGroup=='ha-demo-dim-paris'].{ name: name, flavor: kind, resourceType: type, region: location }"
+ */
+bool
+azure_resource_list(const char *group)
+{
+	char *args[16];
+	int argsIndex = 0;
+	bool success = true;
+
+	Program program;
+
+	char query[BUFSIZE] = { 0 };
+
+	char command[BUFSIZE] = { 0 };
+
+	sformat(query, BUFSIZE,
+			"[?resourceGroup=='%s']"
+			".{ name: name, flavor: kind, resourceType: type, region: location }",
+			group);
+
+	args[argsIndex++] = azureCLI;
+	args[argsIndex++] = "resource";
+	args[argsIndex++] = "list";
+	args[argsIndex++] = "--output";
+	args[argsIndex++] = "table";
+	args[argsIndex++] = "--query";
+	args[argsIndex++] = (char *) query;
+	args[argsIndex++] = NULL;
+
+	program = initialize_program(args, false);
+
+	(void) snprintf_program_command_line(&program, command, sizeof(command));
+
+	log_info("%s", command);
+
+	(void) execute_subprogram(&program);
+	success = program.returnCode == 0;
+
+	if (success)
+	{
+		fformat(stdout, "%s", program.stdOut);
+	}
+	else
+	{
+		(void) log_program_output(&program, LOG_INFO, LOG_ERROR);
+	}
+	free_program(&program);
+
+	return success;
+}
+
+
+/*
+ * azure_fetch_resource_list fetches existing resource names for a short list
+ * of known objects in a target azure resource group.
+ */
+static bool
+azure_fetch_resource_list(const char *group, AzureRegionResources *azRegion)
+{
+	char *args[16];
+	int argsIndex = 0;
+	bool success = true;
+
+	Program program;
+
+	char query[BUFSIZE] = { 0 };
+
+	char command[BUFSIZE] = { 0 };
+
+	sformat(query, BUFSIZE,
+			"[?resourceGroup=='%s'].{ name: name, resourceType: type }",
+			group);
+
+	args[argsIndex++] = azureCLI;
+	args[argsIndex++] = "resource";
+	args[argsIndex++] = "list";
+	args[argsIndex++] = "--output";
+	args[argsIndex++] = "json";
+	args[argsIndex++] = "--query";
+	args[argsIndex++] = (char *) query;
+	args[argsIndex++] = NULL;
+
+	program = initialize_program(args, false);
+
+	(void) snprintf_program_command_line(&program, command, sizeof(command));
+
+	log_info("Fetching resources that might already exist from a previous run");
+	log_info("%s", command);
+
+	(void) execute_subprogram(&program);
+	success = program.returnCode == 0;
+
+	if (success)
+	{
+		/* parson insists on having fresh heap allocated memory, apparently */
+		char *jsonString = strdup(program.stdOut);
+		JSON_Value *js = json_parse_string(jsonString);
+		JSON_Array *jsArray = json_value_get_array(js);
+		int count = json_array_get_count(jsArray);
+
+		if (js == NULL)
+		{
+			log_error("Failed to parse JSON string: %s", program.stdOut);
+			return false;
+		}
+
+		log_info("Found %d Azure resources already created in group \"%s\"",
+				 count, group);
+
+		for (int index = 0; index < count; index++)
+		{
+			JSON_Object *jsObj = json_array_get_object(jsArray, index);
+
+			char *name = (char *) json_object_get_string(jsObj, "name");
+			char *type = (char *) json_object_get_string(jsObj, "resourceType");
+
+			if (streq(type, "Microsoft.Network/virtualNetworks"))
+			{
+				strlcpy(azRegion->vnet, name, sizeof(azRegion->vnet));
+
+				log_info("Found existing vnet \"%s\"", azRegion->vnet);
+			}
+			else if (streq(type, "Microsoft.Network/networkSecurityGroups"))
+			{
+				strlcpy(azRegion->nsg, name, sizeof(azRegion->nsg));
+
+				log_info("Found existing nsg \"%s\"", azRegion->nsg);
+			}
+			else if (streq(type, "Microsoft.Compute/virtualMachines"))
+			{
+				int index = azure_node_index_from_name(group, name);
+
+				strlcpy(azRegion->vmArray[index].name, name, NAMEDATALEN);
+
+				log_info("Found existing VM \"%s\"", name);
+			}
+			else
+			{
+				/* ignore the resource Type listed */
+				log_debug("Unknown resource type: \"%s\" with name \"%s\"",
+						  type, name);
+			}
+		}
+
+		free(jsonString);
+	}
+	else
+	{
+		(void) log_program_output(&program, LOG_INFO, LOG_ERROR);
+	}
+	free_program(&program);
+
+	return success;
+}
+
+
+/*
+ * azure_show_ip_addresses shows public and private IP addresses for our list
+ * of nodes created in a specific resource group.
+ *
+ *   az vm list-ip-addresses -g ha-demo-dim-paris --query '[] [] . { name: virtualMachine.name, "public address": virtualMachine.network.publicIpAddresses[0].ipAddress, "private address": virtualMachine.network.privateIpAddresses[0] }' -o table
+ */
+bool
+azure_show_ip_addresses(const char *group)
+{
+	char *args[16];
+	int argsIndex = 0;
+	bool success = true;
+
+	Program program;
+
+	char query[BUFSIZE] = { 0 };
+
+	char command[BUFSIZE] = { 0 };
+
+	sformat(query, BUFSIZE,
+			"[] [] . { name: virtualMachine.name, "
+			"\"public address\": "
+			"virtualMachine.network.publicIpAddresses[0].ipAddress, "
+			"\"private address\": "
+			"virtualMachine.network.privateIpAddresses[0] }");
+
+	args[argsIndex++] = azureCLI;
+	args[argsIndex++] = "vm";
+	args[argsIndex++] = "list-ip-addresses";
+	args[argsIndex++] = "--resource-group";
+	args[argsIndex++] = (char *) group;
+	args[argsIndex++] = "--query";
+	args[argsIndex++] = (char *) query;
+	args[argsIndex++] = "-o";
+	args[argsIndex++] = "table";
+	args[argsIndex++] = NULL;
+
+	program = initialize_program(args, false);
+
+	(void) snprintf_program_command_line(&program, command, sizeof(command));
+
+	log_info("%s", command);
+
+	(void) execute_subprogram(&program);
+	success = program.returnCode == 0;
+
+	if (success)
+	{
+		fformat(stdout, "%s", program.stdOut);
+	}
+	else
+	{
+		(void) log_program_output(&program, LOG_INFO, LOG_ERROR);
+	}
+	free_program(&program);
+
+	return success;
+}
+
+
+/*
+ * azure_fetch_ip_addresses fetches IP address (both public and private) for
+ * VMs created in an Azure resource group, and fill-in the given array.
+ */
+static bool
+azure_fetch_ip_addresses(const char *group, AzureVMipAddresses *vmArray)
+{
+	char *args[16];
+	int argsIndex = 0;
+	bool success = true;
+
+	Program program;
+
+	char query[BUFSIZE] = { 0 };
+
+	char command[BUFSIZE] = { 0 };
+
+	sformat(query, BUFSIZE,
+			"[] [] . { name: virtualMachine.name, "
+			"\"public address\": "
+			"virtualMachine.network.publicIpAddresses[0].ipAddress, "
+			"\"private address\": "
+			"virtualMachine.network.privateIpAddresses[0] }");
+
+	args[argsIndex++] = azureCLI;
+	args[argsIndex++] = "vm";
+	args[argsIndex++] = "list-ip-addresses";
+	args[argsIndex++] = "--resource-group";
+	args[argsIndex++] = (char *) group;
+	args[argsIndex++] = "--query";
+	args[argsIndex++] = (char *) query;
+	args[argsIndex++] = "-o";
+	args[argsIndex++] = "json";
+	args[argsIndex++] = NULL;
+
+	program = initialize_program(args, false);
+
+	(void) snprintf_program_command_line(&program, command, sizeof(command));
+
+	log_info("%s", command);
+
+	(void) execute_subprogram(&program);
+	success = program.returnCode == 0;
+
+	if (success)
+	{
+		JSON_Value *js = json_parse_string(program.stdOut);
+		JSON_Array *jsArray = json_value_get_array(js);
+		int count = json_array_get_count(jsArray);
+
+		for (int index = 0; index < count; index++)
+		{
+			JSON_Object *jsObj = json_array_get_object(jsArray, index);
+			char *str = NULL;
+			int vmIndex = -1;
+
+			str = (char *) json_object_get_string(jsObj, "name");
+
+			vmIndex = azure_node_index_from_name(group, str);
+
+			if (vmIndex == -1)
+			{
+				/* errors have already been logged */
+				return false;
+			}
+
+			strlcpy(vmArray[vmIndex].name, str, NAMEDATALEN);
+
+			str = (char *) json_object_get_string(jsObj, "private address");
+			strlcpy(vmArray[vmIndex].private, str, BUFSIZE);
+
+			str = (char *) json_object_get_string(jsObj, "public address");
+			strlcpy(vmArray[vmIndex].public, str, BUFSIZE);
+
+			log_debug(
+				"Parsed VM %d as \"%s\" with public IP %s and private IP %s",
+				vmIndex,
+				vmArray[vmIndex].name,
+				vmArray[vmIndex].public,
+				vmArray[vmIndex].private);
+		}
+	}
+	else
+	{
+		(void) log_program_output(&program, LOG_INFO, LOG_ERROR);
+	}
+	free_program(&program);
+
+	return success;
+}
+
+
+/*
+ * run_ssh runs the ssh command to the specified IP address as the given
+ * username, sharing the current terminal tty.
+ */
+static bool
+run_ssh(const char *username, const char *ip)
+{
+	char *args[16];
+	int argsIndex = 0;
+
+	Program program;
+
+	char ssh[MAXPGPATH] = { 0 };
+	char command[BUFSIZE] = { 0 };
+
+	if (!search_path_first("ssh", ssh, LOG_ERROR))
+	{
+		log_fatal("Failed to find program ssh in PATH");
+		return false;
+	}
+
+	args[argsIndex++] = ssh;
+	args[argsIndex++] = "-o";
+	args[argsIndex++] = "StrictHostKeyChecking=no";
+	args[argsIndex++] = "-o";
+	args[argsIndex++] = "UserKnownHostsFile /dev/null";
+	args[argsIndex++] = "-o";
+	args[argsIndex++] = "LogLevel=quiet";
+	args[argsIndex++] = "-l";
+	args[argsIndex++] = (char *) username;
+	args[argsIndex++] = (char *) ip;
+	args[argsIndex++] = NULL;
+
+	program = initialize_program(args, false);
+
+	program.capture = false;    /* don't capture output */
+	program.tty = true;         /* allow sharing the parent's tty */
+
+	(void) snprintf_program_command_line(&program, command, sizeof(command));
+
+	log_info("%s", command);
+
+	(void) execute_subprogram(&program);
+
+	return true;
+}
+
+
+/*
+ * run_ssh_command runs the given command on the remote machine given by ip
+ * address, as the given username.
+ */
+static bool
+run_ssh_command(const char *username,
+				const char *ip,
+				bool tty,
+				const char *command)
+{
+	char *args[16];
+	int argsIndex = 0;
+
+	Program program;
+
+	char ssh[MAXPGPATH] = { 0 };
+	char ssh_command[BUFSIZE] = { 0 };
+
+	if (!search_path_first("ssh", ssh, LOG_ERROR))
+	{
+		log_fatal("Failed to find program ssh in PATH");
+		return false;
+	}
+
+	args[argsIndex++] = ssh;
+
+	if (tty)
+	{
+		args[argsIndex++] = "-t";
+	}
+
+	args[argsIndex++] = "-o";
+	args[argsIndex++] = "StrictHostKeyChecking=no";
+	args[argsIndex++] = "-o";
+	args[argsIndex++] = "UserKnownHostsFile /dev/null";
+	args[argsIndex++] = "-o";
+	args[argsIndex++] = "LogLevel=quiet";
+	args[argsIndex++] = "-l";
+	args[argsIndex++] = (char *) username;
+	args[argsIndex++] = (char *) ip;
+	args[argsIndex++] = "--";
+	args[argsIndex++] = (char *) command;
+	args[argsIndex++] = NULL;
+
+	program = initialize_program(args, false);
+
+	program.capture = false;    /* don't capture output */
+	program.tty = true;         /* allow sharing the parent's tty */
+
+	(void) snprintf_program_command_line(&program, ssh_command, BUFSIZE);
+
+	if (dryRun)
+	{
+		appendPQExpBuffer(azureScript, "\n%s", ssh_command);
+
+		return true;
+	}
+
+	log_info("%s", ssh_command);
+
+	(void) execute_subprogram(&program);
+
+	return true;
+}
+
+
+/*
+ * start_ssh_command starts the given command on the remote machine given by ip
+ * address, as the given username.
+ */
+static bool
+start_ssh_command(const char *username,
+				  const char *ip,
+				  const char *command)
+{
+	char *args[16];
+	int argsIndex = 0;
+
+	Program program;
+
+	char ssh[MAXPGPATH] = { 0 };
+	char ssh_command[BUFSIZE] = { 0 };
+
+	if (!search_path_first("ssh", ssh, LOG_ERROR))
+	{
+		log_fatal("Failed to find program ssh in PATH");
+		return false;
+	}
+
+	args[argsIndex++] = ssh;
+	args[argsIndex++] = "-o";
+	args[argsIndex++] = "StrictHostKeyChecking=no";
+	args[argsIndex++] = "-o";
+	args[argsIndex++] = "UserKnownHostsFile /dev/null";
+	args[argsIndex++] = "-o";
+	args[argsIndex++] = "LogLevel=quiet";
+	args[argsIndex++] = "-l";
+	args[argsIndex++] = (char *) username;
+	args[argsIndex++] = (char *) ip;
+	args[argsIndex++] = "--";
+	args[argsIndex++] = (char *) command;
+	args[argsIndex++] = NULL;
+
+	program = initialize_program(args, false);
+
+	(void) snprintf_program_command_line(&program, ssh_command, BUFSIZE);
+
+	if (dryRun)
+	{
+		appendPQExpBuffer(azureScript, "\n%s", ssh_command);
+
+		return true;
+	}
+
+	return azure_start_command(&program);
+}
+
+
+/*
+ * azure_fetch_vm_addresses fetches a given VM addresses.
+ */
+static bool
+azure_fetch_vm_addresses(const char *group, const char *vm,
+						 AzureVMipAddresses *addresses)
+{
+	char groupName[BUFSIZE] = { 0 };
+	char vmName[BUFSIZE] = { 0 };
+	int vmIndex = -1;
+
+	AzureVMipAddresses vmAddresses[MAX_VMS_PER_REGION] = { 0 };
+
+	sformat(vmName, sizeof(vmName), "%s-%s", group, vm);
+
+	vmIndex = azure_node_index_from_name(group, vmName);
+
+	if (vmIndex == -1)
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/*
+	 * It takes as much time fetching all the IP addresses at once compared to
+	 * fetching a single IP address, so we always fetch them all internally.
+	 */
+	if (!azure_fetch_ip_addresses(group, vmAddresses))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	if (IS_EMPTY_STRING_BUFFER(vmAddresses[vmIndex].name))
+	{
+		log_error(
+			"Failed to find Virtual Machine \"%s\" in resource group \"%s\"",
+			vmName, groupName);
+		return false;
+	}
+
+	/* copy the structure wholesale to the target address */
+	*addresses = vmAddresses[vmIndex];
+
+	return true;
+}
+
+
+/*
+ * azure_vm_ssh runs an ssh command to the given VM public IP address.
+ */
+bool
+azure_vm_ssh(const char *group, const char *vm)
+{
+	AzureVMipAddresses addresses = { 0 };
+
+	if (!azure_fetch_vm_addresses(group, vm, &addresses))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return run_ssh("ha-admin", addresses.public);
+}
+
+
+/*
+ * azure_vm_ssh runs an ssh command to the given VM public IP address.
+ */
+bool
+azure_vm_ssh_command(const char *group,
+					 const char *vm,
+					 bool tty,
+					 const char *command)
+{
+	AzureVMipAddresses addresses = { 0 };
+
+	if (!azure_fetch_vm_addresses(group, vm, &addresses))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return run_ssh_command("ha-admin", addresses.public, tty, command);
+}
+
+
+/*
+ * azure_create_region creates a region on Azure and prepares it for
+ * pg_auto_failover demo/QA activities.
+ *
+ * We need to create a vnet, a subnet, a network security group with a rule
+ * that opens ports 22 (ssh) and 5432 (Postgres) for direct access from the
+ * current IP address of the "client" machine where this pg_autoctl command is
+ * being run.
+ */
+bool
+azure_create_region(const char *prefix,
+					const char *region,
+					const char *location,
+					int cidr,
+					bool fromSource,
+					bool monitor,
+					bool appNode,
+					int nodes)
+{
+	AzureRegionResources azRegion = { 0 };
+	AzureRegionResources azRegionFound = { 0 };
+
+	char vnetPrefix[BUFSIZE] = { 0 };
+	char subnetPrefix[BUFSIZE] = { 0 };
+	char ipAddress[BUFSIZE] = { 0 };
+
+	(void) azure_prepare_region(prefix, region, monitor, appNode, nodes,
+								&azRegion);
+
+	/*
+	 * Fetch Azure objects that might have already been created in the target
+	 * resource group, we're going to re-use them, allowing the command to be
+	 * run several times in a row and then "fix itself", or at least continue
+	 * from where it failed.
+	 */
+	if (!dryRun)
+	{
+		if (!azure_fetch_resource_list(azRegion.group, &azRegionFound))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+	}
+
+	/*
+	 * First create the resource group in the target location.
+	 */
+	if (!azure_create_group(azRegion.group, location))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/*
+	 * Prepare vnet and subnet IP addresses prefixes.
+	 */
+	sformat(vnetPrefix, sizeof(vnetPrefix), "10.%d.0.0/16", cidr);
+	sformat(subnetPrefix, sizeof(subnetPrefix), "10.%d.%d.0/24", cidr, cidr);
+
+	/* never skip a step when --script is used */
+	if (dryRun || IS_EMPTY_STRING_BUFFER(azRegionFound.vnet))
+	{
+		if (!azure_create_vnet(azRegion.group, azRegion.vnet, vnetPrefix))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+	}
+	else
+	{
+		log_info("Skipping creation of vnet \"%s\" which already exist",
+				 azRegion.vnet);
+	}
+
+	/*
+	 * Get our IP address as seen by the outside world.
+	 */
+	if (!azure_get_remote_ip(ipAddress, sizeof(ipAddress)))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/*
+	 * Create the network security group.
+	 */
+	if (dryRun || IS_EMPTY_STRING_BUFFER(azRegionFound.nsg))
+	{
+		if (!azure_create_nsg(azRegion.group, azRegion.nsg))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+	}
+	else
+	{
+		log_info("Skipping creation of nsg \"%s\" which already exist",
+				 azRegion.nsg);
+	}
+
+	/*
+	 * Create the network security rules for SSH and Postgres protocols.
+	 */
+	if (!azure_create_nsg_rule(azRegion.group,
+							   azRegion.nsg,
+							   azRegion.rule,
+							   ipAddress))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/*
+	 * Create the network subnet using previous network security group.
+	 */
+	if (!azure_create_subnet(azRegion.group,
+							 azRegion.vnet,
+							 azRegion.subnet,
+							 subnetPrefix,
+							 azRegion.nsg))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/*
+	 * Now is time to create the virtual machines.
+	 */
+	return azure_provision_nodes(prefix,
+								 region,
+								 fromSource,
+								 monitor,
+								 appNode,
+								 nodes);
+}
+
+
+/*
+ * azure_provision_nodes creates the pg_autoctl VM nodes that we need, and
+ * provision them with our provisioning script.
+ */
+bool
+azure_provision_nodes(const char *prefix,
+					  const char *region,
+					  bool fromSource,
+					  bool monitor,
+					  bool appNode,
+					  int nodes)
+{
+	AzureRegionResources azRegion = { 0 };
+
+	(void) azure_prepare_region(prefix, region, monitor, appNode, nodes,
+								&azRegion);
+
+	if (!azure_fetch_ip_addresses(azRegion.group, azRegion.vmArray))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	if (monitor || nodes > 0)
+	{
+		/*
+		 * Here we run the following commands:
+		 *
+		 *   $ az vm create --name a &
+		 *   $ az vm create --name b &
+		 *   $ wait
+		 *
+		 *   $ az vm run-command invoke --name a --scripts ... &
+		 *   $ az vm run-command invoke --name b --scripts ... &
+		 *   $ wait
+		 *
+		 * We could optimize our code so that we run the provisioning scripts
+		 * for a VM as soon as it's been created, without having to wait until
+		 * the other VMs are created. Two things to keep in mind, though:
+		 *
+		 * - overall, being cleverer here might not be a win as we're going to
+		 *   have to wait until all the VMs are provisioned anyway
+		 *
+		 * - in dry-run mode (--script), we still want to produce the more
+		 *   naive script as shown above, for lack of known advanced control
+		 *   structures in the target shell (we don't require a specific one).
+		 */
+		if (!azure_create_vms(&azRegion, "debian", "ha-admin"))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+
+		if (!azure_provision_vms(&azRegion, fromSource))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+
+		/*
+		 * When provisioning from sources, after the OS related steps in
+		 * azure_provision_vms, we still need to upload our local sources (this
+		 * requires rsync to have been installed in the previous step), and to
+		 * build our software from same sources.
+		 */
+		if (fromSource)
+		{
+			if (!azure_rsync_vms(&azRegion))
+			{
+				/* errors have already been logged */
+				return false;
+			}
+
+			return azure_build_pg_autoctl(&azRegion);
+		}
+	}
+
+	return true;
+}
+
+
+/*
+ * azure_create_nodes run the pg_autoctl commands that create our nodes, and
+ * then register them with systemd on the remote VMs.
+ */
+bool
+azure_create_nodes(const char *prefix,
+				   const char *region,
+				   bool monitor,
+				   bool appNode,
+				   int nodes)
+{
+	AzureRegionResources azRegion = { 0 };
+
+	(void) azure_prepare_region(prefix, region, monitor, appNode, nodes,
+								&azRegion);
+
+	if (!azure_fetch_ip_addresses(azRegion.group, azRegion.vmArray))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	if (monitor)
+	{
+		char *create_monitor =
+			"pg_autoctl create monitor "
+			"--auth trust "
+			"--ssl-self-signed "
+			"--pgdata /home/ha-admin/monitor "
+			"--pgctl /usr/lib/postgresql/11/bin/pg_ctl";
+
+		char *systemd =
+			"pg_autoctl -q show systemd --pgdata /home/ha-admin/monitor "
+			"> pgautofailover.service; "
+			"sudo mv pgautofailover.service /etc/systemd/system; "
+			"sudo systemctl daemon-reload; "
+			"sudo systemctl enable pgautofailover; "
+			"sudo systemctl start pgautofailover";
+
+		bool tty = false;
+		char *host = azRegion.vmArray[0].public;
+
+		/* the monitor is always at index 0 in the vmArray */
+		if (!run_ssh_command("ha-admin", host, tty, create_monitor))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+
+		if (!run_ssh_command("ha-admin", host, tty, systemd))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+	}
+
+	/*
+	 * Now prepare all the other nodes, one at a time, so that we have a the
+	 * primary, etc. It could also be all at once, but one at a time is good
+	 * for a tutorial.
+	 */
+	for (int index = 1; index <= azRegion.nodes; index++)
+	{
+		char *create_postgres_prefix =
+			"pg_autoctl create postgres "
+			"--pgctl /usr/lib/postgresql/11/bin/pg_ctl "
+			"--pgdata /home/ha-admin/pgdata "
+			"--auth trust "
+			"--ssl-self-signed "
+			"--username ha-admin "
+			"--dbname appdb ";
+
+		char create_postgres[BUFSIZE] = { 0 };
+
+		char *systemd =
+			"pg_autoctl -q show systemd --pgdata /home/ha-admin/pgdata "
+			"> pgautofailover.service; "
+			"sudo mv pgautofailover.service /etc/systemd/system; "
+			"sudo systemctl daemon-reload; "
+			"sudo systemctl enable pgautofailover; "
+			"sudo systemctl start pgautofailover";
+
+		bool tty = false;
+		char *host = azRegion.vmArray[index].public;
+
+		sformat(create_postgres, BUFSIZE,
+				"%s "
+				"--hostname %s "
+				"--name %s-%c "
+				"--monitor 'postgres://autoctl_node@%s/pg_auto_failover?sslmode=require'",
+				create_postgres_prefix,
+				azRegion.vmArray[index].private,
+				azRegion.region,
+				'a' + index - 1,
+				azRegion.vmArray[0].private);
+
+		/* the monitor is always at index 0 in the vmArray */
+		if (!run_ssh_command("ha-admin", host, tty, create_postgres))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+
+		if (!run_ssh_command("ha-admin", host, tty, systemd))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+	}
+
+	/*
+	 * Show the current state.
+	 */
+	if (monitor && nodes > 0)
+	{
+		bool tty = true;
+		char *host = azRegion.vmArray[0].public;
+
+		if (!run_ssh_command("ha-admin", host, tty,
+							 "watch -n 0.2 "
+							 "pg_autoctl show state "
+							 "--pgdata /home/ha-admin/monitor"))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+	}
+
+	return true;
+}
+
+
+/*
+ * azure_ls lists the azure resources we created in a specific resource group.
+ */
+bool
+azure_ls(const char *prefix, const char *name)
+{
+	char groupName[BUFSIZE] = { 0 };
+
+	sformat(groupName, sizeof(groupName), "%s-%s", prefix, name);
+
+	return azure_resource_list(groupName);
+}
+
+
+/*
+ * azure_show_ips shows the azure ip addresses for the VMs we created in a
+ * specific resource group.
+ */
+bool
+azure_show_ips(const char *prefix, const char *name)
+{
+	char groupName[BUFSIZE] = { 0 };
+
+	sformat(groupName, sizeof(groupName), "%s-%s", prefix, name);
+
+	return azure_show_ip_addresses(groupName);
+}
+
+
+/*
+ * azure_ssh runs the ssh -l ha-admin <public ip address> command for given
+ * node in given azure group, identified as usual with a prefix and a name.
+ */
+bool
+azure_ssh(const char *prefix, const char *name, const char *vm)
+{
+	char groupName[BUFSIZE] = { 0 };
+
+	sformat(groupName, sizeof(groupName), "%s-%s", prefix, name);
+
+	/* return azure_vm_ssh_command(groupName, vm, true, "watch date -R"); */
+	return azure_vm_ssh(groupName, vm);
+}
+
+
+/*
+ * azure_ssh_command runs the ssh -l ha-admin <public ip address> <command> for
+ * given node in given azure group, identified as usual with a prefix and a
+ * name.
+ */
+bool
+azure_ssh_command(const char *prefix, const char *name, const char *vm,
+				  bool tty, const char *command)
+{
+	char groupName[BUFSIZE] = { 0 };
+
+	sformat(groupName, sizeof(groupName), "%s-%s", prefix, name);
+
+	return azure_vm_ssh_command(groupName, vm, tty, command);
+}
+
+
+/*
+ * azure_sync_source_dir runs rsync in parallel to all the created VMs.
+ */
+bool
+azure_sync_source_dir(const char *prefix,
+					  const char *region,
+					  bool monitor,
+					  bool appNode,
+					  int nodes)
+{
+	AzureRegionResources azRegion = { 0 };
+
+	(void) azure_prepare_region(prefix, region, monitor, appNode, nodes,
+								&azRegion);
+
+	if (!azure_fetch_ip_addresses(azRegion.group, azRegion.vmArray))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	if (!azure_rsync_vms(&azRegion))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return azure_build_pg_autoctl(&azRegion);
+}

--- a/src/bin/pg_autoctl/azure.h
+++ b/src/bin/pg_autoctl/azure.h
@@ -118,6 +118,10 @@ bool azure_vm_ssh_command(const char *group,
 bool azure_create_region(AzureRegionResources *azRegion);
 bool azure_drop_region(AzureRegionResources *azRegion);
 bool azure_provision_nodes(AzureRegionResources *azRegion);
+
+bool azure_deploy_monitor(AzureRegionResources *azRegion);
+bool azure_deploy_postgres(AzureRegionResources *azRegion, int vmIndex);
+
 bool azure_create_nodes(AzureRegionResources *azRegion);
 
 bool azure_ls(AzureRegionResources *azRegion);

--- a/src/bin/pg_autoctl/azure.h
+++ b/src/bin/pg_autoctl/azure.h
@@ -93,6 +93,8 @@ bool azure_create_subnet(const char *group,
 						 const char *prefixes,
 						 const char *nsg);
 
+bool az_group_delete(const char *group);
+
 bool azure_create_vm(AzureRegionResources *azRegion,
 					 const char *name,
 					 const char *image,
@@ -114,6 +116,7 @@ bool azure_vm_ssh_command(const char *group,
 						  const char *command);
 
 bool azure_create_region(AzureRegionResources *azRegion);
+bool azure_drop_region(AzureRegionResources *azRegion);
 bool azure_provision_nodes(AzureRegionResources *azRegion);
 bool azure_create_nodes(AzureRegionResources *azRegion);
 

--- a/src/bin/pg_autoctl/azure.h
+++ b/src/bin/pg_autoctl/azure.h
@@ -17,6 +17,7 @@
 #include "pqexpbuffer.h"
 
 #include "defaults.h"
+#include "parsing.h"
 
 /* global variables from azure.c */
 extern bool dryRun;
@@ -104,6 +105,7 @@ bool azure_create_vms(AzureRegionResources *azRegion,
 					  const char *image,
 					  const char *username);
 
+bool azure_prepare_target_versions(KeyVal *env);
 bool azure_provision_vm(const char *group, const char *name, bool fromSource);
 bool azure_provision_vms(AzureRegionResources *azRegion, bool fromSource);
 

--- a/src/bin/pg_autoctl/azure.h
+++ b/src/bin/pg_autoctl/azure.h
@@ -1,0 +1,124 @@
+/*
+ * src/bin/pg_autoctl/azure.h
+ *     Implementation of a CLI which lets you call `az` cli commands to prepare
+ *     a pg_auto_failover demo or QA environment.
+ *
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the PostgreSQL License.
+ *
+ */
+
+#ifndef AZURE_H
+#define AZURE_H
+
+#include <stdbool.h>
+
+#include "defaults.h"
+
+/* global variables from azure.c */
+extern bool dryRun;
+extern PQExpBuffer azureScript;
+extern char azureCLI[MAXPGPATH];
+
+#define MAX_VMS_PER_REGION 28   /* monitor, then pg ndoes [a-z], then app */
+
+typedef struct AzureVMipAddresses
+{
+	char name[NAMEDATALEN];
+	char public[BUFSIZE];
+	char private[BUFSIZE];
+} AzureVMipAddresses;
+
+
+typedef struct AzureRegionResources
+{
+	char prefix[NAMEDATALEN];
+	char region[NAMEDATALEN];
+	char group[NAMEDATALEN];
+
+	char vnet[BUFSIZE];
+	char nsg[BUFSIZE];
+	char rule[BUFSIZE];
+	char subnet[BUFSIZE];
+
+	bool monitor;               /* do we want a monitor in that region? */
+	bool appNode;               /* do we create an application node? */
+	int nodes;                  /* node count */
+
+	AzureVMipAddresses vmArray[MAX_VMS_PER_REGION];
+} AzureRegionResources;
+
+
+bool azure_psleep(int count, bool force);
+bool azure_get_remote_ip(char *ipAddress, size_t ipAddressSize);
+
+bool azure_create_group(const char *name, const char *location);
+bool azure_create_vnet(const char *group, const char *name, const char *prefix);
+bool azure_create_nsg(const char *group, const char *name);
+
+bool azure_create_nsg_rule(const char *group,
+						   const char *nsgName,
+						   const char *name,
+						   const char *prefixes);
+
+bool azure_create_subnet(const char *group,
+						 const char *vnet,
+						 const char *name,
+						 const char *prefixes,
+						 const char *nsg);
+
+bool azure_create_vm(AzureRegionResources *azRegion,
+					 const char *name,
+					 const char *image,
+					 const char *username);
+
+bool azure_create_vms(AzureRegionResources *azRegion,
+					  const char *image,
+					  const char *username);
+
+bool azure_provision_vm(const char *group, const char *name, bool fromSource);
+bool azure_provision_vms(AzureRegionResources *azRegion, bool fromSource);
+
+bool azure_resource_list(const char *group);
+bool azure_show_ip_addresses(const char *group);
+bool azure_vm_ssh(const char *group, const char *vm);
+bool azure_vm_ssh_command(const char *group,
+						  const char *vm,
+						  bool tty,
+						  const char *command);
+
+bool azure_create_region(const char *prefix,
+						 const char *region,
+						 const char *location,
+						 int cidr,
+						 bool fromSource,
+						 bool monitor,
+						 bool appNode,
+						 int nodes);
+
+bool azure_provision_nodes(const char *prefix,
+						   const char *region,
+						   bool fromSource,
+						   bool monitor,
+						   bool appNode,
+						   int nodes);
+
+bool azure_create_nodes(const char *prefix,
+						const char *region,
+						bool monitor,
+						bool appNode,
+						int nodes);
+
+bool azure_ls(const char *prefix, const char *name);
+bool azure_show_ips(const char *prefix, const char *name);
+bool azure_ssh(const char *prefix, const char *name, const char *vm);
+bool azure_ssh_command(const char *prefix, const char *name, const char *vm,
+					   bool tty, const char *command);
+
+bool azure_sync_source_dir(const char *prefix,
+						   const char *region,
+						   bool monitor,
+						   bool appNode,
+						   int nodes);
+
+#endif  /* AZURE_H */

--- a/src/bin/pg_autoctl/azure.h
+++ b/src/bin/pg_autoctl/azure.h
@@ -107,6 +107,9 @@ bool azure_create_vms(AzureRegionResources *azRegion,
 bool azure_provision_vm(const char *group, const char *name, bool fromSource);
 bool azure_provision_vms(AzureRegionResources *azRegion, bool fromSource);
 
+bool azure_fetch_ip_addresses(const char *group,
+							  AzureVMipAddresses *vmArray);
+
 bool azure_resource_list(const char *group);
 bool azure_show_ip_addresses(const char *group);
 bool azure_vm_ssh(const char *group, const char *vm);
@@ -121,6 +124,7 @@ bool azure_provision_nodes(AzureRegionResources *azRegion);
 
 bool azure_deploy_monitor(AzureRegionResources *azRegion);
 bool azure_deploy_postgres(AzureRegionResources *azRegion, int vmIndex);
+bool azure_deploy_vm(AzureRegionResources *azRegion, const char *vmName);
 
 bool azure_create_nodes(AzureRegionResources *azRegion);
 
@@ -131,5 +135,9 @@ bool azure_ssh_command(AzureRegionResources *azRegion,
 					   const char *vm, bool tty, const char *command);
 
 bool azure_sync_source_dir(AzureRegionResources *azRegion);
+
+/* src/bin/pg_autoctl/cli_do_tmux_azure.c */
+bool tmux_azure_start_or_attach_session(AzureRegionResources *azRegion);
+bool tmux_azure_kill_session(AzureRegionResources *azRegion);
 
 #endif  /* AZURE_H */

--- a/src/bin/pg_autoctl/azure_config.c
+++ b/src/bin/pg_autoctl/azure_config.c
@@ -1,0 +1,209 @@
+/*
+ * src/bin/pg_autoctl/azure_config.c
+ *     Configuration file for azure QA/test environments
+ *
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the PostgreSQL License.
+ *
+ */
+
+#include <pwd.h>
+#include <stdbool.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "postgres_fe.h"
+
+#include "azure.h"
+#include "azure_config.h"
+#include "cli_root.h"
+#include "config.h"
+#include "defaults.h"
+#include "ini_file.h"
+#include "file_utils.h"
+#include "log.h"
+#include "string_utils.h"
+
+#define OPTION_AZURE_PREFIX(config) \
+	make_strbuf_option_default("az", "prefix", "prefix", true, NAMEDATALEN, \
+							   config->prefix, "ha-demo-")
+
+#define OPTION_AZURE_REGION(config) \
+	make_strbuf_option_default("az", "region", "region", true, NAMEDATALEN, \
+							   config->region, "paris")
+
+#define OPTION_AZURE_LOCATION(config) \
+	make_strbuf_option_default("az", "location", "location", true, NAMEDATALEN, \
+							   config->location, "francecentral")
+
+#define OPTION_AZURE_MONITOR(config) \
+	make_int_option_default("group", "monitor", "monitor", true, \
+							&(config->monitor), 1)
+
+#define OPTION_AZURE_NODES(config) \
+	make_int_option_default("group", "nodes", "nodes", true, \
+							&(config->nodes), 2)
+
+#define OPTION_AZURE_APP_NODES(config) \
+	make_int_option_default("group", "appNodes", NULL, true, \
+							&(config->appNodes), 0)
+
+#define OPTION_AZURE_GROUP(config) \
+	make_strbuf_option("resource", "group", NULL, false, NAMEDATALEN, \
+					   config->group)
+
+#define OPTION_AZURE_VNET(config) \
+	make_strbuf_option("resource", "vnet", NULL, false, NAMEDATALEN, \
+					   config->vnet)
+
+#define OPTION_AZURE_NSG(config) \
+	make_strbuf_option("resource", "nsg", NULL, false, NAMEDATALEN, \
+					   config->nsg)
+
+#define OPTION_AZURE_RULE(config) \
+	make_strbuf_option("resource", "rule", NULL, false, NAMEDATALEN, \
+					   config->rule)
+
+#define OPTION_AZURE_SUBNET(config) \
+	make_strbuf_option("resource", "subnet", NULL, false, NAMEDATALEN, \
+					   config->subnet)
+
+
+#define SET_INI_OPTIONS_ARRAY(config) \
+	{ \
+		OPTION_AZURE_PREFIX(config), \
+		OPTION_AZURE_REGION(config), \
+		OPTION_AZURE_LOCATION(config), \
+		OPTION_AZURE_MONITOR(config), \
+		OPTION_AZURE_NODES(config), \
+		OPTION_AZURE_APP_NODES(config), \
+		OPTION_AZURE_GROUP(config), \
+		OPTION_AZURE_VNET(config), \
+		OPTION_AZURE_NSG(config), \
+		OPTION_AZURE_RULE(config), \
+		OPTION_AZURE_SUBNET(config), \
+		INI_OPTION_LAST \
+	}
+
+
+/*
+ * azure_config_read_file reads our azure configuration from an INI
+ * configuration file that has been previously created by our pg_autoctl do
+ * azure commands.
+ */
+bool
+azure_config_read_file(AzureRegionResources *azRegion)
+{
+	IniOption azureOptions[] = SET_INI_OPTIONS_ARRAY(azRegion);
+
+	log_debug("Reading azure configuration from %s", azRegion->filename);
+
+	if (!read_ini_file(azRegion->filename, azureOptions))
+	{
+		log_error("Failed to parse azure configuration file \"%s\"",
+				  azRegion->filename);
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * azure_config_write write the current azure config to given STREAM.
+ */
+bool
+azure_config_write(FILE *stream, AzureRegionResources *azRegion)
+{
+	IniOption azureOptions[] = SET_INI_OPTIONS_ARRAY(azRegion);
+
+	return write_ini_to_stream(stream, azureOptions);
+}
+
+
+/*
+ * azure_config_write_file writes the current values in given azRegion to the
+ * given filename.
+ */
+bool
+azure_config_write_file(AzureRegionResources *azRegion)
+{
+	bool success = false;
+	FILE *fileStream = NULL;
+
+	log_trace("azure_config_write_file \"%s\"", azRegion->filename);
+
+	fileStream = fopen_with_umask(azRegion->filename, "w", FOPEN_FLAGS_W, 0644);
+	if (fileStream == NULL)
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	success = azure_config_write(fileStream, azRegion);
+
+	if (fclose(fileStream) == EOF)
+	{
+		log_error("Failed to write file \"%s\"", azRegion->filename);
+		return false;
+	}
+
+	return success;
+}
+
+
+/*
+ * azure_config_prepare prepares the names we use for the different
+ * Azure network objects that we need: vnet, nsg, nsgrule, subnet.
+ */
+void
+azure_config_prepare(AzureOptions *options, AzureRegionResources *azRegion)
+{
+	/* build the path to our configuration file on-disk */
+	if (!build_xdg_path(azRegion->filename, XDG_CONFIG, ".", "azure.cfg"))
+	{
+		log_fatal("Failed to prepare azure configuration filename");
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+
+	strlcpy(azRegion->prefix, options->prefix, sizeof(azRegion->prefix));
+	strlcpy(azRegion->region, options->region, sizeof(azRegion->region));
+	strlcpy(azRegion->location, options->location, sizeof(azRegion->location));
+
+	sformat(azRegion->group, sizeof(azRegion->group),
+			"%s-%s",
+			options->prefix,
+			options->region);
+
+	/*
+	 * Prepare our Azure object names from the group objects: vnet, subnet,
+	 * nsg, nsg rule.
+	 */
+	sformat(azRegion->vnet, sizeof(azRegion->vnet), "%s-net", azRegion->group);
+	sformat(azRegion->nsg, sizeof(azRegion->nsg), "%s-nsg", azRegion->group);
+
+	sformat(azRegion->rule, sizeof(azRegion->rule),
+			"%s-ssh-and-pg", azRegion->group);
+
+	sformat(azRegion->subnet, sizeof(azRegion->subnet),
+			"%s-subnet", azRegion->group);
+
+	/* transform --monitor and --no-app booleans into integer counts */
+	azRegion->monitor = options->monitor ? 1 : 0;
+	azRegion->appNodes = options->appNode ? 1 : 0;
+	azRegion->nodes = options->nodes;
+
+	azRegion->fromSource = options->fromSource;
+
+	/*
+	 * Prepare vnet and subnet IP addresses prefixes.
+	 */
+	sformat(azRegion->vnetPrefix, sizeof(azRegion->vnetPrefix),
+			"10.%d.0.0/16",
+			options->cidr);
+
+	sformat(azRegion->subnetPrefix, sizeof(azRegion->subnetPrefix),
+			"10.%d.%d.0/24",
+			options->cidr,
+			options->cidr);
+}

--- a/src/bin/pg_autoctl/azure_config.h
+++ b/src/bin/pg_autoctl/azure_config.h
@@ -1,0 +1,29 @@
+/*
+ * src/bin/pg_autoctl/azure_config.h
+ *     Implementation of a CLI which lets you call `az` cli commands to prepare
+ *     a pg_auto_failover demo or QA environment.
+ *
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the PostgreSQL License.
+ *
+ */
+
+#ifndef AZURE_CONFIG_H
+#define AZURE_CONFIG_H
+
+#include <stdbool.h>
+
+#include "postgres_fe.h"
+#include "pqexpbuffer.h"
+
+#include "azure.h"
+#include "defaults.h"
+
+bool azure_config_read_file(AzureRegionResources *azRegion);
+bool azure_config_write(FILE *stream, AzureRegionResources *azRegion);
+bool azure_config_write_file(AzureRegionResources *azRegion);
+
+void azure_config_prepare(AzureOptions *options, AzureRegionResources *azRegion);
+bool azure_get_remote_ip(char *ipAddress, size_t ipAddressSize);
+
+#endif  /* AZURE_CONFIG_H */

--- a/src/bin/pg_autoctl/cli_do_azure.c
+++ b/src/bin/pg_autoctl/cli_do_azure.c
@@ -407,6 +407,8 @@ cli_do_azure_create_environment(int argc, char **argv)
 		exit(EXIT_CODE_INTERNAL_ERROR);
 	}
 
+	(void) outputAzureScript();
+
 	/*
 	 * tmux_azure_start_or_attach_session then creates a tmux session with a
 	 * shell window for each VM in the Azure resource group, and in each
@@ -423,8 +425,6 @@ cli_do_azure_create_environment(int argc, char **argv)
 	{
 		exit(EXIT_CODE_INTERNAL_ERROR);
 	}
-
-	(void) outputAzureScript();
 }
 
 

--- a/src/bin/pg_autoctl/cli_do_azure.c
+++ b/src/bin/pg_autoctl/cli_do_azure.c
@@ -401,9 +401,27 @@ cli_do_azure_create_region(int argc, char **argv)
 		exit(EXIT_CODE_INTERNAL_ERROR);
 	}
 
-	/* that's for testing only */
-	if (false && !azure_psleep(azOptions.nodes, true))
+	(void) outputAzureScript();
+}
+
+
+/*
+ * cli_do_azure_drop_region drops the azure resource group that has been
+ * created to host the azure resources in use for the environment.
+ */
+void
+cli_do_azure_drop_region(int argc, char **argv)
+{
+	if (!azure_drop_region(&azRegion))
 	{
+		log_warn("Configuration file \"%s\" has not been deleted",
+				 azRegion.filename);
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+
+	if (!unlink_file(azRegion.filename))
+	{
+		log_fatal("Failed to remove azure configuration file");
 		exit(EXIT_CODE_INTERNAL_ERROR);
 	}
 

--- a/src/bin/pg_autoctl/cli_do_azure.c
+++ b/src/bin/pg_autoctl/cli_do_azure.c
@@ -492,6 +492,8 @@ cli_do_azure_deploy(int argc, char **argv)
 	{
 		exit(EXIT_CODE_INTERNAL_ERROR);
 	}
+
+	(void) outputAzureScript();
 }
 
 

--- a/src/bin/pg_autoctl/cli_do_azure.c
+++ b/src/bin/pg_autoctl/cli_do_azure.c
@@ -1,0 +1,514 @@
+/*
+ * src/bin/pg_autoctl/cli_do_azure.c
+ *     Implementation of a CLI which lets you call `az` cli commands to prepare
+ *     a pg_auto_failover demo or QA environment.
+ *
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the PostgreSQL License.
+ *
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <getopt.h>
+#include <inttypes.h>
+#include <termios.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "postgres_fe.h"
+#include "pqexpbuffer.h"
+#include "snprintf.h"
+
+#include "azure.h"
+#include "cli_common.h"
+#include "cli_do_root.h"
+#include "cli_root.h"
+#include "commandline.h"
+#include "config.h"
+#include "env_utils.h"
+#include "log.h"
+#include "pidfile.h"
+#include "signals.h"
+#include "string_utils.h"
+
+#include "runprogram.h"
+
+typedef struct AzureOptions
+{
+	char prefix[NAMEDATALEN];
+	char region[NAMEDATALEN];
+	char location[NAMEDATALEN];
+
+	int nodes;
+	int cidr;
+	bool fromSource;
+	bool appNode;
+	bool monitor;
+	bool all;
+	bool watch;
+} AzureOptions;
+
+static AzureOptions azureOptions = { 0 };
+
+bool dryRun = false;
+PQExpBuffer azureScript = NULL;
+
+static void outputAzureScript(void);
+
+
+/*
+ * cli_print_version_getopts parses the CLI options for the pg_autoctl version
+ * command, which are the usual suspects.
+ */
+int
+cli_do_azure_getopts(int argc, char **argv)
+{
+	int c, option_index = 0, errors = 0;
+	int verboseCount = 0;
+	bool printVersion = false;
+
+	AzureOptions options = { 0 };
+
+	static struct option long_options[] = {
+		{ "prefix", required_argument, NULL, 'p' },
+		{ "region", required_argument, NULL, 'r' },
+		{ "location", required_argument, NULL, 'l' },
+		{ "from-source", no_argument, NULL, 's' },
+		{ "nodes", required_argument, NULL, 'N' },
+		{ "monitor", no_argument, NULL, 'M' },
+		{ "no-app", no_argument, NULL, 'n' },
+		{ "all", no_argument, NULL, 'A' },
+		{ "script", no_argument, NULL, 'S' },
+		{ "watch", no_argument, NULL, 'T' },
+		{ "az", no_argument, NULL, 'Z' },
+		{ "cidr", no_argument, NULL, 'c' },
+		{ "version", no_argument, NULL, 'V' },
+		{ "verbose", no_argument, NULL, 'v' },
+		{ "quiet", no_argument, NULL, 'q' },
+		{ "help", no_argument, NULL, 'h' },
+		{ NULL, 0, NULL, 0 }
+	};
+
+	optind = 0;
+
+	/* set our defaults */
+	options.cidr = 11;          /* 10.11.0.0/16 and 10.11.11.0/24 */
+	options.nodes = 2;
+	options.fromSource = false;
+	options.appNode = true;
+	options.monitor = false;
+	options.all = false;
+	options.watch = false;
+
+	strlcpy(options.prefix, "ha-demo", sizeof(options.prefix));
+
+	/*
+	 * The only command lines that are using keeper_cli_getopt_pgdata are
+	 * terminal ones: they don't accept subcommands. In that case our option
+	 * parsing can happen in any order and we don't need getopt_long to behave
+	 * in a POSIXLY_CORRECT way.
+	 *
+	 * The unsetenv() call allows getopt_long() to reorder arguments for us.
+	 */
+	unsetenv("POSIXLY_CORRECT");
+
+	while ((c = getopt_long(argc, argv, "p:n:l:N:MAWSTVvqh",
+							long_options, &option_index)) != -1)
+	{
+		switch (c)
+		{
+			/* { "prefix", required_argument, NULL, 'p' }, */
+			case 'p':
+			{
+				strlcpy(options.prefix, optarg, NAMEDATALEN);
+				log_trace("--prefix %s", options.prefix);
+				break;
+			}
+
+			/* { "region", required_argument, NULL, 'r' }, */
+			case 'r':
+			{
+				strlcpy(options.region, optarg, NAMEDATALEN);
+				log_trace("--region %s", options.region);
+				break;
+			}
+
+			/* { "location", required_argument, NULL, 'l' }, */
+			case 'l':
+			{
+				strlcpy(options.location, optarg, NAMEDATALEN);
+				log_trace("--location %s", options.location);
+				break;
+			}
+
+			/* { "az", no_argument, NULL, 'Z' }, */
+			case 'Z':
+			{
+				strlcpy(azureCLI, optarg, NAMEDATALEN);
+				log_trace("--az %s", azureCLI);
+				break;
+			}
+
+			/* { "cidr", no_argument, NULL, 'c' }, */
+			case 'c':
+			{
+				if (!stringToInt(optarg, &options.cidr))
+				{
+					log_error("Failed to parse --cidr number \"%s\"", optarg);
+					errors++;
+				}
+				else if (options.cidr < 1 || options.cidr > 254)
+				{
+					log_error("Failed to parse --cidr number \"%s\"", optarg);
+					errors++;
+				}
+				else
+				{
+					log_trace("--cidr %d", options.cidr);
+				}
+				break;
+			}
+
+			/* { "nodes", required_argument, NULL, 'N' }, */
+			case 'N':
+			{
+				if (!stringToInt(optarg, &options.nodes))
+				{
+					log_error("Failed to parse --nodes number \"%s\"", optarg);
+					errors++;
+				}
+				log_trace("--nodes %d", options.nodes);
+				break;
+			}
+
+			/* { "monitor", no_argument, NULL, 'M' }, */
+			case 'M':
+			{
+				options.monitor = true;
+				log_trace("--monitor");
+				break;
+			}
+
+			/* { "no-app", no_argument, NULL, 'n' }, */
+			case 'n':
+			{
+				options.appNode = false;
+				log_trace("--no-app");
+				break;
+			}
+
+			/* { "from-source", required_argument, NULL, 's' }, */
+			case 's':
+			{
+				options.fromSource = true;
+				log_trace("--from-source");
+				break;
+			}
+
+			/* { "all", no_argument, NULL, 'A' }, */
+			case 'A':
+			{
+				options.all = true;
+				log_trace("--monitor");
+				break;
+			}
+
+			/* { "script", no_argument, NULL, 'S' }, */
+			case 'S':
+			{
+				dryRun = true;
+				log_trace("--script");
+				break;
+			}
+
+			/* { "watch", no_argument, NULL, 'T' }, */
+			case 'T':
+			{
+				options.watch = true;
+				log_trace("--watch");
+				break;
+			}
+
+			case 'h':
+			{
+				commandline_help(stderr);
+				exit(EXIT_CODE_QUIT);
+				break;
+			}
+
+			case 'V':
+			{
+				/* keeper_cli_print_version prints version and exits. */
+				printVersion = true;
+				break;
+			}
+
+			case 'v':
+			{
+				++verboseCount;
+				switch (verboseCount)
+				{
+					case 1:
+					{
+						log_set_level(LOG_INFO);
+						break;
+					}
+
+					case 2:
+					{
+						log_set_level(LOG_DEBUG);
+						break;
+					}
+
+					default:
+					{
+						log_set_level(LOG_TRACE);
+						break;
+					}
+				}
+				break;
+			}
+
+			case 'q':
+			{
+				log_set_level(LOG_ERROR);
+				break;
+			}
+
+			default:
+			{
+				/* getopt_long already wrote an error message */
+				errors++;
+				break;
+			}
+		}
+	}
+
+	if (IS_EMPTY_STRING_BUFFER(options.prefix))
+	{
+		++errors;
+		log_fatal("--prefix is a mandatory option");
+	}
+
+	if (IS_EMPTY_STRING_BUFFER(azureCLI))
+	{
+		if (!search_path_first("az", azureCLI, LOG_ERROR))
+		{
+			++errors;
+			log_fatal("Failed to find program \"%s\" in PATH", "az");
+		}
+	}
+	else
+	{
+		if (!file_exists(azureCLI))
+		{
+			++errors;
+			log_fatal("No such file or directory: \"%s\"", azureCLI);
+		}
+	}
+
+	if (errors > 0)
+	{
+		commandline_help(stderr);
+		exit(EXIT_CODE_BAD_ARGS);
+	}
+
+	if (printVersion)
+	{
+		keeper_cli_print_version(argc, argv);
+	}
+
+	/*
+	 * In --script mode (or dry run) we generate a script with the commands we
+	 * would run instead of actually running them.
+	 */
+	if (dryRun)
+	{
+		azureScript = createPQExpBuffer();
+
+		if (azureScript == NULL)
+		{
+			log_error("Failed to allocate memory");
+			exit(EXIT_CODE_INTERNAL_ERROR);
+		}
+
+		appendPQExpBuffer(azureScript,
+						  "# azure commands for pg_auto_failover demo");
+	}
+
+	/* publish parsed options */
+	azureOptions = options;
+
+	return optind;
+}
+
+
+/*
+ * outputAzureScript writes the azure script to stdout.
+ */
+static void
+outputAzureScript()
+{
+	if (dryRun)
+	{
+		fformat(stdout, "%s\n", azureScript->data);
+		destroyPQExpBuffer(azureScript);
+	}
+}
+
+
+/*
+ * cli_do_azure_create_region creates an Azure region with some nodes and
+ * network rules for a demo or QA context of pg_auto_failover.
+ */
+void
+cli_do_azure_create_region(int argc, char **argv)
+{
+	AzureOptions options = azureOptions;
+
+	if (IS_EMPTY_STRING_BUFFER(options.location))
+	{
+		log_fatal("--location is a mandatory option");
+		exit(EXIT_CODE_BAD_ARGS);
+	}
+
+	if (!azure_create_region(options.prefix,
+							 options.region,
+							 options.location,
+							 options.cidr,
+							 options.fromSource,
+							 options.monitor,
+							 options.appNode,
+							 options.nodes))
+	{
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+
+	/* that's for testing only */
+	if (false && !azure_psleep(options.nodes, true))
+	{
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+
+	(void) outputAzureScript();
+}
+
+
+/*
+ * cli_do_azure_create_nodes creates the pg_autoctl services in an Azure
+ * region that's been created and provisionned before.
+ */
+void
+cli_do_azure_create_nodes(int argc, char **argv)
+{
+	AzureOptions options = azureOptions;
+
+	if (!azure_create_nodes(options.prefix,
+							options.region,
+							options.monitor,
+							options.appNode,
+							options.nodes))
+	{
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+
+	(void) outputAzureScript();
+}
+
+
+/*
+ * cli_do_azure_ls lists Azure resources created in the target region.
+ */
+void
+cli_do_azure_ls(int argc, char **argv)
+{
+	AzureOptions options = azureOptions;
+
+	if (!azure_ls(options.prefix, options.region))
+	{
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+}
+
+
+/*
+ * cli_do_azure_show_ips lists Azure ip addresses assigned to created VMs in a
+ * specific region.
+ */
+void
+cli_do_azure_show_ips(int argc, char **argv)
+{
+	AzureOptions options = azureOptions;
+
+	if (!azure_show_ips(options.prefix, options.region))
+	{
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+}
+
+
+/*
+ * cli_do_azure_ssh starts an ssh command to the given Azure VM in a specific
+ * prefix and region name.
+ */
+void
+cli_do_azure_ssh(int argc, char **argv)
+{
+	AzureOptions options = azureOptions;
+
+	if (argc != 1)
+	{
+		(void) commandline_print_usage(&do_azure_ssh, stderr);
+		exit(EXIT_CODE_BAD_ARGS);
+	}
+
+	if (!azure_ssh(options.prefix, options.region, argv[0]))
+	{
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+}
+
+
+/*
+ * cli_do_azure_rsync uses rsync to upload the current sources to all the
+ * created VMs in the target region.
+ */
+void
+cli_do_azure_rsync(int argc, char **argv)
+{
+	AzureOptions options = azureOptions;
+
+	if (!azure_sync_source_dir(options.prefix,
+							   options.region,
+							   options.monitor,
+							   options.appNode,
+							   options.nodes))
+	{
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+}
+
+
+/*
+ * cli_do_azure_ssh starts an ssh command to the given Azure VM in a specific
+ * prefix and region name.
+ */
+void
+cli_do_azure_show_state(int argc, char **argv)
+{
+	AzureOptions options = azureOptions;
+	char *pg_autoctl_command =
+		options.watch
+		? "watch -n 0.2 pg_autoctl show state --pgdata ./monitor"
+		: "pg_autoctl show state --pgdata ./monitor";
+
+	if (!azure_ssh_command(options.prefix, options.region,
+						   "monitor",
+						   options.watch, /* tty is needed for watch */
+						   pg_autoctl_command))
+	{
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+}

--- a/src/bin/pg_autoctl/cli_do_azure.c
+++ b/src/bin/pg_autoctl/cli_do_azure.c
@@ -463,6 +463,8 @@ cli_do_azure_drop_region(int argc, char **argv)
 		exit(EXIT_CODE_INTERNAL_ERROR);
 	}
 
+	log_info("Removing azure configuration file \"%s\"", azRegion.filename);
+
 	if (!unlink_file(azRegion.filename))
 	{
 		log_fatal("Failed to remove azure configuration file");

--- a/src/bin/pg_autoctl/cli_do_azure.c
+++ b/src/bin/pg_autoctl/cli_do_azure.c
@@ -456,12 +456,18 @@ cli_do_azure_create_region(int argc, char **argv)
 void
 cli_do_azure_drop_region(int argc, char **argv)
 {
+	bool success = true;
+
 	if (!azure_drop_region(&azRegion))
 	{
 		log_warn("Configuration file \"%s\" has not been deleted",
 				 azRegion.filename);
 		exit(EXIT_CODE_INTERNAL_ERROR);
 	}
+
+	log_info("Killing tmux sessions \"%s\"", azRegion.group);
+
+	success = success && tmux_azure_kill_session(&azRegion);
 
 	log_info("Removing azure configuration file \"%s\"", azRegion.filename);
 

--- a/src/bin/pg_autoctl/cli_do_azure.c
+++ b/src/bin/pg_autoctl/cli_do_azure.c
@@ -333,6 +333,11 @@ cli_do_azure_getopts(int argc, char **argv)
 		/* maybe late we will merge new options in the pre-existing file */
 		log_warn("Ignoring command line options, "
 				 "configuration file takes precedence");
+
+		log_info("Using --prefix \"%s\" --region \"%s\" --location \"%s\"",
+				 azRegion.prefix,
+				 azRegion.region,
+				 azRegion.location);
 	}
 	else
 	{

--- a/src/bin/pg_autoctl/cli_do_root.c
+++ b/src/bin/pg_autoctl/cli_do_root.c
@@ -306,10 +306,15 @@ CommandLine do_tmux_commands =
 					 "set of facilities to handle tmux interactive sessions",
 					 NULL, NULL, NULL, do_tmux);
 
-
-CommandLine do_azure_create_region =
+/*
+ * pg_autoctl do azure ...
+ *
+ * Set of commands to prepare and control a full QA environment running in
+ * Azure VMs, provisionned either from our packages or from local source code.
+ */
+CommandLine do_azure_provision_region =
 	make_command("region",
-				 "Create an azure region: resource group, network, VMs",
+				 "Provision an azure region: resource group, network, VMs",
 				 "[option ...]",
 				 "  --prefix    azure group name prefix (ha-demo)\n"
 				 "  --region    name to use for referencing the region\n"
@@ -320,7 +325,7 @@ CommandLine do_azure_create_region =
 				 cli_do_azure_getopts,
 				 cli_do_azure_create_region);
 
-CommandLine do_azure_create_nodes =
+CommandLine do_azure_provision_nodes =
 	make_command("nodes",
 				 "Provision our pre-created VM with pg_autoctl Postgres nodes",
 				 "[option ...]",
@@ -333,20 +338,36 @@ CommandLine do_azure_create_nodes =
 				 cli_do_azure_create_nodes);
 
 
-CommandLine *do_azure_create[] = {
-	&do_azure_create_region,
-	&do_azure_create_nodes,
+CommandLine *do_azure_provision[] = {
+	&do_azure_provision_region,
+	&do_azure_provision_nodes,
 	NULL
 };
 
-CommandLine do_azure_create_commands =
-	make_command_set("create",
-					 "create azure resources for a pg_auto_failover demo",
-					 NULL, NULL, NULL, do_azure_create);
+CommandLine do_azure_provision_commands =
+	make_command_set("provision",
+					 "provision azure resources for a pg_auto_failover demo",
+					 NULL, NULL, NULL, do_azure_provision);
+
+CommandLine do_azure_create =
+	make_command("create",
+				 "Create an azure QA environment",
+				 "[option ...]",
+				 "  --prefix      azure group name prefix (ha-demo)\n"
+				 "  --region      name to use for referencing the region\n"
+				 "  --location    azure location to use for the resources\n"
+				 "  --nodes       number of Postgres nodes to create (2)\n"
+				 "  --script      output a script instead of creating resources\n"
+				 "  --no-monitor  do not create the pg_autoctl monitor node\n"
+				 "  --no-app      do not create the application node\n"
+				 "  --cidr        use the 10.CIDR.CIDR.0/24 subnet (11)\n"
+				 "  --from-source provision pg_auto_failover from sources\n",
+				 cli_do_azure_getopts,
+				 cli_do_azure_create_environment);
 
 CommandLine do_azure_drop =
 	make_command("drop",
-				 "Drop an azure region: resource group, network, VMs",
+				 "Drop an azure QA environment: resource group, network, VMs",
 				 "[option ...]",
 				 "  --prefix    azure group name prefix (ha-demo)\n"
 				 "  --region    name to use for referencing the region\n"
@@ -356,6 +377,14 @@ CommandLine do_azure_drop =
 				 "  --script    output a shell script instead of creating resources\n",
 				 cli_do_azure_getopts,
 				 cli_do_azure_drop_region);
+
+CommandLine do_azure_deploy =
+	make_command("deploy",
+				 "Deploy a pg_autoctl VMs, given by name",
+				 "[option ...] vmName",
+				 "",
+				 cli_do_azure_getopts,
+				 cli_do_azure_deploy);
 
 CommandLine do_azure_show_ips =
 	make_command("ips",
@@ -416,9 +445,45 @@ CommandLine do_azure_sync =
 				 cli_do_azure_getopts,
 				 cli_do_azure_rsync);
 
+CommandLine do_azure_tmux_session =
+	make_command("session",
+				 "Create or attach a tmux session for the created Azure VMs",
+				 "[option ...]",
+				 "  --prefix    azure group name prefix (ha-demo)\n"
+				 "  --region    region to use for referencing the region\n"
+				 "  --monitor   should we create a monitor in the region (false)\n"
+				 "  --nodes     number of Postgres nodes to create (2)\n",
+				 cli_do_azure_getopts,
+				 cli_do_azure_tmux_session);
+
+CommandLine do_azure_tmux_kill =
+	make_command("kill",
+				 "Kill an existing tmux session for Azure VMs",
+				 "[option ...]",
+				 "  --prefix    azure group name prefix (ha-demo)\n"
+				 "  --region    region to use for referencing the region\n"
+				 "  --monitor   should we create a monitor in the region (false)\n"
+				 "  --nodes     number of Postgres nodes to create (2)\n",
+				 cli_do_azure_getopts,
+				 cli_do_azure_tmux_kill);
+
+CommandLine *do_azure_tmux[] = {
+	&do_azure_tmux_session,
+	&do_azure_tmux_kill,
+	NULL
+};
+
+CommandLine do_azure_tmux_commands =
+	make_command_set("tmux",
+					 "Run a tmux session with an Azure setup for QA/testing",
+					 NULL, NULL, NULL, do_azure_tmux);
+
 CommandLine *do_azure[] = {
-	&do_azure_create_commands,
+	&do_azure_provision_commands,
+	&do_azure_tmux_commands,
 	&do_azure_show_commands,
+	&do_azure_deploy,
+	&do_azure_create,
 	&do_azure_drop,
 	&do_azure_ls,
 	&do_azure_ssh,

--- a/src/bin/pg_autoctl/cli_do_root.c
+++ b/src/bin/pg_autoctl/cli_do_root.c
@@ -344,6 +344,19 @@ CommandLine do_azure_create_commands =
 					 "create azure resources for a pg_auto_failover demo",
 					 NULL, NULL, NULL, do_azure_create);
 
+CommandLine do_azure_drop =
+	make_command("drop",
+				 "Drop an azure region: resource group, network, VMs",
+				 "[option ...]",
+				 "  --prefix    azure group name prefix (ha-demo)\n"
+				 "  --region    name to use for referencing the region\n"
+				 "  --location  azure location where to create a resource group\n"
+				 "  --monitor   should we create a monitor in the region (false)\n"
+				 "  --nodes     number of Postgres nodes to create (2)\n"
+				 "  --script    output a shell script instead of creating resources\n",
+				 cli_do_azure_getopts,
+				 cli_do_azure_drop_region);
+
 CommandLine do_azure_show_ips =
 	make_command("ips",
 				 "Show public and private IP addresses for selected VMs",
@@ -406,6 +419,7 @@ CommandLine do_azure_sync =
 CommandLine *do_azure[] = {
 	&do_azure_create_commands,
 	&do_azure_show_commands,
+	&do_azure_drop,
 	&do_azure_ls,
 	&do_azure_ssh,
 	&do_azure_sync,

--- a/src/bin/pg_autoctl/cli_do_root.c
+++ b/src/bin/pg_autoctl/cli_do_root.c
@@ -307,6 +307,117 @@ CommandLine do_tmux_commands =
 					 NULL, NULL, NULL, do_tmux);
 
 
+CommandLine do_azure_create_region =
+	make_command("region",
+				 "Create an azure region: resource group, network, VMs",
+				 "[option ...]",
+				 "  --prefix    azure group name prefix (ha-demo)\n"
+				 "  --region    name to use for referencing the region\n"
+				 "  --location  azure location where to create a resource group\n"
+				 "  --monitor   should we create a monitor in the region (false)\n"
+				 "  --nodes     number of Postgres nodes to create (2)\n"
+				 "  --script    output a shell script instead of creating resources\n",
+				 cli_do_azure_getopts,
+				 cli_do_azure_create_region);
+
+CommandLine do_azure_create_nodes =
+	make_command("nodes",
+				 "Provision our pre-created VM with pg_autoctl Postgres nodes",
+				 "[option ...]",
+				 "  --prefix    azure group name prefix (ha-demo)\n"
+				 "  --region    name to use for referencing the region\n"
+				 "  --monitor   should we create a monitor in the region (false)\n"
+				 "  --nodes     number of Postgres nodes to create (2)\n"
+				 "  --script    output a shell script instead of creating resources\n",
+				 cli_do_azure_getopts,
+				 cli_do_azure_create_nodes);
+
+
+CommandLine *do_azure_create[] = {
+	&do_azure_create_region,
+	&do_azure_create_nodes,
+	NULL
+};
+
+CommandLine do_azure_create_commands =
+	make_command_set("create",
+					 "create azure resources for a pg_auto_failover demo",
+					 NULL, NULL, NULL, do_azure_create);
+
+CommandLine do_azure_show_ips =
+	make_command("ips",
+				 "Show public and private IP addresses for selected VMs",
+				 "[option ...]",
+				 "  --prefix    azure group name prefix (ha-demo)\n"
+				 "  --region    name to use for referencing the region\n",
+				 cli_do_azure_getopts,
+				 cli_do_azure_show_ips);
+
+CommandLine do_azure_show_state =
+	make_command("state",
+				 "Connect to the monitor node to show the current state",
+				 "[option ...]",
+				 "  --prefix    azure group name prefix (ha-demo)\n"
+				 "  --region    name to use for referencing the region\n"
+				 "  --watch     run the command again every 0.2s\n",
+				 cli_do_azure_getopts,
+				 cli_do_azure_show_state);
+
+CommandLine *do_azure_show[] = {
+	&do_azure_show_ips,
+	&do_azure_show_state,
+	NULL
+};
+
+CommandLine do_azure_show_commands =
+	make_command_set("show",
+					 "show azure resources for a pg_auto_failover demo",
+					 NULL, NULL, NULL, do_azure_show);
+
+CommandLine do_azure_ls =
+	make_command("ls",
+				 "List resources in a given azure region",
+				 "[option ...]",
+				 "  --prefix    azure group name prefix (ha-demo)\n"
+				 "  --region    name to use for referencing the region\n",
+				 cli_do_azure_getopts,
+				 cli_do_azure_ls);
+
+CommandLine do_azure_ssh =
+	make_command("ssh",
+				 "Runs ssh -l ha-admin <public ip address> for a given VM name",
+				 "[option ...]",
+				 "  --prefix    azure group name prefix (ha-demo)\n"
+				 "  --region    name to use for referencing the region\n",
+				 cli_do_azure_getopts,
+				 cli_do_azure_ssh);
+
+CommandLine do_azure_sync =
+	make_command("sync",
+				 "Rsync pg_auto_failover sources on all the target region VMs",
+				 "[option ...]",
+				 "  --prefix    azure group name prefix (ha-demo)\n"
+				 "  --region    region to use for referencing the region\n"
+				 "  --monitor   should we create a monitor in the region (false)\n"
+				 "  --nodes     number of Postgres nodes to create (2)\n",
+				 cli_do_azure_getopts,
+				 cli_do_azure_rsync);
+
+CommandLine *do_azure[] = {
+	&do_azure_create_commands,
+	&do_azure_show_commands,
+	&do_azure_ls,
+	&do_azure_ssh,
+	&do_azure_sync,
+	NULL
+};
+
+CommandLine do_azure_commands =
+	make_command_set("azure",
+					 "manage a set of azure resources for a pg_auto_failover demo",
+					 NULL, NULL, NULL, do_azure);
+
+
 CommandLine *do_subcommands[] = {
 	&do_monitor_commands,
 	&do_fsm_commands,
@@ -317,6 +428,7 @@ CommandLine *do_subcommands[] = {
 	&do_service_postgres_ctl_commands,
 	&do_service_commands,
 	&do_tmux_commands,
+	&do_azure_commands,
 	NULL
 };
 

--- a/src/bin/pg_autoctl/cli_do_root.h
+++ b/src/bin/pg_autoctl/cli_do_root.h
@@ -60,6 +60,8 @@ extern CommandLine do_standby_promote;
 
 extern CommandLine do_discover;
 
+extern CommandLine do_azure_ssh;
+
 extern CommandLine do_commands;
 extern CommandLine *do_subcommands[];
 
@@ -96,5 +98,15 @@ void cli_do_tmux_session(int argc, char **argv);
 void cli_do_tmux_stop(int argc, char **argv);
 void cli_do_tmux_clean(int argc, char **argv);
 void cli_do_tmux_wait(int argc, char **argv);
+
+/* src/bin/pg_autoctl_cli_do_azure.c */
+int cli_do_azure_getopts(int argc, char **argv);
+void cli_do_azure_create_region(int argc, char **argv);
+void cli_do_azure_create_nodes(int argc, char **argv);
+void cli_do_azure_ls(int argc, char **argv);
+void cli_do_azure_show_ips(int argc, char **argv);
+void cli_do_azure_ssh(int argc, char **argv);
+void cli_do_azure_rsync(int argc, char **argv);
+void cli_do_azure_show_state(int argc, char **argv);
 
 #endif  /* CLI_DO_ROOT_H */

--- a/src/bin/pg_autoctl/cli_do_root.h
+++ b/src/bin/pg_autoctl/cli_do_root.h
@@ -99,15 +99,19 @@ void cli_do_tmux_stop(int argc, char **argv);
 void cli_do_tmux_clean(int argc, char **argv);
 void cli_do_tmux_wait(int argc, char **argv);
 
-/* src/bin/pg_autoctl_cli_do_azure.c */
+/* src/bin/pg_autoctl/cli_do_azure.c */
 int cli_do_azure_getopts(int argc, char **argv);
+void cli_do_azure_create_environment(int argc, char **argv);
 void cli_do_azure_create_region(int argc, char **argv);
 void cli_do_azure_drop_region(int argc, char **argv);
+void cli_do_azure_deploy(int argc, char **argv);
 void cli_do_azure_create_nodes(int argc, char **argv);
 void cli_do_azure_ls(int argc, char **argv);
 void cli_do_azure_show_ips(int argc, char **argv);
 void cli_do_azure_ssh(int argc, char **argv);
 void cli_do_azure_rsync(int argc, char **argv);
 void cli_do_azure_show_state(int argc, char **argv);
+void cli_do_azure_tmux_session(int argc, char **argv);
+void cli_do_azure_tmux_kill(int argc, char **argv);
 
 #endif  /* CLI_DO_ROOT_H */

--- a/src/bin/pg_autoctl/cli_do_root.h
+++ b/src/bin/pg_autoctl/cli_do_root.h
@@ -102,6 +102,7 @@ void cli_do_tmux_wait(int argc, char **argv);
 /* src/bin/pg_autoctl_cli_do_azure.c */
 int cli_do_azure_getopts(int argc, char **argv);
 void cli_do_azure_create_region(int argc, char **argv);
+void cli_do_azure_drop_region(int argc, char **argv);
 void cli_do_azure_create_nodes(int argc, char **argv);
 void cli_do_azure_ls(int argc, char **argv);
 void cli_do_azure_show_ips(int argc, char **argv);

--- a/src/bin/pg_autoctl/cli_do_tmux.h
+++ b/src/bin/pg_autoctl/cli_do_tmux.h
@@ -63,11 +63,13 @@ void tmux_pg_autoctl_create_postgres(PQExpBuffer script,
 									 bool replicationQuorum,
 									 int candidatePriority);
 
-bool tmux_start_server(const char *root, const char *scriptName);
+bool tmux_start_server(const char *scriptName);
 bool pg_autoctl_getpid(const char *pgdata, pid_t *pid);
 
 bool tmux_has_session(const char *tmux_path, const char *sessionName);
+bool tmux_attach_session(const char *tmux_path, const char *sessionName);
 bool tmux_kill_session(TmuxOptions *options);
+bool tmux_kill_session_by_name(const char *sessionName);
 
 void tmux_process_options(TmuxOptions *options);
 void tmux_cleanup_stale_directory(TmuxOptions *options);

--- a/src/bin/pg_autoctl/cli_do_tmux_azure.c
+++ b/src/bin/pg_autoctl/cli_do_tmux_azure.c
@@ -169,7 +169,7 @@ prepare_tmux_azure_script(AzureRegionResources *azRegion, PQExpBuffer script)
 	tmux_add_command(script, "select-layout even-vertical");
 
 	tmux_add_send_keys_command(script,
-							   "%s do azure show state",
+							   "%s do azure show state --watch",
 							   pg_autoctl_argv0);
 
 	/* add a window for interactive pg_autoctl commands */

--- a/src/bin/pg_autoctl/cli_do_tmux_azure.c
+++ b/src/bin/pg_autoctl/cli_do_tmux_azure.c
@@ -1,0 +1,245 @@
+/*
+ * src/bin/pg_autoctl/cli_do_tmux_azure.c
+ *
+ *     Implementation of commands that create a tmux session to connect to a
+ *     set of Azure VMs where we run pg_autoctl nodes for QA and testing.
+ *
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the PostgreSQL License.
+ *
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <getopt.h>
+#include <inttypes.h>
+#include <termios.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "postgres_fe.h"
+#include "pqexpbuffer.h"
+#include "snprintf.h"
+
+#include "azure.h"
+#include "azure_config.h"
+#include "cli_common.h"
+#include "cli_do_root.h"
+#include "cli_do_tmux.h"
+#include "cli_root.h"
+#include "commandline.h"
+#include "config.h"
+#include "env_utils.h"
+#include "log.h"
+#include "pidfile.h"
+#include "signals.h"
+#include "string_utils.h"
+
+#include "runprogram.h"
+
+static void tmux_azure_new_session(PQExpBuffer script,
+								   AzureRegionResources *azRegion);
+
+static void tmux_azure_deploy(PQExpBuffer script,
+							  AzureRegionResources *azRegion,
+							  const char *vmName);
+
+static void tmux_azure_ssh(PQExpBuffer script, AzureRegionResources *azRegion,
+						   const char *vmName);
+
+static void tmux_azure_systemctl_status(PQExpBuffer script,
+										AzureRegionResources *azRegion);
+
+static void prepare_tmux_azure_script(AzureRegionResources *azRegion,
+									  PQExpBuffer script);
+
+
+/*
+ * tmux_azure_new_session appends a new-session command to the given tmux
+ * script buffer, using the azure group name for the tmux session name.
+ */
+static void
+tmux_azure_new_session(PQExpBuffer script, AzureRegionResources *azRegion)
+{
+	tmux_add_command(script, "new-session -s %s", azRegion->group);
+}
+
+
+/*
+ * tmux_azure_deploy_postgres appends a pg_autoctl do azure deploy command for
+ * the given vmName to the given script buffer.
+ */
+static void
+tmux_azure_deploy(PQExpBuffer script, AzureRegionResources *azRegion,
+				  const char *vmName)
+{
+	tmux_add_send_keys_command(script,
+							   "%s do azure deploy %s",
+							   pg_autoctl_argv0,
+							   vmName);
+}
+
+
+/*
+ * tmux_azure_ssh appends a pg_autoctl do azure ssh command for the given
+ * vmName to the given script buffer.
+ */
+static void
+tmux_azure_ssh(PQExpBuffer script, AzureRegionResources *azRegion,
+			   const char *vmName)
+{
+	tmux_add_send_keys_command(script,
+							   "%s do azure ssh %s",
+							   pg_autoctl_argv0,
+							   vmName);
+}
+
+
+/*
+ * tmux_azure_ssh appends a pg_autoctl do azure ssh command for the given
+ * vmName to the given script buffer.
+ */
+static void
+tmux_azure_systemctl_status(PQExpBuffer script,
+							AzureRegionResources *azRegion)
+{
+	tmux_add_send_keys_command(script, "systemctl status pgautofailover");
+}
+
+
+/*
+ * prepare_tmux_script prepares a script for a tmux session with the given
+ * azure region resources.
+ */
+static void
+prepare_tmux_azure_script(AzureRegionResources *azRegion, PQExpBuffer script)
+{
+	tmux_add_command(script, "set-option -g default-shell /bin/bash");
+
+	tmux_azure_new_session(script, azRegion);
+
+	/* deploy VMs each in a new tmux window */
+	for (int vmIndex = 0; vmIndex <= azRegion->nodes; vmIndex++)
+	{
+		const char *vmName = azRegion->vmArray[vmIndex].name;
+
+		/* after the first VM, create new tmux windows for each VM */
+		if (vmIndex > 0)
+		{
+			tmux_add_command(script, "split-window -v");
+			tmux_add_command(script, "select-layout even-vertical");
+		}
+
+		tmux_azure_deploy(script, azRegion, vmName);
+		tmux_azure_ssh(script, azRegion, vmName);
+		tmux_azure_systemctl_status(script, azRegion);
+	}
+
+	/* add a window for pg_autoctl show state */
+	tmux_add_command(script, "split-window -v");
+	tmux_add_command(script, "select-layout even-vertical");
+
+	tmux_add_send_keys_command(script,
+							   "%s do azure show state",
+							   pg_autoctl_argv0);
+
+	/* add a window for interactive pg_autoctl commands */
+	tmux_add_command(script, "split-window -v");
+	tmux_add_command(script, "select-layout even-vertical");
+	tmux_add_send_keys_command(script,
+							   "%s do azure show ips",
+							   pg_autoctl_argv0);
+}
+
+
+/*
+ * cli_do_azure_tmux_session starts a new tmux session for the given azure
+ * region and resources, or attach an existing session that might be running in
+ * the background already.
+ */
+bool
+tmux_azure_start_or_attach_session(AzureRegionResources *azRegion)
+{
+	char tmux[MAXPGPATH] = { 0 };
+
+	PQExpBuffer script = createPQExpBuffer();
+	char scriptName[MAXPGPATH] = { 0 };
+
+	if (setenv("PG_AUTOCTL_DEBUG", "1", 1) != 0)
+	{
+		log_error("Failed to set environment PG_AUTOCTL_DEBUG: %m");
+		return false;
+	}
+
+	if (!search_path_first("tmux", tmux, LOG_ERROR))
+	{
+		log_fatal("Failed to find program tmux in PATH");
+		return false;
+	}
+
+	/* we might just re-use a pre-existing tmux session */
+	if (!dryRun && tmux_has_session(tmux, azRegion->group))
+	{
+		return tmux_attach_session(tmux, azRegion->group);
+	}
+
+	/*
+	 * Okay, so we have to create the session now. And for that we need the IP
+	 * addresses of the target VMs.
+	 */
+	if (!azure_fetch_ip_addresses(azRegion->group, azRegion->vmArray))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	if (script == NULL)
+	{
+		log_error("Failed to allocate memory");
+		return false;
+	}
+
+	/* prepare the tmux script */
+	(void) prepare_tmux_azure_script(azRegion, script);
+
+	/*
+	 * Start a tmux session from the script.
+	 */
+	if (dryRun)
+	{
+		fformat(stdout, "%s", script->data);
+		destroyPQExpBuffer(script);
+	}
+	else
+	{
+		/* write the tmux script to file */
+		sformat(scriptName, sizeof(scriptName), "%s.tmux", azRegion->group);
+		log_info("Writing tmux session script \"%s\"", scriptName);
+
+		if (!write_file(script->data, script->len, scriptName))
+		{
+			log_fatal("Failed to write tmux script at \"%s\"", scriptName);
+			return false;
+		}
+
+		if (!tmux_start_server(scriptName))
+		{
+			log_fatal("Failed to start the tmux session, see above for details");
+			return false;
+		}
+	}
+
+	return true;
+}
+
+
+/*
+ * tmux_azure_kill_session kills a tmux session for the given QA setup, when
+ * the tmux session already exists.
+ */
+bool
+tmux_azure_kill_session(AzureRegionResources *azRegion)
+{
+	return tmux_kill_session_by_name(azRegion->group);
+}


### PR DESCRIPTION
The following commands allow to easily deploy a testing or QA environment
for pg_auto_failover using Azure VMs, which looks more like what typical
users and customers are using than our default `make cluster` approach where
all the nodes are running on localhost.

In particular we can test system integration and packages based
provisioning, so that's better for end-to-end QA.

Here's the list of new commands provided:

    pg_autoctl do azure
    + provision  provision azure resources for a pg_auto_failover demo
    + tmux       Run a tmux session with an Azure setup for QA/testing
    + show       show azure resources for a pg_auto_failover demo
      deploy     Deploy a pg_autoctl VMs, given by name
      create     Create an azure QA environment
      drop       Drop an azure QA environment: resource group, network, VMs
      ls         List resources in a given azure region
      ssh        Runs ssh -l ha-admin <public ip address> for a given VM name
      sync       Rsync pg_auto_failover sources on all the target region VMs
  
    pg_autoctl do azure provision
      region  Provision an azure region: resource group, network, VMs
      nodes   Provision our pre-created VM with pg_autoctl Postgres nodes
  
    pg_autoctl do azure tmux
      session  Create or attach a tmux session for the created Azure VMs
      kill     Kill an existing tmux session for Azure VMs
  
    pg_autoctl do azure show
      ips    Show public and private IP addresses for selected VMs
      state  Connect to the monitor node to show the current state

And there's the new top-level commands:

    make azcluster
    make azdrop

Contrary to `make cluster` when exiting the tmux session the resources are not dropped, and it's possible to connect again to the same tmux session with either `make azcluster` or `pg_autoctl do azure tmux session`.