### PR TITLE
Fix tmux script when having PATH with spaces

### DIFF
--- a/src/bin/pg_autoctl/cli_do_tmux.c
+++ b/src/bin/pg_autoctl/cli_do_tmux.c
@@ -303,7 +303,7 @@ tmux_setenv(PQExpBuffer script, const char *sessionName, const char *root)
 		exit(EXIT_CODE_INTERNAL_ERROR);
 	}
 
-	tmux_add_command(script, "set-environment -t %s PATH %s", sessionName, PATH);
+	tmux_add_command(script, "set-environment -t %s PATH \"%s\"", sessionName, PATH);
 
 	for (int i = 0; xdg[i][0] != NULL; i++)
 	{


### PR DESCRIPTION
I had some paths in my PATH that contained spaces, because of WSL. This caused
issues with the tmux script, because these were neither escaped nor quoted.