### PR TITLE
Typo fix from a previous merge.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the PostgreSQL License.
 
+CONTAINER_NAME = pg_auto_failover
 TEST_CONTAINER_NAME = pg_auto_failover_test
 DOCKER_RUN_OPTS = --privileged  -ti --rm
 


### PR DESCRIPTION
Without that we can't do

    $ make build
    $ make interactive-test