### PR TITLE
Implement pg_autoctl create postgres --pg-hba-lan option.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,60 @@
+version: "3.9"  # optional since v1.27.0
+services:
+  monitor:
+    image: citusdata/pg_auto_failover:demo
+    environment:
+      PGDATA: /tmp/pgaf
+      PG_AUTOCTL_DEBUG: 1
+    command: pg_autoctl create monitor --ssl-self-signed --auth trust --run
+    expose:
+      - 5432
+  node1:
+    image: citusdata/pg_auto_failover:demo
+    environment:
+      PGDATA: /tmp/pgaf
+      PG_AUTOCTL_DEBUG: 1
+    command: [
+    "pg_autoctl", "create", "postgres",
+    "--ssl-self-signed",
+    "--auth", "trust",
+    "--pg-hba-lan",
+    "--username", "ad",
+    "--dbname", "analytics",
+    "--monitor", "postgresql://autoctl_node@monitor/pg_auto_failover",
+    "--run"]
+    expose:
+      - 5432
+  node2:
+    image: citusdata/pg_auto_failover:demo
+    expose:
+      - 5432
+    environment:
+      PGDATA: /tmp/pgaf
+      PG_AUTOCTL_DEBUG: 1
+    command: [
+    "pg_autoctl", "create", "postgres",
+    "--ssl-self-signed",
+    "--auth", "trust",
+    "--pg-hba-lan",
+    "--username", "ad",
+    "--dbname", "analytics",
+    "--monitor", "postgresql://autoctl_node@monitor/pg_auto_failover",
+    "--run"]
+    expose:
+      - 5432
+  node3:
+    image: citusdata/pg_auto_failover:demo
+    environment:
+      PGDATA: /tmp/pgaf
+      PG_AUTOCTL_DEBUG: 1
+    command: [
+    "pg_autoctl", "create", "postgres",
+    "--ssl-self-signed",
+    "--auth", "trust",
+    "--pg-hba-lan",
+    "--username", "ad",
+    "--dbname", "analytics",
+    "--monitor", "postgresql://autoctl_node@monitor/pg_auto_failover",
+    "--run"]
+    expose:
+      - 5432

--- a/docs/ref/reference.rst
+++ b/docs/ref/reference.rst
@@ -424,6 +424,7 @@ The other commands accept the same set of options.
     --monitor         pg_auto_failover Monitor Postgres URL
     --auth            authentication method for connections from monitor
     --skip-pg-hba     skip editing pg_hba.conf rules
+    --pg-hba-lan      edit pg_hba.conf rules for --dbname in detected LAN
     --candidate-priority    priority of the node to be promoted to become primary
     --replication-quorum    true if node participates in write quorum
     --ssl-self-signed setup network encryption using self signed certificates (does NOT protect against MITM)

--- a/src/bin/pg_autoctl/cli_common.c
+++ b/src/bin/pg_autoctl/cli_common.c
@@ -232,17 +232,17 @@ cli_common_keeper_getopts(int argc, char **argv,
 			{
 				/* { "pg-hba-lan", required_argument, NULL, 'L' }, */
 				if (LocalOptionConfig.pgSetup.hbaLevel != HBA_EDIT_UNKNOWN &&
-					LocalOptionConfig.pgSetup.hbaLevel != HBA_EDIT_APP)
+					LocalOptionConfig.pgSetup.hbaLevel != HBA_EDIT_LAN)
 				{
 					errors++;
 					log_error("Please use either --skip-pg-hba or --pg-hba-lan");
 				}
 
 				strlcpy(LocalOptionConfig.pgSetup.hbaLevelStr,
-						pgsetup_hba_level_to_string(HBA_EDIT_APP),
+						pgsetup_hba_level_to_string(HBA_EDIT_LAN),
 						sizeof(LocalOptionConfig.pgSetup.hbaLevelStr));
 
-				LocalOptionConfig.pgSetup.hbaLevel = HBA_EDIT_APP;
+				LocalOptionConfig.pgSetup.hbaLevel = HBA_EDIT_LAN;
 
 				log_trace("--pg-hba-lan");
 				break;

--- a/src/bin/pg_autoctl/cli_common.h
+++ b/src/bin/pg_autoctl/cli_common.h
@@ -22,6 +22,7 @@ extern MonitorConfig monitorOptions;
 extern KeeperConfig keeperOptions;
 extern bool createAndRun;
 extern bool outputJSON;
+extern bool openAppHBAonLAN;
 
 #define SSL_CA_FILE_FLAG 1      /* root public certificate */
 #define SSL_CRL_FILE_FLAG 2     /* certificates revocation list */

--- a/src/bin/pg_autoctl/cli_create_drop_node.c
+++ b/src/bin/pg_autoctl/cli_create_drop_node.c
@@ -1305,10 +1305,11 @@ discover_hostname(char *hostname, int size,
 	while (!pgsql_retry_policy_expired(&retryPolicy))
 	{
 		bool mayRetry = false;
+		int logLevel = retryPolicy.attempts == 0 ? LOG_WARN : LOG_DEBUG;
 
 		/* fetch our local address among the network interfaces */
 		if (fetchLocalIPAddress(ipAddr, BUFSIZE, monitorHostname, monitorPort,
-								&mayRetry))
+								logLevel, &mayRetry))
 		{
 			/* success: break out of the retry loop */
 			break;

--- a/src/bin/pg_autoctl/cli_create_drop_node.c
+++ b/src/bin/pg_autoctl/cli_create_drop_node.c
@@ -1305,11 +1305,10 @@ discover_hostname(char *hostname, int size,
 	while (!pgsql_retry_policy_expired(&retryPolicy))
 	{
 		bool mayRetry = false;
-		int logLevel = retryPolicy.attempts == 0 ? LOG_WARN : LOG_DEBUG;
 
 		/* fetch our local address among the network interfaces */
 		if (fetchLocalIPAddress(ipAddr, BUFSIZE, monitorHostname, monitorPort,
-								logLevel, &mayRetry))
+								LOG_DEBUG, &mayRetry))
 		{
 			/* success: break out of the retry loop */
 			break;
@@ -1399,6 +1398,7 @@ check_hostname(const char *hostname)
 	else
 	{
 		char cidr[BUFSIZE];
+		char ipaddr[BUFSIZE];
 
 		if (!fetchLocalCIDR(hostname, cidr, BUFSIZE))
 		{
@@ -1408,6 +1408,6 @@ check_hostname(const char *hostname)
 		}
 
 		/* use pghba_check_hostname for log diagnostics */
-		(void) pghba_check_hostname(hostname);
+		(void) pghba_check_hostname(hostname, ipaddr, sizeof(ipaddr));
 	}
 }

--- a/src/bin/pg_autoctl/cli_create_drop_node.c
+++ b/src/bin/pg_autoctl/cli_create_drop_node.c
@@ -97,9 +97,10 @@ CommandLine create_postgres_command =
 		"  --monitor         pg_auto_failover Monitor Postgres URL\n"
 		"  --auth            authentication method for connections from monitor\n"
 		"  --skip-pg-hba     skip editing pg_hba.conf rules\n"
+		"  --pg-hba-lan      edit pg_hba.conf rules for --dbname in detected LAN\n"
+		KEEPER_CLI_SSL_OPTIONS
 		"  --candidate-priority    priority of the node to be promoted to become primary\n"
-		"  --replication-quorum    true if node participates in write quorum\n"
-		KEEPER_CLI_SSL_OPTIONS,
+		"  --replication-quorum    true if node participates in write quorum\n",
 		cli_create_postgres_getopts,
 		cli_create_postgres);
 
@@ -284,6 +285,7 @@ cli_create_postgres_getopts(int argc, char **argv)
 		{ "username", required_argument, NULL, 'U' },
 		{ "auth", required_argument, NULL, 'A' },
 		{ "skip-pg-hba", no_argument, NULL, 'S' },
+		{ "pg-hba-lan", no_argument, NULL, 'L' },
 		{ "dbname", required_argument, NULL, 'd' },
 		{ "name", required_argument, NULL, 'a' },
 		{ "hostname", required_argument, NULL, 'n' },
@@ -311,7 +313,7 @@ cli_create_postgres_getopts(int argc, char **argv)
 
 	int optind =
 		cli_create_node_getopts(argc, argv, long_options,
-								"C:D:H:p:l:U:A:Sd:a:n:f:m:MI:RVvqhP:r:xsN",
+								"C:D:H:p:l:U:A:SLd:a:n:f:m:MI:RVvqhP:r:xsN",
 								&options);
 
 	/* publish our option parsing in the global variable */
@@ -470,9 +472,13 @@ cli_create_monitor_getopts(int argc, char **argv)
 					log_error("Please use either --auth or --skip-pg-hba");
 				}
 
+				/* force default authentication method then */
 				strlcpy(options.pgSetup.authMethod,
-						SKIP_HBA_AUTH_METHOD,
+						DEFAULT_AUTH_METHOD,
 						NAMEDATALEN);
+
+				options.pgSetup.hbaLevel = HBA_EDIT_SKIP;
+
 				log_trace("--skip-pg-hba");
 				break;
 			}

--- a/src/bin/pg_autoctl/cli_do_misc.c
+++ b/src/bin/pg_autoctl/cli_do_misc.c
@@ -188,6 +188,7 @@ keeper_cli_create_monitor_user(int argc, char **argv)
 									  PG_AUTOCTL_HEALTH_PASSWORD,
 									  monitorHostname,
 									  "trust",
+									  HBA_EDIT_MINIMAL,
 									  connlimit))
 	{
 		log_fatal("Failed to create the database user that the pg_auto_failover "

--- a/src/bin/pg_autoctl/cli_do_root.c
+++ b/src/bin/pg_autoctl/cli_do_root.c
@@ -572,7 +572,7 @@ keeper_cli_keeper_setup_getopts(int argc, char **argv)
 
 	int optind = cli_common_keeper_getopts(argc, argv,
 										   long_options,
-										   "C:D:H:p:l:U:A:Sd:n:f:m:MRVvqhP:r:xsN",
+										   "C:D:H:p:l:U:A:SLd:n:f:m:MRVvqhP:r:xsN",
 										   &options,
 										   &sslCommandLineOptions);
 

--- a/src/bin/pg_autoctl/cli_do_show.c
+++ b/src/bin/pg_autoctl/cli_do_show.c
@@ -88,10 +88,12 @@ static void
 cli_show_ipaddr(int argc, char **argv)
 {
 	char ipAddr[BUFSIZE];
+	bool mayRetry = false;
 
 	if (!fetchLocalIPAddress(ipAddr, BUFSIZE,
 							 DEFAULT_INTERFACE_LOOKUP_SERVICE_NAME,
-							 DEFAULT_INTERFACE_LOOKUP_SERVICE_PORT))
+							 DEFAULT_INTERFACE_LOOKUP_SERVICE_PORT,
+							 &mayRetry))
 	{
 		log_warn("Failed to determine network configuration.");
 		exit(EXIT_CODE_INTERNAL_ERROR);
@@ -111,10 +113,12 @@ cli_show_cidr(int argc, char **argv)
 {
 	char ipAddr[BUFSIZE];
 	char cidr[BUFSIZE];
+	bool mayRetry = false;
 
 	if (!fetchLocalIPAddress(ipAddr, BUFSIZE,
 							 DEFAULT_INTERFACE_LOOKUP_SERVICE_NAME,
-							 DEFAULT_INTERFACE_LOOKUP_SERVICE_PORT))
+							 DEFAULT_INTERFACE_LOOKUP_SERVICE_PORT,
+							 &mayRetry))
 	{
 		log_warn("Failed to determine network configuration.");
 		exit(EXIT_CODE_INTERNAL_ERROR);
@@ -207,6 +211,8 @@ cli_show_hostname(int argc, char **argv)
 	char monitorHostname[_POSIX_HOST_NAME_MAX];
 	int monitorPort = pgsetup_get_pgport();
 
+	bool mayRetry = false;
+
 	/*
 	 * When no argument is used, use hostname(3) and 5432, as we would for a
 	 * monitor (pg_autoctl create monitor).
@@ -256,7 +262,9 @@ cli_show_hostname(int argc, char **argv)
 	}
 
 	/* fetch the default local address used when connecting remotely */
-	if (!fetchLocalIPAddress(ipAddr, BUFSIZE, monitorHostname, monitorPort))
+	if (!fetchLocalIPAddress(ipAddr, BUFSIZE,
+							 monitorHostname, monitorPort,
+							 &mayRetry))
 	{
 		log_warn("Failed to determine network configuration.");
 		exit(EXIT_CODE_INTERNAL_ERROR);

--- a/src/bin/pg_autoctl/cli_do_show.c
+++ b/src/bin/pg_autoctl/cli_do_show.c
@@ -93,7 +93,7 @@ cli_show_ipaddr(int argc, char **argv)
 	if (!fetchLocalIPAddress(ipAddr, BUFSIZE,
 							 DEFAULT_INTERFACE_LOOKUP_SERVICE_NAME,
 							 DEFAULT_INTERFACE_LOOKUP_SERVICE_PORT,
-							 &mayRetry))
+							 LOG_WARN, &mayRetry))
 	{
 		log_warn("Failed to determine network configuration.");
 		exit(EXIT_CODE_INTERNAL_ERROR);
@@ -118,7 +118,7 @@ cli_show_cidr(int argc, char **argv)
 	if (!fetchLocalIPAddress(ipAddr, BUFSIZE,
 							 DEFAULT_INTERFACE_LOOKUP_SERVICE_NAME,
 							 DEFAULT_INTERFACE_LOOKUP_SERVICE_PORT,
-							 &mayRetry))
+							 LOG_WARN, &mayRetry))
 	{
 		log_warn("Failed to determine network configuration.");
 		exit(EXIT_CODE_INTERNAL_ERROR);
@@ -264,7 +264,7 @@ cli_show_hostname(int argc, char **argv)
 	/* fetch the default local address used when connecting remotely */
 	if (!fetchLocalIPAddress(ipAddr, BUFSIZE,
 							 monitorHostname, monitorPort,
-							 &mayRetry))
+							 LOG_WARN, &mayRetry))
 	{
 		log_warn("Failed to determine network configuration.");
 		exit(EXIT_CODE_INTERNAL_ERROR);

--- a/src/bin/pg_autoctl/cli_do_show.c
+++ b/src/bin/pg_autoctl/cli_do_show.c
@@ -329,6 +329,7 @@ cli_show_reverse(int argc, char **argv)
 		log_fatal("Failed to find an IP address for hostname \"%s\" that "
 				  "matches hostname again in a reverse-DNS lookup.",
 				  hostname);
+		log_info("Continuing with IP address \"%s\"", ipaddr);
 		exit(EXIT_CODE_INTERNAL_ERROR);
 	}
 

--- a/src/bin/pg_autoctl/cli_do_tmux.c
+++ b/src/bin/pg_autoctl/cli_do_tmux.c
@@ -646,7 +646,9 @@ tmux_pg_autoctl_create_postgres(PQExpBuffer script,
 
 	tmux_add_send_keys_command(script,
 							   "%s create postgres %s "
-							   "--monitor %s --name %s "
+							   "--monitor %s "
+							   "--name %s "
+							   "--dbname demo --pg-hba-lan "
 							   "--replication-quorum %s "
 							   "--candidate-priority %d "
 							   "--run",

--- a/src/bin/pg_autoctl/cli_do_tmux.c
+++ b/src/bin/pg_autoctl/cli_do_tmux.c
@@ -648,7 +648,8 @@ tmux_pg_autoctl_create_postgres(PQExpBuffer script,
 							   "%s create postgres %s "
 							   "--monitor %s "
 							   "--name %s "
-							   "--dbname demo --pg-hba-lan "
+							   "--dbname demo "
+							   "--pg-hba-lan "
 							   "--replication-quorum %s "
 							   "--candidate-priority %d "
 							   "--run",

--- a/src/bin/pg_autoctl/defaults.h
+++ b/src/bin/pg_autoctl/defaults.h
@@ -32,7 +32,6 @@
 #define DEFAULT_DATABASE_NAME "postgres"
 #define DEFAULT_USERNAME "postgres"
 #define DEFAULT_AUTH_METHOD "trust"
-#define SKIP_HBA_AUTH_METHOD "skip"
 #define REPLICATION_SLOT_NAME_DEFAULT "pgautofailover_standby"
 #define REPLICATION_SLOT_NAME_PATTERN "^pgautofailover_standby_"
 #define REPLICATION_PASSWORD_DEFAULT NULL

--- a/src/bin/pg_autoctl/ipaddr.c
+++ b/src/bin/pg_autoctl/ipaddr.c
@@ -55,7 +55,7 @@ static bool ipaddr_getsockname(int sock, char *ipaddr, size_t size);
 bool
 fetchLocalIPAddress(char *localIpAddress, int size,
 					const char *serviceName, int servicePort,
-					bool *mayRetry)
+					int logLevel, bool *mayRetry)
 {
 	struct addrinfo *lookup;
 	struct addrinfo *ai;
@@ -109,7 +109,7 @@ fetchLocalIPAddress(char *localIpAddress, int size,
 
 		if (err < 0)
 		{
-			log_warn("Failed to connect to %s: %m", addr);
+			log_level(logLevel, "Failed to connect to %s: %m", addr);
 		}
 		else
 		{
@@ -137,16 +137,18 @@ fetchLocalIPAddress(char *localIpAddress, int size,
 
 			if (strcmp(DEFAULT_INTERFACE_LOOKUP_SERVICE_NAME, serviceName) == 0)
 			{
-				log_warn("Failed to connect to \"%s\" on port %d "
-						 "to discover this machine hostname, "
-						 "please use --hostname",
-						 serviceName, servicePort);
+				log_level(logLevel,
+						  "Failed to connect to \"%s\" on port %d "
+						  "to discover this machine hostname, "
+						  "please use --hostname",
+						  serviceName, servicePort);
 			}
 			else
 			{
-				log_warn("Failed to connect to any of the IP addresses for "
-						 "monitor hostname \"%s\" and port %d",
-						 serviceName, servicePort);
+				log_level(logLevel,
+						  "Failed to connect to any of the IP addresses for "
+						  "monitor hostname \"%s\" and port %d",
+						  serviceName, servicePort);
 			}
 			return false;
 		}

--- a/src/bin/pg_autoctl/ipaddr.c
+++ b/src/bin/pg_autoctl/ipaddr.c
@@ -54,7 +54,8 @@ static bool ipaddr_getsockname(int sock, char *ipaddr, size_t size);
  */
 bool
 fetchLocalIPAddress(char *localIpAddress, int size,
-					const char *serviceName, int servicePort)
+					const char *serviceName, int servicePort,
+					bool *mayRetry)
 {
 	struct addrinfo *lookup;
 	struct addrinfo *ai;
@@ -64,6 +65,7 @@ fetchLocalIPAddress(char *localIpAddress, int size,
 
 	int sock;
 
+	*mayRetry = false;
 
 	/* prepare getaddrinfo hints for name resolution or IP address parsing */
 	memset(&hints, 0, sizeof(hints));
@@ -131,6 +133,8 @@ fetchLocalIPAddress(char *localIpAddress, int size,
 		}
 		else
 		{
+			*mayRetry = true;
+
 			if (strcmp(DEFAULT_INTERFACE_LOOKUP_SERVICE_NAME, serviceName) == 0)
 			{
 				log_warn("Failed to connect to \"%s\" on port %d "

--- a/src/bin/pg_autoctl/ipaddr.h
+++ b/src/bin/pg_autoctl/ipaddr.h
@@ -23,7 +23,7 @@ typedef enum
 IPType ip_address_type(const char *hostname);
 bool fetchLocalIPAddress(char *localIpAddress, int size,
 						 const char *serviceName, int servicePort,
-						 bool *mayRetry);
+						 int logLevel, bool *mayRetry);
 bool fetchLocalCIDR(const char *localIpAddress, char *localCIDR, int size);
 bool findHostnameLocalAddress(const char *hostname,
 							  char *localIpAddress, int size);

--- a/src/bin/pg_autoctl/ipaddr.h
+++ b/src/bin/pg_autoctl/ipaddr.h
@@ -22,7 +22,8 @@ typedef enum
 
 IPType ip_address_type(const char *hostname);
 bool fetchLocalIPAddress(char *localIpAddress, int size,
-						 const char *serviceName, int servicePort);
+						 const char *serviceName, int servicePort,
+						 bool *mayRetry);
 bool fetchLocalCIDR(const char *localIpAddress, char *localCIDR, int size);
 bool findHostnameLocalAddress(const char *hostname,
 							  char *localIpAddress, int size);

--- a/src/bin/pg_autoctl/keeper.c
+++ b/src/bin/pg_autoctl/keeper.c
@@ -1567,7 +1567,8 @@ keeper_update_group_hba(Keeper *keeper, NodeAddressArray *diffNodesArray)
 									   postgresSetup->ssl.active,
 									   postgresSetup->dbname,
 									   PG_AUTOCTL_REPLICA_USERNAME,
-									   authMethod))
+									   authMethod,
+									   postgresSetup->hbaLevel))
 	{
 		log_error("Failed to edit HBA file \"%s\" to update rules to current "
 				  "list of nodes registered on the monitor",

--- a/src/bin/pg_autoctl/keeper_config.c
+++ b/src/bin/pg_autoctl/keeper_config.c
@@ -98,6 +98,10 @@
 	make_strbuf_option("postgresql", "auth_method", "auth", \
 					   false, MAXPGPATH, config->pgSetup.authMethod)
 
+#define OPTION_POSTGRESQL_HBA_LEVEL(config) \
+	make_strbuf_option("postgresql", "hba_level", NULL, \
+					   false, MAXPGPATH, config->pgSetup.hbaLevelStr)
+
 #define OPTION_SSL_ACTIVE(config) \
 	make_int_option_default("ssl", "active", NULL, \
 							false, &(config->pgSetup.ssl.active), 0)
@@ -396,6 +400,18 @@ keeper_config_read_file_skip_pgsetup(KeeperConfig *config,
 			return false;
 		}
 	}
+
+	/*
+	 * Turn the configuration string for hbaLevel into our enum value.
+	 */
+	if (IS_EMPTY_STRING_BUFFER(config->pgSetup.hbaLevelStr))
+	{
+		strlcpy(config->pgSetup.hbaLevelStr, "minimal", NAMEDATALEN);
+	}
+
+	/* set the ENUM value for hbaLevel */
+	config->pgSetup.hbaLevel =
+		pgsetup_parse_hba_level(config->pgSetup.hbaLevelStr);
 
 	/*
 	 * Required for grandfathering old clusters that don't have sslmode

--- a/src/bin/pg_autoctl/keeper_pg_init.c
+++ b/src/bin/pg_autoctl/keeper_pg_init.c
@@ -760,7 +760,7 @@ create_database_and_extension(Keeper *keeper)
 	 * When --pg-hba-lan is used, we also open the local network CIDR
 	 * connections for the given --username and --dbname.
 	 */
-	if (pgSetup->hbaLevel == HBA_EDIT_APP)
+	if (pgSetup->hbaLevel == HBA_EDIT_LAN)
 	{
 		if (!pghba_enable_lan_cidr(&keeper->postgres.sqlClient,
 								   keeper->config.pgSetup.ssl.active,

--- a/src/bin/pg_autoctl/monitor_config.c
+++ b/src/bin/pg_autoctl/monitor_config.c
@@ -470,9 +470,12 @@ monitor_config_get_postgres_uri(MonitorConfig *config, char *connectionString,
 		 * PostgreSQL server to open it up to the local area network, e.g.
 		 * 129.168.1.0/23, so it should just work here.
 		 */
+		bool mayRetry = false;
+
 		if (!fetchLocalIPAddress(host, BUFSIZE,
 								 DEFAULT_INTERFACE_LOOKUP_SERVICE_NAME,
-								 DEFAULT_INTERFACE_LOOKUP_SERVICE_PORT))
+								 DEFAULT_INTERFACE_LOOKUP_SERVICE_PORT,
+								 &mayRetry))
 		{
 			/* error is already logged */
 			return false;

--- a/src/bin/pg_autoctl/monitor_config.c
+++ b/src/bin/pg_autoctl/monitor_config.c
@@ -196,8 +196,11 @@ monitor_config_init(MonitorConfig *config,
 	strlcpy(config->pgSetup.dbname, PG_AUTOCTL_MONITOR_DBNAME, NAMEDATALEN);
 	strlcpy(config->pgSetup.username, PG_AUTOCTL_MONITOR_USERNAME, NAMEDATALEN);
 
-	strlcpy(config->pgSetup.hbaLevelStr, "app", NAMEDATALEN);
-	config->pgSetup.hbaLevel = HBA_EDIT_APP;
+	if (config->pgSetup.hbaLevel == HBA_EDIT_UNKNOWN)
+	{
+		strlcpy(config->pgSetup.hbaLevelStr, "app", NAMEDATALEN);
+		config->pgSetup.hbaLevel = HBA_EDIT_APP;
+	}
 }
 
 

--- a/src/bin/pg_autoctl/monitor_config.c
+++ b/src/bin/pg_autoctl/monitor_config.c
@@ -195,6 +195,9 @@ monitor_config_init(MonitorConfig *config,
 	/* A part of the monitor's pgSetup is hard-coded. */
 	strlcpy(config->pgSetup.dbname, PG_AUTOCTL_MONITOR_DBNAME, NAMEDATALEN);
 	strlcpy(config->pgSetup.username, PG_AUTOCTL_MONITOR_USERNAME, NAMEDATALEN);
+
+	strlcpy(config->pgSetup.hbaLevelStr, "app", NAMEDATALEN);
+	config->pgSetup.hbaLevel = HBA_EDIT_APP;
 }
 
 

--- a/src/bin/pg_autoctl/monitor_config.c
+++ b/src/bin/pg_autoctl/monitor_config.c
@@ -475,7 +475,7 @@ monitor_config_get_postgres_uri(MonitorConfig *config, char *connectionString,
 		if (!fetchLocalIPAddress(host, BUFSIZE,
 								 DEFAULT_INTERFACE_LOOKUP_SERVICE_NAME,
 								 DEFAULT_INTERFACE_LOOKUP_SERVICE_PORT,
-								 &mayRetry))
+								 LOG_WARN, &mayRetry))
 		{
 			/* error is already logged */
 			return false;

--- a/src/bin/pg_autoctl/monitor_config.c
+++ b/src/bin/pg_autoctl/monitor_config.c
@@ -199,7 +199,7 @@ monitor_config_init(MonitorConfig *config,
 	if (config->pgSetup.hbaLevel == HBA_EDIT_UNKNOWN)
 	{
 		strlcpy(config->pgSetup.hbaLevelStr, "app", NAMEDATALEN);
-		config->pgSetup.hbaLevel = HBA_EDIT_APP;
+		config->pgSetup.hbaLevel = HBA_EDIT_LAN;
 	}
 }
 

--- a/src/bin/pg_autoctl/monitor_pg_init.c
+++ b/src/bin/pg_autoctl/monitor_pg_init.c
@@ -220,6 +220,7 @@ monitor_install(const char *hostname,
 							   hostname,
 							   PG_AUTOCTL_MONITOR_USERNAME,
 							   pg_setup_get_auth_method(&pgSetup),
+							   pgSetup.hbaLevel,
 							   NULL))
 	{
 		log_warn("Failed to grant connection to local network.");

--- a/src/bin/pg_autoctl/pghba.h
+++ b/src/bin/pg_autoctl/pghba.h
@@ -10,6 +10,7 @@
 #ifndef PGHBA_H
 #define PGHBA_H
 
+#include "pgsetup.h"
 #include "pgsql.h"
 
 /* supported HBA database values */
@@ -27,14 +28,16 @@ bool pghba_ensure_host_rule_exists(const char *hbaFilePath,
 								   const char *database,
 								   const char *username,
 								   const char *hostname,
-								   const char *authenticationScheme);
+								   const char *authenticationScheme,
+								   HBAEditLevel hbaLevel);
 
 bool pghba_ensure_host_rules_exist(const char *hbaFilePath,
 								   NodeAddressArray *nodesArray,
 								   bool ssl,
 								   const char *database,
 								   const char *username,
-								   const char *authenticationScheme);
+								   const char *authenticationScheme,
+								   HBAEditLevel hbaLevel);
 
 bool pghba_enable_lan_cidr(PGSQL *pgsql,
 						   bool ssl,
@@ -43,6 +46,7 @@ bool pghba_enable_lan_cidr(PGSQL *pgsql,
 						   const char *hostname,
 						   const char *username,
 						   const char *authenticationScheme,
+						   HBAEditLevel hbaLevel,
 						   const char *pgdata);
 
 bool pghba_check_hostname(const char *hostname);

--- a/src/bin/pg_autoctl/pghba.h
+++ b/src/bin/pg_autoctl/pghba.h
@@ -49,6 +49,6 @@ bool pghba_enable_lan_cidr(PGSQL *pgsql,
 						   HBAEditLevel hbaLevel,
 						   const char *pgdata);
 
-bool pghba_check_hostname(const char *hostname);
+bool pghba_check_hostname(const char *hostname, char *ipaddr, size_t size);
 
 #endif /* PGHBA_H */

--- a/src/bin/pg_autoctl/pgsetup.c
+++ b/src/bin/pg_autoctl/pgsetup.c
@@ -1934,4 +1934,7 @@ pgsetup_hba_level_to_string(HBAEditLevel hbaLevel)
 		case HBA_EDIT_UNKNOWN:
 			return "unknown";
 	}
+
+	log_error("BUG: hbaLevel %d is unknown", hbaLevel);
+	return "unknown";
 }

--- a/src/bin/pg_autoctl/pgsetup.c
+++ b/src/bin/pg_autoctl/pgsetup.c
@@ -63,10 +63,19 @@ pg_setup_init(PostgresSetup *pgSetup,
 	pgSetup->control = options->control;
 
 	/*
-	 * Also make sure that we keep the hbaLevel to edit.
+	 * Also make sure that we keep the hbaLevel to edit. Remember that
+	 * --skip-pg-hba is registered in the config as --auth skip.
 	 */
-	pgSetup->hbaLevel = options->hbaLevel;
-	strlcpy(pgSetup->hbaLevelStr, options->hbaLevelStr, NAMEDATALEN);
+	if (strcmp(options->authMethod, "skip") == 0)
+	{
+		pgSetup->hbaLevel = HBA_EDIT_SKIP;
+		strlcpy(pgSetup->hbaLevelStr, options->authMethod, NAMEDATALEN);
+	}
+	else
+	{
+		pgSetup->hbaLevel = options->hbaLevel;
+		strlcpy(pgSetup->hbaLevelStr, options->hbaLevelStr, NAMEDATALEN);
+	}
 
 	/*
 	 * Make sure that we keep the SSL options too.

--- a/src/bin/pg_autoctl/pgsetup.c
+++ b/src/bin/pg_autoctl/pgsetup.c
@@ -1899,7 +1899,7 @@ pgsetup_parse_hba_level(const char *level)
 	HBAEditLevel enumArray[] = {
 		HBA_EDIT_SKIP,
 		HBA_EDIT_MINIMAL,
-		HBA_EDIT_APP
+		HBA_EDIT_LAN
 	};
 
 	char *levelArray[] = { "skip", "minimal", "app", NULL };
@@ -1935,7 +1935,7 @@ pgsetup_hba_level_to_string(HBAEditLevel hbaLevel)
 			return "minimal";
 		}
 
-		case HBA_EDIT_APP:
+		case HBA_EDIT_LAN:
 		{
 			return "app";
 		}

--- a/src/bin/pg_autoctl/pgsetup.h
+++ b/src/bin/pg_autoctl/pgsetup.h
@@ -127,6 +127,22 @@ typedef struct NodeReplicationSettings
 	bool replicationQuorum;     /* true if participates in write quorum */
 } NodeReplicationSettings;
 
+
+/*
+ * How much should we edit the Postgres HBA file?
+ *
+ * The default value is HBA_EDIT_MINIMAL and pg_autoctl then add entries for
+ * the monitor to be able to connect to the local node, and an entry for the
+ * other nodes to be able to connect with streaming replication privileges.
+ */
+typedef enum
+{
+	HBA_EDIT_UNKNOWN = 0,
+	HBA_EDIT_SKIP,
+	HBA_EDIT_MINIMAL,
+	HBA_EDIT_APP,
+} HBAEditLevel;
+
 /*
  * pg_auto_failover also support SSL settings.
  */
@@ -175,6 +191,8 @@ typedef struct pg_setup
 	char listen_addresses[MAXPGPATH];       /* listen_addresses */
 	int proxyport;                          /* Proxy port */
 	char authMethod[NAMEDATALEN];           /* auth method, defaults to trust */
+	char hbaLevelStr[NAMEDATALEN];          /* user choice of HBA editing */
+	HBAEditLevel hbaLevel;                  /* user choice of HBA editing */
 	PostmasterStatus pm_status;             /* Postmaster status */
 	bool is_in_recovery;                    /* select pg_is_in_recovery() */
 	PostgresControlData control;            /* pg_controldata pgdata */
@@ -212,9 +230,6 @@ char * pmStatusToString(PostmasterStatus pm_status);
 
 char * pg_setup_get_username(PostgresSetup *pgSetup);
 
-#define SKIP_HBA(authMethod) \
-	(strncmp(authMethod, SKIP_HBA_AUTH_METHOD, strlen(SKIP_HBA_AUTH_METHOD)) == 0)
-
 char * pg_setup_get_auth_method(PostgresSetup *pgSetup);
 bool pg_setup_skip_hba_edits(PostgresSetup *pgSetup);
 
@@ -230,5 +245,7 @@ char * pgsetup_sslmode_to_string(SSLMode sslMode);
 
 bool pg_setup_standby_slot_supported(PostgresSetup *pgSetup, int logLevel);
 
+HBAEditLevel pgsetup_parse_hba_level(const char *level);
+char * pgsetup_hba_level_to_string(HBAEditLevel hbaLevel);
 
 #endif /* PGSETUP_H */

--- a/src/bin/pg_autoctl/pgsetup.h
+++ b/src/bin/pg_autoctl/pgsetup.h
@@ -140,7 +140,7 @@ typedef enum
 	HBA_EDIT_UNKNOWN = 0,
 	HBA_EDIT_SKIP,
 	HBA_EDIT_MINIMAL,
-	HBA_EDIT_APP,
+	HBA_EDIT_LAN,
 } HBAEditLevel;
 
 /*

--- a/src/bin/pg_autoctl/pgsql.c
+++ b/src/bin/pg_autoctl/pgsql.c
@@ -667,8 +667,11 @@ pgsql_retry_open_connection(PGSQL *pgsql)
 			{
 				uint64_t now = time(NULL);
 
-				if (lastWarningMessage != PQPING_NO_RESPONSE ||
-					(now - lastWarningTime) > 30)
+				/* no message at all the first 30s */
+
+				if ((now - pgsql->retryPolicy.startTime) > 30 &&
+					(lastWarningMessage != PQPING_NO_RESPONSE ||
+					 (now - lastWarningTime) > 30))
 				{
 					lastWarningMessage = PQPING_NO_RESPONSE;
 					lastWarningTime = now;

--- a/src/bin/pg_autoctl/primary_standby.c
+++ b/src/bin/pg_autoctl/primary_standby.c
@@ -683,7 +683,8 @@ postgres_add_default_settings(LocalPostgresServer *postgres)
  */
 bool
 primary_create_user_with_hba(LocalPostgresServer *postgres, char *userName,
-							 char *password, char *hostname, char *authMethod,
+							 char *password, char *hostname,
+							 char *authMethod, HBAEditLevel hbaLevel,
 							 int connlimit)
 {
 	PGSQL *pgsql = &(postgres->sqlClient);
@@ -715,7 +716,8 @@ primary_create_user_with_hba(LocalPostgresServer *postgres, char *userName,
 									   NULL,
 									   userName,
 									   hostname,
-									   authMethod))
+									   authMethod,
+									   hbaLevel))
 	{
 		log_error("Failed to set the pg_hba rule for user \"%s\"", userName);
 		return false;

--- a/src/bin/pg_autoctl/primary_standby.h
+++ b/src/bin/pg_autoctl/primary_standby.h
@@ -81,7 +81,8 @@ bool primary_disable_synchronous_replication(LocalPostgresServer *postgres);
 bool postgres_add_default_settings(LocalPostgresServer *postgres);
 bool primary_create_user_with_hba(LocalPostgresServer *postgres, char *userName,
 								  char *password, char *hostname,
-								  char *authMethod, int connlimit);
+								  char *authMethod, HBAEditLevel hbaLevel,
+								  int connlimit);
 bool primary_create_replication_user(LocalPostgresServer *postgres,
 									 char *replicationUser,
 									 char *replicationPassword);


### PR DESCRIPTION
With this option pg_autoctl edits the pg_hba.conf for Postgres to grant
connection privileges on the detected LAN for the --dbname database and for
the --username user.

The LAN detection is done the same way as with the monitor.

The idea is to simplify steps for running demos using docker-compose, where a single command can be used to start processes in each contained, and sync between running containers and extra actions isn't easily implemented.