### PR TITLE
Test/run make installcheck in docker and travis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the PostgreSQL License.
 
-FSM = docs/fsm.png
-CONTAINER_NAME = pg_auto_failover
 TEST_CONTAINER_NAME = pg_auto_failover_test
 DOCKER_RUN_OPTS = --privileged  -ti --rm
-PDF = ./docs/_build/latex/pg_auto_failover.pdf
 
 NOSETESTS = $(shell which nosetests3 || which nosetests)
 
@@ -25,8 +22,14 @@ else
 	TEST_ARGUMENT = $(TEST:%=tests/%.py)
 endif
 
+# Documentation and images
+FSM = docs/fsm.png
+PDF = ./docs/_build/latex/pg_auto_failover.pdf
+
+# Command line with DEBUG facilities
 PG_AUTOCTL = PG_AUTOCTL_DEBUG=1 ./src/bin/pg_autoctl/pg_autoctl
 
+# make cluster arguments
 NODES ?= 2
 NODES_ASYNC ?= 0
 NODES_SYNC_SB ?= -1
@@ -37,6 +40,7 @@ TMUX_LAYOUT ?= even-vertical	# could be "tiled"
 TMUX_TOP_DIR = ./tmux
 TMUX_SCRIPT = ./tmux/script-$(FIRST_PGPORT).tmux
 
+# make azcluster arguments
 AZURE_PREFIX ?= ha-demo-$(shell whoami)
 AZURE_REGION ?= paris
 AZURE_LOCATION ?= francecentral

--- a/src/monitor/expected/dummy_update.out
+++ b/src/monitor/expected/dummy_update.out
@@ -19,5 +19,5 @@ select installed_version
 -- should error because installed extension isn't compatible with .so
 select * from pgautofailover.get_primary('unknown formation');
 ERROR:  loaded "pgautofailover" library version differs from installed extension version
-DETAIL:  Loaded library requires 1.3, but the installed extension version is dummy.
+DETAIL:  Loaded library requires 1.4, but the installed extension version is dummy.
 HINT:  Run ALTER EXTENSION pgautofailover UPDATE and try again.

--- a/src/monitor/expected/monitor.out
+++ b/src/monitor/expected/monitor.out
@@ -85,11 +85,17 @@ assigned_group_state        | catchingup
 assigned_candidate_priority | 100
 assigned_replication_quorum | t
 
--- attempt to register node_3 now fails because node_1 is still in wait_primary
+-- register node_3 concurrently to node2 (probably) doing pg_basebackup
 select *
   from pgautofailover.register_node('default', 'localhost', 9879, 'postgres');
-ERROR:  primary node localhost:9876 is already in state wait_primary
-HINT:  Retry registering in a moment
+-[ RECORD 1 ]---------------+-------------
+assigned_node_id            | 3
+assigned_group_id           | 0
+assigned_group_state        | wait_standby
+assigned_candidate_priority | 100
+assigned_replication_quorum | t
+assigned_node_name          | node_3
+
 select formationid, nodename, goalstate, reportedstate
   from pgautofailover.node;
 -[ RECORD 1 ]-+-------------
@@ -102,6 +108,11 @@ formationid   | default
 nodename      | node_2
 goalstate     | catchingup
 reportedstate | wait_standby
+-[ RECORD 3 ]-+-------------
+formationid   | default
+nodename      | node_3
+goalstate     | wait_standby
+reportedstate | init
 
 table pgautofailover.formation;
 -[ RECORD 1 ]--------+---------
@@ -109,7 +120,7 @@ formationid          | default
 kind                 | pgsql
 dbname               | postgres
 opt_secondary        | t
-number_sync_standbys | 0
+number_sync_standbys | 1
 
 -- dump the pgautofailover.node table, omitting the timely columns
 select formationid, nodeid, groupid, nodehost, nodeport,
@@ -135,6 +146,16 @@ goalstate           | catchingup
 reportedstate       | wait_standby
 reportedpgisrunning | t
 reportedrepstate    | unknown
+-[ RECORD 3 ]-------+-------------
+formationid         | default
+nodeid              | 3
+groupid             | 0
+nodehost            | localhost
+nodeport            | 9879
+goalstate           | wait_standby
+reportedstate       | init
+reportedpgisrunning | t
+reportedrepstate    | async
 
 select * from pgautofailover.get_primary('unknown formation');
 ERROR:  group has no writable node right now
@@ -162,7 +183,15 @@ node_host       | localhost
 node_port       | 9877
 node_lsn        | 0/0
 node_is_primary | f
+-[ RECORD 2 ]---+----------
+node_id         | 3
+node_name       | node_3
+node_host       | localhost
+node_port       | 9879
+node_lsn        | 0/0
+node_is_primary | f
 
+-- remove the primary node
 select pgautofailover.remove_node(1);
 -[ RECORD 1 ]--
 remove_node | t
@@ -181,11 +210,21 @@ select formationid, nodeid, groupid, nodehost, nodeport,
   from pgautofailover.node;
 -[ RECORD 1 ]-------+-------------
 formationid         | default
+nodeid              | 3
+groupid             | 0
+nodehost            | localhost
+nodeport            | 9879
+goalstate           | report_lsn
+reportedstate       | init
+reportedpgisrunning | t
+reportedrepstate    | async
+-[ RECORD 2 ]-------+-------------
+formationid         | default
 nodeid              | 2
 groupid             | 0
 nodehost            | localhost
 nodeport            | 9877
-goalstate           | single
+goalstate           | report_lsn
 reportedstate       | wait_standby
 reportedpgisrunning | t
 reportedrepstate    | unknown
@@ -198,26 +237,6 @@ node_name | node_2
 node_host | localhost
 node_port | 9877
 
--- node_2 reports catchingup and gets assigned single, now alone
-select *
-  from pgautofailover.node_active('default', 2, 0,
-                                  current_group_role => 'catchingup');
--[ RECORD 1 ]---------------+-------
-assigned_node_id            | 2
-assigned_group_id           | 0
-assigned_group_state        | single
-assigned_candidate_priority | 100
-assigned_replication_quorum | t
-
-select * from pgautofailover.node_active('default', 2, 0);
--[ RECORD 1 ]---------------+-------
-assigned_node_id            | 2
-assigned_group_id           | 0
-assigned_group_state        | single
-assigned_candidate_priority | 100
-assigned_replication_quorum | t
-
 -- should fail as there's no primary at this point
 select pgautofailover.perform_failover();
-ERROR:  cannot fail over: group 0 in formation default currently has 1 node registered
-DETAIL:  At least 2 nodes are required to implement a failover
+ERROR:  couldn't find the primary node in formation "default", group 0

--- a/src/monitor/expected/workers.out
+++ b/src/monitor/expected/workers.out
@@ -19,27 +19,27 @@ select *
                                     desired_group_id => 0,
                                     node_kind => 'coordinator');
 -[ RECORD 1 ]---------------+--------------
-assigned_node_id            | 3
+assigned_node_id            | 4
 assigned_group_id           | 0
 assigned_group_state        | single
 assigned_candidate_priority | 100
 assigned_replication_quorum | t
-assigned_node_name          | coordinator_3
+assigned_node_name          | coordinator_4
 
 select *
-  from pgautofailover.set_node_system_identifier(3, 6862008014275870855);
+  from pgautofailover.set_node_system_identifier(4, 6862008014275870855);
 -[ RECORD 1 ]------------
-node_id   | 3
-node_name | coordinator_3
+node_id   | 4
+node_name | coordinator_4
 node_host | localhost
 node_port | 9876
 
 -- coordinator_1 reports single
 select *
-  from pgautofailover.node_active('citus', 3, 0,
+  from pgautofailover.node_active('citus', 4, 0,
                                   current_group_role => 'single');
 -[ RECORD 1 ]---------------+-------
-assigned_node_id            | 3
+assigned_node_id            | 4
 assigned_group_id           | 0
 assigned_group_state        | single
 assigned_candidate_priority | 100
@@ -52,10 +52,10 @@ select *
                                     desired_group_id => 1,
                                     node_kind => 'worker');
 -[ RECORD 1 ]---------------+---------
-assigned_node_id            | 4
+assigned_node_id            | 5
 assigned_group_id           | 1
 assigned_group_state        | single
 assigned_candidate_priority | 100
 assigned_replication_quorum | t
-assigned_node_name          | worker_4
+assigned_node_name          | worker_5
 

--- a/src/monitor/sql/monitor.sql
+++ b/src/monitor/sql/monitor.sql
@@ -38,7 +38,7 @@ select *
   from pgautofailover.node_active('default', 2, 0,
                                   current_group_role => 'wait_standby');
 
--- attempt to register node_3 now fails because node_1 is still in wait_primary
+-- register node_3 concurrently to node2 (probably) doing pg_basebackup
 select *
   from pgautofailover.register_node('default', 'localhost', 9879, 'postgres');
 
@@ -59,6 +59,7 @@ select * from pgautofailover.get_primary();
 select * from pgautofailover.get_primary('default', 0);
 select * from pgautofailover.get_other_nodes(1);
 
+-- remove the primary node
 select pgautofailover.remove_node(1);
 
 table pgautofailover.formation;
@@ -70,13 +71,6 @@ select formationid, nodeid, groupid, nodehost, nodeport,
 
 select *
   from pgautofailover.set_node_system_identifier(2, 6852685710417058800);
-
--- node_2 reports catchingup and gets assigned single, now alone
-select *
-  from pgautofailover.node_active('default', 2, 0,
-                                  current_group_role => 'catchingup');
-
-select * from pgautofailover.node_active('default', 2, 0);
 
 -- should fail as there's no primary at this point
 select pgautofailover.perform_failover();

--- a/src/monitor/sql/workers.sql
+++ b/src/monitor/sql/workers.sql
@@ -17,11 +17,11 @@ select *
                                     node_kind => 'coordinator');
 
 select *
-  from pgautofailover.set_node_system_identifier(3, 6862008014275870855);
+  from pgautofailover.set_node_system_identifier(4, 6862008014275870855);
 
 -- coordinator_1 reports single
 select *
-  from pgautofailover.node_active('citus', 3, 0,
+  from pgautofailover.node_active('citus', 4, 0,
                                   current_group_role => 'single');
 
 -- register first worker

--- a/tests/test_installcheck.py
+++ b/tests/test_installcheck.py
@@ -1,0 +1,74 @@
+import pgautofailover_utils as pgautofailover
+from nose.tools import *
+
+import subprocess
+import shutil
+import os
+
+cluster = None
+node1 = None
+node2 = None
+
+
+def setup_module():
+    global cluster
+    cluster = pgautofailover.Cluster()
+
+
+def teardown_module():
+    cluster.destroy()
+
+
+def test_000_create_monitor():
+    monitor = cluster.create_monitor("/tmp/check/monitor")
+    monitor.run()
+    monitor.wait_until_pg_is_running()
+
+
+def test_001_add_hba_entry():
+    with open(os.path.join("/tmp/check/monitor", "pg_hba.conf"), "a") as hba:
+        hba.write("host all all %s trust\n" % cluster.networkSubnet)
+
+    # print()
+    # with open(os.path.join("/tmp/check/monitor", "pg_hba.conf"), "r") as hba:
+    #     lines = hba.readlines()
+    #     for line in lines[-10:]:
+    #         print("%s" % line[:-1])
+
+    cluster.monitor.reload_postgres()
+
+
+def test_002_make_installcheck():
+    p = subprocess.Popen(
+        [
+            "sudo",
+            shutil.which("chmod"),
+            "-R",
+            "go+w",
+            "/usr/src/pg_auto_failover/src/monitor",
+        ]
+    )
+    assert p.wait() == 0
+
+    p = subprocess.Popen(
+        [
+            "sudo",
+            "-E",
+            "-u",
+            os.getenv("USER"),
+            "env",
+            "PATH=" + os.getenv("PATH"),
+            "PGHOST=" + str(cluster.monitor.vnode.address),
+            "make",
+            "-C",
+            "/usr/src/pg_auto_failover/src/monitor",
+            "installcheck",
+        ]
+    )
+
+    if p.wait() != 0:
+        diff = "/usr/src/pg_auto_failover/src/monitor/regression.diffs"
+        with open(diff, "r") as d:
+            print("%s" % d.read())
+
+        raise Exception("make installcheck failed")

--- a/tests/test_installcheck.py
+++ b/tests/test_installcheck.py
@@ -4,6 +4,7 @@ from nose.tools import *
 import subprocess
 import shutil
 import os
+import os.path
 
 cluster = None
 node1 = None
@@ -39,13 +40,19 @@ def test_001_add_hba_entry():
 
 
 def test_002_make_installcheck():
+    # support both the local Dockerfile and also Travis build environments
+    if "TRAVIS_BUILD_DIR" in os.environ:
+        topdir = os.environ["TRAVIS_BUILD_DIR"]
+    else:
+        topdir = "/usr/src/pg_auto_failover"
+
     p = subprocess.Popen(
         [
             "sudo",
             shutil.which("chmod"),
             "-R",
             "go+w",
-            "/usr/src/pg_auto_failover/src/monitor",
+            os.path.join(topdir, "src/monitor"),
         ]
     )
     assert p.wait() == 0
@@ -61,13 +68,13 @@ def test_002_make_installcheck():
             "PGHOST=" + str(cluster.monitor.vnode.address),
             "make",
             "-C",
-            "/usr/src/pg_auto_failover/src/monitor",
+            os.path.join(topdir, "src/monitor"),
             "installcheck",
         ]
     )
 
     if p.wait() != 0:
-        diff = "/usr/src/pg_auto_failover/src/monitor/regression.diffs"
+        diff = os.path.join(topdir, "src/monitor/regression.diffs")
         with open(diff, "r") as d:
             print("%s" % d.read())
 


### PR DESCRIPTION
At the moment the `make -C src/monitor intallcheck` target fails. We often forget to update our test suite for the monitor. This PR includes this step in the travis tests.

Fixes #464 