### PR TITLE
Fix bytes mangling opportunity.

### DIFF
--- a/src/bin/lib/subcommands.c/runprogram.h
+++ b/src/bin/lib/subcommands.c/runprogram.h
@@ -596,6 +596,9 @@ read_into_buf(Program *prog, int filedes, PQExpBuffer buffer, bool error)
 
 	if (bytes > 0)
 	{
+		/* terminate the buffer after the length we read bytes */
+		temp_buffer[bytes] = '\0';
+
 		appendPQExpBufferStr(buffer, temp_buffer);
 
 		if (prog->processBuffer)

--- a/src/bin/lib/subcommands.c/runprogram.h
+++ b/src/bin/lib/subcommands.c/runprogram.h
@@ -591,12 +591,12 @@ waitprogram(Program *prog, pid_t childPid)
 static size_t
 read_into_buf(Program *prog, int filedes, PQExpBuffer buffer, bool error)
 {
-	char temp_buffer[BUFSIZE] = { 0 };
+	char temp_buffer[BUFSIZE+1] = { 0 };
 	size_t bytes = read(filedes, temp_buffer, BUFSIZE);
 
 	if (bytes > 0)
 	{
-		/* terminate the buffer after the length we read bytes */
+		/* terminate the buffer after the length we read */
 		temp_buffer[bytes] = '\0';
 
 		appendPQExpBufferStr(buffer, temp_buffer);


### PR DESCRIPTION
The read() call might have left garbage in the buffer after the last byte,
so enforce end-of-string at the boundary returned.