### PR TITLE
Feature/docker run make cluster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:buster-slim
 
 ENV PGDATA /var/lib/postgresql/data
 
@@ -32,13 +32,13 @@ RUN apt-get update \
     lsof \
     psutils \
     postgresql-common \
-    postgresql-server-dev-13 \
+    postgresql-server-dev-11 \
 	&& rm -rf /var/lib/apt/lists/*
 
 # install Postgres 13 (current in bullseye), bypass initdb of a "main" cluster
 RUN echo 'create_main_cluster = false' | sudo tee -a /etc/postgresql-common/createcluster.conf
 RUN apt-get update\
-	&& apt-get install -y --no-install-recommends postgresql-13 \
+	&& apt-get install -y --no-install-recommends postgresql-11 \
 	&& rm -rf /var/lib/apt/lists/*
 
 RUN adduser --disabled-password --gecos '' docker
@@ -55,6 +55,6 @@ RUN make -s clean && make -s install -j8
 COPY ./tests/ ./tests
 
 USER docker
-ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/postgresql/13/bin
-ENV PGVERSION 13
+ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/postgresql/11/bin
+ENV PGVERSION 11
 ENV PG_AUTOCTL_DEBUG 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-FROM debian:buster-slim
-
-ENV PGDATA /var/lib/postgresql/data
+FROM debian:buster-slim as build-test
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
@@ -58,3 +56,40 @@ USER docker
 ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/postgresql/11/bin
 ENV PGVERSION 11
 ENV PG_AUTOCTL_DEBUG 1
+
+
+FROM debian:stable-slim as run
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    make \
+    sudo \
+    tmux \
+    watch \
+    lsof \
+    psutils \
+    postgresql-common \
+    postgresql-server-dev-11 \
+	&& rm -rf /var/lib/apt/lists/*
+
+# install Postgres 13 (current in bullseye), bypass initdb of a "main" cluster
+RUN echo 'create_main_cluster = false' | sudo tee -a /etc/postgresql-common/createcluster.conf
+RUN apt-get update\
+	&& apt-get install -y --no-install-recommends postgresql-11 \
+	&& rm -rf /var/lib/apt/lists/*
+
+RUN adduser --disabled-password --gecos '' docker
+RUN adduser docker sudo
+RUN adduser docker postgres
+RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+COPY --from=build-test /usr/lib/postgresql/11/lib/pgautofailover.so /usr/lib/postgresql/11/lib
+COPY --from=build-test /usr/share/postgresql/11/extension/pgautofailover* /usr/share/postgresql/11/extension/
+COPY --from=build-test /usr/lib/postgresql/11/bin/pg_autoctl /usr/local/bin
+
+USER docker
+ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/postgresql/11/bin
+ENV PGVERSION 11
+ENV PG_AUTOCTL_DEBUG 1
+
+CMD pg_autoctl do tmux session --nodes 3

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,6 @@ RUN apt-get update \
     lsof \
     psutils \
     postgresql-common \
-    postgresql-server-dev-11 \
 	&& rm -rf /var/lib/apt/lists/*
 
 # install Postgres 13 (current in bullseye), bypass initdb of a "main" cluster

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update \
     libkrb5-dev \
     libssl-dev \
     libedit-dev \
+    libreadline-dev \
     libpam-dev \
     zlib1g-dev \
     libxml2-dev \
@@ -20,18 +21,29 @@ RUN apt-get update \
     make \
     openssl \
     pipenv \
-    postgresql-12 \
-    postgresql-server-dev-12 \
     python3-nose \
     python3 \
 	python3-setuptools \
 	python3-psycopg2 \
 	python3-pyroute2 \
     sudo \
-    && rm -rf /var/lib/apt/lists/*
+    tmux \
+    watch \
+    lsof \
+    psutils \
+    postgresql-common \
+    postgresql-server-dev-13 \
+	&& rm -rf /var/lib/apt/lists/*
+
+# install Postgres 13 (current in bullseye), bypass initdb of a "main" cluster
+RUN echo 'create_main_cluster = false' | sudo tee -a /etc/postgresql-common/createcluster.conf
+RUN apt-get update\
+	&& apt-get install -y --no-install-recommends postgresql-13 \
+	&& rm -rf /var/lib/apt/lists/*
 
 RUN adduser --disabled-password --gecos '' docker
 RUN adduser docker sudo
+RUN adduser docker postgres
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 WORKDIR /usr/src/pg_auto_failover
@@ -43,5 +55,6 @@ RUN make -s clean && make -s install -j8
 COPY ./tests/ ./tests
 
 USER docker
-ENV PATH $PATH:/usr/lib/postgresql/12/bin
-ENV PGVERSION 12
+ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/postgresql/13/bin
+ENV PGVERSION 13
+ENV PG_AUTOCTL_DEBUG 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,7 @@ RUN apt-get update \
     lsof \
     psutils \
     postgresql-common \
+    libpq-dev \
 	&& rm -rf /var/lib/apt/lists/*
 
 # install Postgres 13 (current in bullseye), bypass initdb of a "main" cluster

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@
 # Licensed under the PostgreSQL License.
 
 FSM = docs/fsm.png
-TEST_CONTAINER_NAME = pg_auto_failover-test
+CONTAINER_NAME = pg_auto_failover
+TEST_CONTAINER_NAME = pg_auto_failover_test
 DOCKER_RUN_OPTS = --cap-add=SYS_ADMIN --cap-add=NET_ADMIN -ti --rm
 PDF = ./docs/_build/latex/pg_auto_failover.pdf
 
@@ -95,18 +96,28 @@ indent:
 docs: $(FSM)
 	$(MAKE) -C docs html
 
-build-test:
-	docker build				\
+build:
+	docker build				    \
 		$(DOCKER_BUILD_OPTS)		\
+		-t $(CONTAINER_NAME)	    \
+		.
+
+interactive-test:
+	docker run --name $(CONTAINER_NAME) --rm -ti $(CONTAINER_NAME)
+
+
+build-test:
+	docker build				    \
+		$(DOCKER_BUILD_OPTS)		\
+		--target build-test         \
 		-t $(TEST_CONTAINER_NAME)	\
 		.
 
-
 run-test: build-test
-	docker run					\
-		--name $(TEST_CONTAINER_NAME)		\
-		$(DOCKER_RUN_OPTS)			\
-		$(TEST_CONTAINER_NAME)			\
+	docker run					                \
+		--name $(TEST_CONTAINER_NAME)		    \
+		$(DOCKER_RUN_OPTS)			            \
+		$(TEST_CONTAINER_NAME)			        \
 		make -C /usr/src/pg_auto_failover test	\
 		TEST='${TEST}'
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 FSM = docs/fsm.png
 CONTAINER_NAME = pg_auto_failover
 TEST_CONTAINER_NAME = pg_auto_failover_test
-DOCKER_RUN_OPTS = --cap-add=SYS_ADMIN --cap-add=NET_ADMIN -ti --rm
+DOCKER_RUN_OPTS = --privileged  -ti --rm
 PDF = ./docs/_build/latex/pg_auto_failover.pdf
 
 NOSETESTS = $(shell which nosetests3 || which nosetests)

--- a/src/bin/pg_autoctl/cli_do_tmux.c
+++ b/src/bin/pg_autoctl/cli_do_tmux.c
@@ -35,6 +35,12 @@
 
 #include "runprogram.h"
 
+char *tmux_banner[] = {
+	"# to quit tmux: type either C-b d or `tmux detach`",
+	"# to test failover: pg_autoctl perform failover",
+	NULL
+};
+
 TmuxOptions tmuxOptions = { 0 };
 
 char *xdg[][3] = {
@@ -618,6 +624,11 @@ prepare_tmux_script(TmuxOptions *options, PQExpBuffer script)
 		{
 			appendPQExpBuffer(script, "%s\n", extraLines[lineNumber]);
 		}
+	}
+
+	for (int i = 0; tmux_banner[i] != NULL; i++)
+	{
+		tmux_add_send_keys_command(script, "%s", tmux_banner[i]);
 	}
 }
 

--- a/src/bin/pg_autoctl/cli_do_tmux.c
+++ b/src/bin/pg_autoctl/cli_do_tmux.c
@@ -36,7 +36,7 @@
 #include "runprogram.h"
 
 char *tmux_banner[] = {
-	"# to quit tmux: type either C-b d or `tmux detach`",
+	"# to quit tmux: type either `Ctrl+b d` or `tmux detach`",
 	"# to test failover: pg_autoctl perform failover",
 	NULL
 };

--- a/src/bin/pg_autoctl/cli_do_tmux.c
+++ b/src/bin/pg_autoctl/cli_do_tmux.c
@@ -272,22 +272,43 @@ tmux_add_send_keys_command(PQExpBuffer script, const char *fmt, ...)
 
 /*
  * tmux_add_xdg_environment sets the environment variables that we need for the
- * whole session to be self-contained in the given root directory.
+ * whole session to be self-contained in the given root directory. The
+ * implementation of this function relies on the fact that the tmux script has
+ * been prepared with tmux set-environment commands, per tmux_setenv.
  */
 void
-tmux_add_xdg_environment(PQExpBuffer script, const char *root)
+tmux_add_xdg_environment(PQExpBuffer script)
 {
-	/*
-	 * For demo/tests purposes, arrange a self-contained setup where everything
-	 * is to be found in the given options.root directory.
-	 */
+	tmux_add_send_keys_command(script, "eval $(tmux show-environment -s)");
+}
+
+
+/*
+ * tmux_setenv adds setenv commands to the tmux script.
+ */
+void
+tmux_setenv(PQExpBuffer script, const char *sessionName, const char *root)
+{
+	char PATH[BUFSIZE] = { 0 };
+
+	if (!get_env_copy("PATH", PATH, sizeof(PATH)))
+	{
+		log_fatal("Failed to get PATH from the environment");
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+
+	tmux_add_command(script, "set-environment -t %s PATH %s", sessionName, PATH);
+
 	for (int i = 0; xdg[i][0] != NULL; i++)
 	{
 		char *var = xdg[i][0];
 		char *dir = xdg[i][1];
 
-		tmux_add_send_keys_command(script,
-								   "export %s=\"%s/%s\"", var, root, dir);
+		tmux_add_command(script, "set-environment -t %s %s \"%s/%s\"",
+						 sessionName,
+						 var,
+						 root,
+						 dir);
 	}
 }
 
@@ -381,12 +402,13 @@ tmux_add_new_session(PQExpBuffer script, const char *root, int pgport)
 	 * For demo/tests purposes, arrange a self-contained setup where everything
 	 * is to be found in the given options.root directory.
 	 */
-	for (int i = 0; xdg[i][0] != NULL; i++)
-	{
-		char *var = xdg[i][0];
 
-		tmux_add_command(script, "set-option update-environment %s", var);
-	}
+	/* for (int i = 0; xdg[i][0] != NULL; i++) */
+	/* { */
+	/*  char *var = xdg[i][0]; */
+
+	/*  tmux_add_command(script, "set-option update-environment %s", var); */
+	/* } */
 
 	tmux_add_command(script, "new-session -s %s", sessionName);
 }
@@ -475,9 +497,10 @@ prepare_tmux_script(TmuxOptions *options, PQExpBuffer script)
 	tmux_add_command(script, "set-option -g default-shell /bin/bash");
 
 	(void) tmux_add_new_session(script, root, pgport);
+	(void) tmux_setenv(script, sessionName, root);
 
 	/* start a monitor */
-	(void) tmux_add_xdg_environment(script, root);
+	(void) tmux_add_xdg_environment(script);
 	tmux_pg_autoctl_create_monitor(script, root, pgport++);
 
 	/* start the Postgres nodes, using the monitor URI */
@@ -495,7 +518,7 @@ prepare_tmux_script(TmuxOptions *options, PQExpBuffer script)
 		tmux_add_command(script, "split-window -v");
 		tmux_add_command(script, "select-layout even-vertical");
 
-		(void) tmux_add_xdg_environment(script, root);
+		(void) tmux_add_xdg_environment(script);
 
 		/*
 		 * Force node ordering to easy debugging of interactive sessions: each
@@ -527,7 +550,7 @@ prepare_tmux_script(TmuxOptions *options, PQExpBuffer script)
 	tmux_add_command(script, "split-window -v");
 	tmux_add_command(script, "select-layout even-vertical");
 
-	(void) tmux_add_xdg_environment(script, root);
+	(void) tmux_add_xdg_environment(script);
 	tmux_add_send_keys_command(script, "export PGDATA=\"%s/monitor\"", root);
 	tmux_add_send_keys_command(script,
 							   "PG_AUTOCTL_DEBUG=1 "
@@ -542,7 +565,7 @@ prepare_tmux_script(TmuxOptions *options, PQExpBuffer script)
 	/* add a window for interactive pg_autoctl commands */
 	tmux_add_command(script, "split-window -v");
 	tmux_add_command(script, "select-layout even-vertical");
-	(void) tmux_add_xdg_environment(script, root);
+	(void) tmux_add_xdg_environment(script);
 	tmux_add_send_keys_command(script, "export PGDATA=\"%s/monitor\"", root);
 
 	if (options->numSync != -1)
@@ -628,7 +651,7 @@ tmux_start_server(const char *scriptName)
 	 *   tmux start-server \; source-file ${scriptName}
 	 */
 	args[argsIndex++] = (char *) tmux;
-	args[argsIndex++] = "-v";
+	args[argsIndex++] = "-u";
 	args[argsIndex++] = "start-server";
 	args[argsIndex++] = ";";
 	args[argsIndex++] = "source-file";

--- a/src/bin/pg_autoctl/cli_do_tmux.h
+++ b/src/bin/pg_autoctl/cli_do_tmux.h
@@ -48,7 +48,8 @@ bool tmux_has_session(const char *tmux_path, const char *sessionName);
 void tmux_add_new_session(PQExpBuffer script,
 						  const char *root, int pgport);
 
-void tmux_add_xdg_environment(PQExpBuffer script, const char *root);
+void tmux_add_xdg_environment(PQExpBuffer script);
+void tmux_setenv(PQExpBuffer script, const char *sessionName, const char *root);
 bool tmux_prepare_XDG_environment(const char *root,
 								  bool createDirectories);
 

--- a/src/bin/pg_autoctl/pgctl.h
+++ b/src/bin/pg_autoctl/pgctl.h
@@ -35,6 +35,7 @@ bool config_find_pg_ctl(PostgresSetup *pgSetup);
 bool find_extension_control_file(const char *pg_ctl, const char *extName);
 bool pg_ctl_version(PostgresSetup *pgSetup);
 bool set_pg_ctl_from_config_bindir(PostgresSetup *pgSetup, const char *pg_config);
+bool find_pg_config_from_pg_ctl(const char *pg_ctl, char *pg_config, size_t size);
 
 bool pg_add_auto_failover_default_settings(PostgresSetup *pgSetup,
 										   char *configFilePath,


### PR DESCRIPTION
Make it possible to run the following scenario:

    $ docker build -t pg_auto_failover .
    $ docker run --name pg_auto_failover --rm -ti pg_auto_failover

We split the Dockerfile in two separate builds, one that is used to run our test suite, and the other where we only prepare an interactive test environment, and that we should be able to share on dockerhub or other places.

Ideally we will then push our docker image to dockerhub or someplace, and users who just want to see how pg_auto_failover works easily will be able to:

    $ docker run --rm -ti citusdata/pg_auto_failover

In passing, update to newer Docker requirements with respect to privileges, fixing #491.