### PR TITLE
Refrain from preventing changes that are not really changes.

### DIFF
--- a/src/monitor/node_active_protocol.c
+++ b/src/monitor/node_active_protocol.c
@@ -1722,7 +1722,8 @@ set_node_candidate_priority(PG_FUNCTION_ARGS)
 	ListCell *nodeCell = NULL;
 	int nonZeroCandidatePriorityNodeCount = 0;
 
-	AutoFailoverNode *currentNode = GetAutoFailoverNodeByName(formationId, nodeName);
+	AutoFailoverNode *currentNode =
+		GetAutoFailoverNodeByName(formationId, nodeName);
 
 	if (currentNode == NULL)
 	{
@@ -1748,7 +1749,7 @@ set_node_candidate_priority(PG_FUNCTION_ARGS)
 							   MAX_USER_DEFINED_CANDIDATE_PRIORITY)));
 	}
 
-	if (candidatePriority == 0)
+	if (candidatePriority == 0 && currentNode->candidatePriority != 0)
 	{
 		/*
 		 * We need to ensure we have at least two nodes with a non-zero
@@ -1862,7 +1863,8 @@ set_node_replication_quorum(PG_FUNCTION_ARGS)
 	bool replicationQuorum = PG_GETARG_BOOL(2);
 
 
-	AutoFailoverNode *currentNode = GetAutoFailoverNodeByName(formationId, nodeName);
+	AutoFailoverNode *currentNode =
+		GetAutoFailoverNodeByName(formationId, nodeName);
 
 	if (currentNode == NULL)
 	{


### PR DESCRIPTION
When a user runs the same command twice in a row, such as with the
following, make it so that the second time just works. It didn't because we
failed to observe that setting the candidate priority to zero could be a
non-changer if that's already the current value of the setting.

  pg_autoctl set node candidate-priority --name node3 0

We could also skip the operation entirely, but this has two drawbacks:

  - the client implementation would then need to decide if it has to wait
    for the apply-settings steps to happen or immediately return,

  - more importantly, if there's a problem with synchronous_standby_names it
    might be good that setting a value to its current setting, thus applying
	no changes, forces a cache invalidation of the primary's setup.

Fixes #526 