### PR TITLE
Deduplicate PATH entries that are symlinks resolving to other PATH entries

### DIFF
--- a/src/bin/pg_autoctl/file_utils.c
+++ b/src/bin/pg_autoctl/file_utils.c
@@ -607,13 +607,6 @@ search_path(const char *filename, SearchPath *result)
 bool
 search_path_deduplicate_symlinks(SearchPath *results, SearchPath *dedup)
 {
-	if (results->found < 2)
-	{
-		/* copy our results over to dedup and be done already */
-		*dedup = *results;
-		return true;
-	}
-
 	/* now re-initialize the target structure dedup */
 	dedup->found = 0;
 
@@ -631,21 +624,14 @@ search_path_deduplicate_symlinks(SearchPath *results, SearchPath *dedup)
 		}
 
 		/* add-in the realpath to dedup, unless it's already in there */
-		if (dedup->found == 0)
+		for (int dIndex = 0; dIndex < dedup->found; dIndex++)
 		{
-			alreadyThere = false;
-		}
-		else
-		{
-			for (int dIndex = 0; dIndex < dedup->found; dIndex++)
+			if (strcmp(dedup->matches[dIndex], currentRealPath) == 0)
 			{
-				if (strcmp(dedup->matches[dIndex], currentRealPath) == 0)
-				{
-					alreadyThere = true;
+				alreadyThere = true;
 
-					log_debug("dedup: skipping \"%s\"", currentPath);
-					break;
-				}
+				log_debug("dedup: skipping \"%s\"", currentPath);
+				break;
 			}
 		}
 

--- a/src/bin/pg_autoctl/file_utils.h
+++ b/src/bin/pg_autoctl/file_utils.h
@@ -56,6 +56,7 @@ void path_in_same_directory(const char *basePath,
 
 bool search_path_first(const char *filename, char *result, int logLevel);
 bool search_path(const char *filename, SearchPath *result);
+bool search_path_deduplicate_symlinks(SearchPath *results, SearchPath *dedup);
 bool unlink_file(const char *filename);
 bool set_program_absolute_path(char *program, int size);
 bool normalize_filename(const char *filename, char *dst, int size);

--- a/src/bin/pg_autoctl/pgctl.c
+++ b/src/bin/pg_autoctl/pgctl.c
@@ -306,10 +306,18 @@ set_pg_ctl_from_PG_CONFIG(PostgresSetup *pgSetup)
 bool
 set_pg_ctl_from_pg_config(PostgresSetup *pgSetup)
 {
+	SearchPath all_pg_configs = { 0 };
 	SearchPath pg_configs = { 0 };
 
-	if (!search_path("pg_config", &pg_configs))
+	if (!search_path("pg_config", &all_pg_configs))
 	{
+		return false;
+	}
+
+	if (!search_path_deduplicate_symlinks(&all_pg_configs, &pg_configs))
+	{
+		log_error("Failed to resolve symlinks found in PATH entries, "
+				  "see above for details");
 		return false;
 	}
 


### PR DESCRIPTION
In recent debian releases /bin is a symlink to /usr/bin, which means we're
going to find pg_config twice on that system. But it's twice the same entry,
and we can deduplicate and realize we only have one entry actually.

Fixes #545 