### PR TITLE
Feature/zero config pg autoctl

### DIFF
--- a/src/bin/pg_autoctl/cli_common.c
+++ b/src/bin/pg_autoctl/cli_common.c
@@ -1991,11 +1991,12 @@ cli_get_name_getopts(int argc, char **argv)
 	{
 		if (!IS_EMPTY_STRING_BUFFER(options.pgSetup.pgdata))
 		{
-			log_warn("Given --monitor URI, the --pgdata option is ignored");
 			log_info("Connecting to monitor at \"%s\"", options.monitor_pguri);
 		}
 	}
-	else
+
+	/* when --pgdata is given, still initialise our pathnames */
+	if (!IS_EMPTY_STRING_BUFFER(options.pgSetup.pgdata))
 	{
 		(void) prepare_keeper_options(&options);
 	}
@@ -2029,6 +2030,8 @@ cli_use_monitor_option(KeeperConfig *options)
 						 options->monitor_pguri,
 						 sizeof(options->monitor_pguri)))
 		{
+			log_debug("Using environment PG_AUTOCTL_MONITOR \"%s\"",
+					  options->monitor_pguri);
 			return true;
 		}
 	}

--- a/src/bin/pg_autoctl/cli_common.c
+++ b/src/bin/pg_autoctl/cli_common.c
@@ -1583,6 +1583,19 @@ cli_common_ensure_formation(KeeperConfig *options)
 		return true;
 	}
 
+	/*
+	 * When --monitor has been used rather than --pgdata, we are operating at a
+	 * distance and we don't expect a configuration file to exist.
+	 */
+	if (IS_EMPTY_STRING_BUFFER(options->pgSetup.pgdata))
+	{
+		strlcpy(options->formation,
+				FORMATION_DEFAULT,
+				sizeof(options->formation));
+
+		return true;
+	}
+
 	switch (ProbeConfigurationFileRole(options->pathnames.config))
 	{
 		case PG_AUTOCTL_ROLE_MONITOR:
@@ -1834,6 +1847,7 @@ cli_get_name_getopts(int argc, char **argv)
 
 	static struct option long_options[] = {
 		{ "pgdata", required_argument, NULL, 'D' },
+		{ "monitor", required_argument, NULL, 'm' },
 		{ "formation", required_argument, NULL, 'f' },
 		{ "name", required_argument, NULL, 'a' },
 		{ "json", no_argument, NULL, 'J' },
@@ -1873,6 +1887,19 @@ cli_get_name_getopts(int argc, char **argv)
 			{
 				strlcpy(options.pgSetup.pgdata, optarg, MAXPGPATH);
 				log_trace("--pgdata %s", options.pgSetup.pgdata);
+				break;
+			}
+
+			case 'm':
+			{
+				if (!validate_connection_string(optarg))
+				{
+					log_fatal("Failed to parse --monitor connection string, "
+							  "see above for details.");
+					exit(EXIT_CODE_BAD_ARGS);
+				}
+				strlcpy(options.monitor_pguri, optarg, MAXCONNINFO);
+				log_trace("--monitor %s", options.monitor_pguri);
 				break;
 			}
 
@@ -1959,7 +1986,19 @@ cli_get_name_getopts(int argc, char **argv)
 	}
 
 	/* now that we have the command line parameters, prepare the options */
-	(void) prepare_keeper_options(&options);
+	/* when we have a monitor URI we don't need PGDATA */
+	if (IS_EMPTY_STRING_BUFFER(options.monitor_pguri))
+	{
+		(void) prepare_keeper_options(&options);
+	}
+	else
+	{
+		if (!IS_EMPTY_STRING_BUFFER(options.pgSetup.pgdata))
+		{
+			log_warn("Given --monitor URI, the --pgdata option is ignored");
+			log_info("Connecting to monitor at \"%s\"", options.monitor_pguri);
+		}
+	}
 
 	/* ensure --formation, or get it from the configuration file */
 	if (!cli_common_ensure_formation(&options))
@@ -1976,6 +2015,33 @@ cli_get_name_getopts(int argc, char **argv)
 
 
 /*
+ * cli_monitor_init_from_option_or_config initialises a monitor connection
+ * either from the --monitor Postgres URI given on the command line, or from
+ * the configuration file of the local node (monitor or keeper).
+ */
+void
+cli_monitor_init_from_option_or_config(Monitor *monitor, KeeperConfig *kconfig)
+{
+	if (IS_EMPTY_STRING_BUFFER(kconfig->monitor_pguri))
+	{
+		if (!monitor_init_from_pgsetup(monitor, &(kconfig->pgSetup)))
+		{
+			/* errors have already been logged */
+			exit(EXIT_CODE_BAD_CONFIG);
+		}
+	}
+	else
+	{
+		if (!monitor_init(monitor, kconfig->monitor_pguri))
+		{
+			/* errors have already been logged */
+			exit(EXIT_CODE_BAD_ARGS);
+		}
+	}
+}
+
+
+/*
  * cli_ensure_node_name ensures that we have a node name to continue with,
  * either from the command line itself, or from the configuration file when
  * we're dealing with a keeper node.
@@ -1983,31 +2049,38 @@ cli_get_name_getopts(int argc, char **argv)
 void
 cli_ensure_node_name(Keeper *keeper)
 {
+	/* if we have a --name option, we're done already */
+	if (!IS_EMPTY_STRING_BUFFER(keeper->config.name))
+	{
+		return;
+	}
+
+	/* we might have --monitor instead of --pgdata */
+	if (IS_EMPTY_STRING_BUFFER(keeper->config.pgSetup.pgdata))
+	{
+		log_fatal("Please use either --name or --pgdata "
+				  "to target a specific node");
+		exit(EXIT_CODE_BAD_ARGS);
+	}
+
 	switch (ProbeConfigurationFileRole(keeper->config.pathnames.config))
 	{
 		case PG_AUTOCTL_ROLE_MONITOR:
 		{
-			if (IS_EMPTY_STRING_BUFFER(keeper->config.name))
-			{
-				log_fatal("Please use --name to target a specific node");
-				exit(EXIT_CODE_BAD_ARGS);
-			}
+			log_fatal("Please use --name to target a specific node");
+			exit(EXIT_CODE_BAD_ARGS);
 			break;
 		}
 
 		case PG_AUTOCTL_ROLE_KEEPER:
 		{
-			/* when --name has not been used, fetch it from the config */
-			if (IS_EMPTY_STRING_BUFFER(keeper->config.name))
-			{
-				bool monitorDisabledIsOk = false;
+			bool monitorDisabledIsOk = false;
 
-				if (!keeper_config_read_file_skip_pgsetup(&(keeper->config),
-														  monitorDisabledIsOk))
-				{
-					/* errors have already been logged */
-					exit(EXIT_CODE_BAD_CONFIG);
-				}
+			if (!keeper_config_read_file_skip_pgsetup(&(keeper->config),
+													  monitorDisabledIsOk))
+			{
+				/* errors have already been logged */
+				exit(EXIT_CODE_BAD_CONFIG);
 			}
 			break;
 		}
@@ -2017,6 +2090,100 @@ cli_ensure_node_name(Keeper *keeper)
 			log_fatal("Unrecognized configuration file \"%s\"",
 					  keeper->config.pathnames.config);
 			exit(EXIT_CODE_INTERNAL_ERROR);
+		}
+	}
+}
+
+
+/*
+ * cli_set_groupId sets the kconfig.groupId depending on the --group argument
+ * given on the command line, and if that was not given then figures it out:
+ *
+ * - it could be that we have a single group in the formation, in that case
+ *   --group must be zero, so we set it that way,
+ *
+ * - we may have a local keeper node setup thanks to --pgdata, in that case
+ *   read the configuration file and grab the groupId from there.
+ */
+void
+cli_set_groupId(Monitor *monitor, KeeperConfig *kconfig)
+{
+	int groupsCount = 0;
+
+	if (!monitor_count_groups(monitor, kconfig->formation, &groupsCount))
+	{
+		/* errors have already been logged */
+		exit(EXIT_CODE_MONITOR);
+	}
+
+	if (groupsCount == 0)
+	{
+		/* nothing to be done here */
+		log_fatal("The monitor currently has no Postgres nodes "
+				  "registered in formation \"%s\"",
+				  kconfig->formation);
+		exit(EXIT_CODE_BAD_STATE);
+	}
+
+	/*
+	 * When --group was not given, we may proceed when there is only one
+	 * possible target group in the formation, which is the case with Postgres
+	 * standalone setups.
+	 */
+	if (kconfig->groupId == -1)
+	{
+		/*
+		 * When --group is not given and we have a keeper node, we can grab a
+		 * default from the configuration file. We have to support the usage
+		 * either --monitor or --pgdata. We have a local keeper node/role only
+		 * when we have been given --pgdata.
+		 */
+		if (!IS_EMPTY_STRING_BUFFER(kconfig->pgSetup.pgdata))
+		{
+			pgAutoCtlNodeRole role =
+				ProbeConfigurationFileRole(kconfig->pathnames.config);
+
+			if (role == PG_AUTOCTL_ROLE_KEEPER)
+			{
+				const bool missingPgdataIsOk = true;
+				const bool pgIsNotRunningIsOk = true;
+				const bool monitorDisabledIsOk = false;
+
+				if (!keeper_config_read_file(kconfig,
+											 missingPgdataIsOk,
+											 pgIsNotRunningIsOk,
+											 monitorDisabledIsOk))
+				{
+					/* errors have already been logged */
+					exit(EXIT_CODE_BAD_CONFIG);
+				}
+
+				log_info("Targetting group %d in formation \"%s\"",
+						 kconfig->groupId,
+						 kconfig->formation);
+			}
+		}
+	}
+
+	/*
+	 * We tried to see if we have a local keeper configuration to grab the
+	 * groupId from, what if we don't have a local setup, or the local setup is
+	 * not a keeper role.
+	 */
+	if (kconfig->groupId == -1)
+	{
+		if (groupsCount == 1)
+		{
+			/* we have only one group, it's group number zero, proceed */
+			kconfig->groupId = 0;
+			kconfig->pgSetup.pgKind = NODE_KIND_STANDALONE;
+		}
+		else
+		{
+			log_error("Please use the --group option to target a "
+					  "specific group in formation \"%s\"",
+					  kconfig->formation);
+			exit(EXIT_CODE_BAD_ARGS);
 		}
 	}
 }

--- a/src/bin/pg_autoctl/cli_common.h
+++ b/src/bin/pg_autoctl/cli_common.h
@@ -167,6 +167,7 @@ void set_first_pgctl(PostgresSetup *pgSetup);
 bool monitor_init_from_pgsetup(Monitor *monitor, PostgresSetup *pgSetup);
 
 void exit_unless_role_is_keeper(KeeperConfig *kconfig);
+void cli_set_groupId(Monitor *monitor, KeeperConfig *kconfig);
 
 /* cli_create_drop_node.c */
 bool cli_create_config(Keeper *keeper);
@@ -188,6 +189,8 @@ bool cli_pg_autoctl_reload(const char *pidfile);
 
 int cli_node_metadata_getopts(int argc, char **argv);
 int cli_get_name_getopts(int argc, char **argv);
+void cli_monitor_init_from_option_or_config(Monitor *monitor,
+											KeeperConfig *kconfig);
 void cli_ensure_node_name(Keeper *keeper);
 
 bool discover_hostname(char *hostname, int size,

--- a/src/bin/pg_autoctl/cli_common.h
+++ b/src/bin/pg_autoctl/cli_common.h
@@ -189,6 +189,7 @@ bool cli_pg_autoctl_reload(const char *pidfile);
 
 int cli_node_metadata_getopts(int argc, char **argv);
 int cli_get_name_getopts(int argc, char **argv);
+bool cli_use_monitor_option(KeeperConfig *options);
 void cli_monitor_init_from_option_or_config(Monitor *monitor,
 											KeeperConfig *kconfig);
 void cli_ensure_node_name(Keeper *keeper);

--- a/src/bin/pg_autoctl/cli_do_tmux.h
+++ b/src/bin/pg_autoctl/cli_do_tmux.h
@@ -70,7 +70,8 @@ void tmux_add_new_session(PQExpBuffer script,
 						  const char *root, int pgport);
 
 void tmux_add_xdg_environment(PQExpBuffer script);
-void tmux_setenv(PQExpBuffer script, const char *sessionName, const char *root);
+void tmux_setenv(PQExpBuffer script,
+				 const char *sessionName, const char *root, int firstPort);
 bool tmux_prepare_XDG_environment(const char *root,
 								  bool createDirectories);
 

--- a/src/bin/pg_autoctl/cli_formation.c
+++ b/src/bin/pg_autoctl/cli_formation.c
@@ -361,15 +361,15 @@ keeper_cli_formation_create_getopts(int argc, char **argv)
 	/* when we have a monitor URI we don't need PGDATA */
 	if (IS_EMPTY_STRING_BUFFER(options.monitor_pguri))
 	{
-		cli_common_get_set_pgdata_or_exit(&(options.pgSetup));
-	}
-	else
-	{
 		if (!IS_EMPTY_STRING_BUFFER(options.pgSetup.pgdata))
 		{
 			log_warn("Given --monitor URI, the --pgdata option is ignored");
 			log_info("Connecting to monitor at \"%s\"", options.monitor_pguri);
 		}
+	}
+	else
+	{
+		cli_common_get_set_pgdata_or_exit(&(options.pgSetup));
 	}
 
 	if (IS_EMPTY_STRING_BUFFER(options.formation) ||

--- a/src/bin/pg_autoctl/cli_formation.c
+++ b/src/bin/pg_autoctl/cli_formation.c
@@ -183,7 +183,7 @@ keeper_cli_formation_getopts(int argc, char **argv)
 		if (!IS_EMPTY_STRING_BUFFER(options.pgSetup.pgdata))
 		{
 			log_warn("Given --monitor URI, the --pgdata option is ignored");
-			log_info("Using monitor URI \"%s\"", options.monitor_pguri);
+			log_info("Connecting to monitor at \"%s\"", options.monitor_pguri);
 		}
 	}
 
@@ -368,7 +368,7 @@ keeper_cli_formation_create_getopts(int argc, char **argv)
 		if (!IS_EMPTY_STRING_BUFFER(options.pgSetup.pgdata))
 		{
 			log_warn("Given --monitor URI, the --pgdata option is ignored");
-			log_info("Using monitor URI \"%s\"", options.monitor_pguri);
+			log_info("Connecting to monitor at \"%s\"", options.monitor_pguri);
 		}
 	}
 

--- a/src/bin/pg_autoctl/cli_get_set_properties.c
+++ b/src/bin/pg_autoctl/cli_get_set_properties.c
@@ -201,14 +201,11 @@ static bool
 get_node_replication_settings(NodeReplicationSettings *settings)
 {
 	Keeper keeper = { 0 };
+	Monitor *monitor = &(keeper.monitor);
 
 	keeper.config = keeperOptions;
 
-	if (!monitor_init_from_pgsetup(&keeper.monitor, &keeper.config.pgSetup))
-	{
-		/* errors have already been logged */
-		exit(EXIT_CODE_BAD_CONFIG);
-	}
+	(void) cli_monitor_init_from_option_or_config(monitor, &(keeper.config));
 
 	/* grab --name from either the command options or the configuration file */
 	(void) cli_ensure_node_name(&keeper);
@@ -300,11 +297,7 @@ cli_get_formation_settings(int argc, char **argv)
 	KeeperConfig config = keeperOptions;
 	Monitor monitor = { 0 };
 
-	if (!monitor_init_from_pgsetup(&monitor, &config.pgSetup))
-	{
-		/* errors have already been logged */
-		exit(EXIT_CODE_BAD_CONFIG);
-	}
+	(void) cli_monitor_init_from_option_or_config(&monitor, &config);
 
 	if (outputJSON)
 	{
@@ -334,11 +327,7 @@ cli_get_formation_number_sync_standbys(int argc, char **argv)
 	Monitor monitor = { 0 };
 	int numberSyncStandbys = 0;
 
-	if (!monitor_init_from_pgsetup(&monitor, &config.pgSetup))
-	{
-		/* errors have already been logged */
-		exit(EXIT_CODE_BAD_CONFIG);
-	}
+	(void) cli_monitor_init_from_option_or_config(&monitor, &config);
 
 	if (!monitor_get_formation_number_sync_standbys(&monitor,
 													config.formation,
@@ -373,6 +362,7 @@ static void
 cli_set_node_replication_quorum(int argc, char **argv)
 {
 	Keeper keeper = { 0 };
+	Monitor *monitor = &(keeper.monitor);
 	bool replicationQuorum = false;
 
 	keeper.config = keeperOptions;
@@ -394,11 +384,7 @@ cli_set_node_replication_quorum(int argc, char **argv)
 		exit(EXIT_CODE_BAD_ARGS);
 	}
 
-	if (!monitor_init_from_pgsetup(&keeper.monitor, &keeper.config.pgSetup))
-	{
-		/* errors have already been logged */
-		exit(EXIT_CODE_BAD_CONFIG);
-	}
+	(void) cli_monitor_init_from_option_or_config(monitor, &(keeper.config));
 
 	/* grab --name from either the command options or the configuration file */
 	(void) cli_ensure_node_name(&keeper);
@@ -435,7 +421,7 @@ static void
 cli_set_node_candidate_priority(int argc, char **argv)
 {
 	Keeper keeper = { 0 };
-
+	Monitor *monitor = &(keeper.monitor);
 
 	keeper.config = keeperOptions;
 
@@ -457,11 +443,7 @@ cli_set_node_candidate_priority(int argc, char **argv)
 		exit(EXIT_CODE_BAD_ARGS);
 	}
 
-	if (!monitor_init_from_pgsetup(&keeper.monitor, &keeper.config.pgSetup))
-	{
-		/* errors have already been logged */
-		exit(EXIT_CODE_BAD_CONFIG);
-	}
+	(void) cli_monitor_init_from_option_or_config(monitor, &(keeper.config));
 
 	/* grab --name from either the command options or the configuration file */
 	(void) cli_ensure_node_name(&keeper);
@@ -603,7 +585,6 @@ cli_set_formation_number_sync_standbys(int argc, char **argv)
 	KeeperConfig config = keeperOptions;
 	Monitor monitor = { 0 };
 
-
 	char synchronous_standby_names[BUFSIZE] = { 0 };
 
 	if (argc != 1)
@@ -623,11 +604,7 @@ cli_set_formation_number_sync_standbys(int argc, char **argv)
 		exit(EXIT_CODE_BAD_ARGS);
 	}
 
-	if (!monitor_init_from_pgsetup(&monitor, &config.pgSetup))
-	{
-		/* errors have already been logged */
-		exit(EXIT_CODE_BAD_CONFIG);
-	}
+	(void) cli_monitor_init_from_option_or_config(&monitor, &config);
 
 	/* change the default group when it is still unknown */
 	if (config.groupId == -1)

--- a/src/bin/pg_autoctl/cli_perform.c
+++ b/src/bin/pg_autoctl/cli_perform.c
@@ -205,7 +205,15 @@ cli_perform_failover_getopts(int argc, char **argv)
 	}
 
 	/* when we have a monitor URI we don't need PGDATA */
-	if (IS_EMPTY_STRING_BUFFER(options.monitor_pguri))
+	if (cli_use_monitor_option(&options))
+	{
+		if (!IS_EMPTY_STRING_BUFFER(options.pgSetup.pgdata))
+		{
+			log_warn("Given --monitor URI, the --pgdata option is ignored");
+			log_info("Connecting to monitor at \"%s\"", options.monitor_pguri);
+		}
+	}
+	else
 	{
 		cli_common_get_set_pgdata_or_exit(&(options.pgSetup));
 
@@ -214,14 +222,6 @@ cli_perform_failover_getopts(int argc, char **argv)
 		{
 			/* errors have already been logged */
 			exit(EXIT_CODE_BAD_ARGS);
-		}
-	}
-	else
-	{
-		if (!IS_EMPTY_STRING_BUFFER(options.pgSetup.pgdata))
-		{
-			log_warn("Given --monitor URI, the --pgdata option is ignored");
-			log_info("Connecting to monitor at \"%s\"", options.monitor_pguri);
 		}
 	}
 

--- a/src/bin/pg_autoctl/cli_perform.c
+++ b/src/bin/pg_autoctl/cli_perform.c
@@ -212,6 +212,9 @@ cli_perform_failover_getopts(int argc, char **argv)
 			log_warn("Given --monitor URI, the --pgdata option is ignored");
 			log_info("Connecting to monitor at \"%s\"", options.monitor_pguri);
 		}
+
+		/* the rest of the program needs pgdata actually empty */
+		bzero((void *) options.pgSetup.pgdata, sizeof(options.pgSetup.pgdata));
 	}
 	else
 	{

--- a/src/bin/pg_autoctl/cli_show.c
+++ b/src/bin/pg_autoctl/cli_show.c
@@ -335,7 +335,11 @@ cli_show_state_getopts(int argc, char **argv)
 	else
 	{
 		cli_common_get_set_pgdata_or_exit(&(options.pgSetup));
+	}
 
+	/* when --pgdata is given, still initialise our pathnames */
+	if (!IS_EMPTY_STRING_BUFFER(options.pgSetup.pgdata))
+	{
 		if (!keeper_config_set_pathnames_from_pgdata(&(options.pathnames),
 													 options.pgSetup.pgdata))
 		{
@@ -724,12 +728,16 @@ cli_show_standby_names_getopts(int argc, char **argv)
 	else
 	{
 		cli_common_get_set_pgdata_or_exit(&(options.pgSetup));
+	}
 
+	/* when --pgdata is given, still initialise our pathnames */
+	if (!IS_EMPTY_STRING_BUFFER(options.pgSetup.pgdata))
+	{
 		if (!keeper_config_set_pathnames_from_pgdata(&(options.pathnames),
 													 options.pgSetup.pgdata))
 		{
 			/* errors have already been logged */
-			exit(EXIT_CODE_BAD_ARGS);
+			exit(EXIT_CODE_BAD_CONFIG);
 		}
 	}
 
@@ -940,7 +948,11 @@ cli_show_uri_getopts(int argc, char **argv)
 	else
 	{
 		cli_common_get_set_pgdata_or_exit(&(options.pgSetup));
+	}
 
+	/* when --pgdata is given, still initialise our pathnames */
+	if (!IS_EMPTY_STRING_BUFFER(options.pgSetup.pgdata))
+	{
 		if (!keeper_config_set_pathnames_from_pgdata(&(options.pathnames),
 													 options.pgSetup.pgdata))
 		{

--- a/src/bin/pg_autoctl/cli_show.c
+++ b/src/bin/pg_autoctl/cli_show.c
@@ -324,7 +324,15 @@ cli_show_state_getopts(int argc, char **argv)
 	}
 
 	/* when we have a monitor URI we don't need PGDATA */
-	if (IS_EMPTY_STRING_BUFFER(options.monitor_pguri))
+	if (cli_use_monitor_option(&options))
+	{
+		if (!IS_EMPTY_STRING_BUFFER(options.pgSetup.pgdata))
+		{
+			log_warn("Given --monitor URI, the --pgdata option is ignored");
+			log_info("Connecting to monitor at \"%s\"", options.monitor_pguri);
+		}
+	}
+	else
 	{
 		cli_common_get_set_pgdata_or_exit(&(options.pgSetup));
 
@@ -333,14 +341,6 @@ cli_show_state_getopts(int argc, char **argv)
 		{
 			/* errors have already been logged */
 			exit(EXIT_CODE_BAD_CONFIG);
-		}
-	}
-	else
-	{
-		if (!IS_EMPTY_STRING_BUFFER(options.pgSetup.pgdata))
-		{
-			log_warn("Given --monitor URI, the --pgdata option is ignored");
-			log_info("Connecting to monitor at \"%s\"", options.monitor_pguri);
 		}
 	}
 
@@ -367,22 +367,7 @@ cli_show_events(int argc, char **argv)
 	KeeperConfig config = keeperOptions;
 	Monitor monitor = { 0 };
 
-	if (!IS_EMPTY_STRING_BUFFER(config.monitor_pguri))
-	{
-		if (!monitor_init(&monitor, config.monitor_pguri))
-		{
-			/* errors have already been logged */
-			exit(EXIT_CODE_BAD_ARGS);
-		}
-	}
-	else
-	{
-		if (!monitor_init_from_pgsetup(&monitor, &config.pgSetup))
-		{
-			/* errors have already been logged */
-			exit(EXIT_CODE_BAD_ARGS);
-		}
-	}
+	(void) cli_monitor_init_from_option_or_config(&monitor, &config);
 
 	if (outputJSON)
 	{
@@ -426,22 +411,7 @@ cli_show_state(int argc, char **argv)
 		exit(EXIT_CODE_QUIT);
 	}
 
-	if (!IS_EMPTY_STRING_BUFFER(config.monitor_pguri))
-	{
-		if (!monitor_init(&monitor, config.monitor_pguri))
-		{
-			/* errors have already been logged */
-			exit(EXIT_CODE_BAD_ARGS);
-		}
-	}
-	else
-	{
-		if (!monitor_init_from_pgsetup(&monitor, &config.pgSetup))
-		{
-			/* errors have already been logged */
-			exit(EXIT_CODE_BAD_ARGS);
-		}
-	}
+	(void) cli_monitor_init_from_option_or_config(&monitor, &config);
 
 	if (outputJSON)
 	{
@@ -743,7 +713,15 @@ cli_show_standby_names_getopts(int argc, char **argv)
 	}
 
 	/* when we have a monitor URI we don't need PGDATA */
-	if (IS_EMPTY_STRING_BUFFER(options.monitor_pguri))
+	if (cli_use_monitor_option(&options))
+	{
+		if (!IS_EMPTY_STRING_BUFFER(options.pgSetup.pgdata))
+		{
+			log_warn("Given --monitor URI, the --pgdata option is ignored");
+			log_info("Connecting to monitor at \"%s\"", options.monitor_pguri);
+		}
+	}
+	else
 	{
 		cli_common_get_set_pgdata_or_exit(&(options.pgSetup));
 
@@ -752,14 +730,6 @@ cli_show_standby_names_getopts(int argc, char **argv)
 		{
 			/* errors have already been logged */
 			exit(EXIT_CODE_BAD_ARGS);
-		}
-	}
-	else
-	{
-		if (!IS_EMPTY_STRING_BUFFER(options.pgSetup.pgdata))
-		{
-			log_warn("Given --monitor URI, the --pgdata option is ignored");
-			log_info("Connecting to monitor at \"%s\"", options.monitor_pguri);
 		}
 	}
 
@@ -959,7 +929,15 @@ cli_show_uri_getopts(int argc, char **argv)
 	}
 
 	/* when we have a monitor URI we don't need PGDATA */
-	if (IS_EMPTY_STRING_BUFFER(options.monitor_pguri))
+	if (cli_use_monitor_option(&options))
+	{
+		if (!IS_EMPTY_STRING_BUFFER(options.pgSetup.pgdata))
+		{
+			log_warn("Given --monitor URI, the --pgdata option is ignored");
+			log_info("Connecting to monitor at \"%s\"", options.monitor_pguri);
+		}
+	}
+	else
 	{
 		cli_common_get_set_pgdata_or_exit(&(options.pgSetup));
 
@@ -968,14 +946,6 @@ cli_show_uri_getopts(int argc, char **argv)
 		{
 			/* errors have already been logged */
 			exit(EXIT_CODE_BAD_CONFIG);
-		}
-	}
-	else
-	{
-		if (!IS_EMPTY_STRING_BUFFER(options.pgSetup.pgdata))
-		{
-			log_warn("Given --monitor URI, the --pgdata option is ignored");
-			log_info("Connecting to monitor at \"%s\"", options.monitor_pguri);
 		}
 	}
 

--- a/src/bin/pg_autoctl/cli_show.c
+++ b/src/bin/pg_autoctl/cli_show.c
@@ -24,6 +24,7 @@
 #include "monitor_pg_init.h"
 #include "monitor.h"
 #include "nodestate_utils.h"
+#include "parsing.h"
 #include "pgctl.h"
 #include "pghba.h"
 #include "pgsetup.h"
@@ -1069,12 +1070,11 @@ cli_show_uri(int argc, char **argv)
 			exit(EXIT_CODE_BAD_ARGS);
 		}
 
-		/* cook the sslmode=prefer bits */
-		ssl.active = true;
-		ssl.sslMode = SSL_MODE_PREFER;
-		strlcpy(ssl.sslModeStr,
-				pgsetup_sslmode_to_string(ssl.sslMode),
-				sizeof(ssl.sslModeStr));
+		if (!parse_pguri_ssl_settings(kconfig.monitor_pguri, &ssl))
+		{
+			/* errors have already been logged */
+			exit(EXIT_CODE_BAD_ARGS);
+		}
 	}
 	else
 	{

--- a/src/bin/pg_autoctl/defaults.h
+++ b/src/bin/pg_autoctl/defaults.h
@@ -26,6 +26,9 @@
 /* environment variable for containing the id of the logging semaphore */
 #define PG_AUTOCTL_LOG_SEMAPHORE "PG_AUTOCTL_LOG_SEMAPHORE"
 
+/* environment variable for --monitor, when used instead of --pgdata */
+#define PG_AUTOCTL_MONITOR "PG_AUTOCTL_MONITOR"
+
 /* default values for the pg_autoctl settings */
 #define POSTGRES_PORT 5432
 #define POSTGRES_DEFAULT_LISTEN_ADDRESSES "*"

--- a/src/bin/pg_autoctl/formation_config.h
+++ b/src/bin/pg_autoctl/formation_config.h
@@ -16,6 +16,8 @@
 typedef struct FormationConfig
 {
 	/* pg_auto_failover formation setup */
+	char monitor_pguri[MAXCONNINFO];
+
 	char formation[NAMEDATALEN];
 	char formationKind[NAMEDATALEN];
 	char dbname[NAMEDATALEN];

--- a/src/bin/pg_autoctl/parsing.h
+++ b/src/bin/pg_autoctl/parsing.h
@@ -76,6 +76,8 @@ bool parse_pguri_info_key_vals(const char *pguri,
 
 bool buildPostgresURIfromPieces(URIParams *uriParams, char *pguri);
 
+bool parse_pguri_ssl_settings(const char *pguri, SSLOptions *ssl);
+
 bool parseLSN(const char *str, uint64_t *lsn);
 bool parseNodesArray(const char *nodesJSON,
 					 NodeAddressArray *nodesArray,

--- a/src/bin/pg_autoctl/pgsql.c
+++ b/src/bin/pg_autoctl/pgsql.c
@@ -60,6 +60,13 @@ parseSingleValueResult(void *ctx, PGresult *result)
 	{
 		char *value = PQgetvalue(result, 0, 0);
 
+		/* this function is never used when we expect NULL values */
+		if (PQgetisnull(result, 0, 0))
+		{
+			context->parsedOk = false;
+			return;
+		}
+
 		switch (context->resultType)
 		{
 			case PGSQL_RESULT_BOOL:

--- a/src/monitor/node_active_protocol.c
+++ b/src/monitor/node_active_protocol.c
@@ -2085,7 +2085,6 @@ synchronous_standby_names(PG_FUNCTION_ARGS)
 
 	AutoFailoverFormation *formation = GetFormation(formationId);
 
-
 	List *nodesGroupList = AutoFailoverNodeGroup(formationId, groupId);
 	int nodesCount = list_length(nodesGroupList);
 
@@ -2095,7 +2094,10 @@ synchronous_standby_names(PG_FUNCTION_ARGS)
 	 */
 	if (nodesCount == 0)
 	{
-		PG_RETURN_NULL();
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_OBJECT_DEFINITION),
+				 errmsg("no nodes found in group %d of formation \"%s\"",
+						groupId, formationId)));
 	}
 
 	/* when we have a SINGLE node we disable synchronous replication */

--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -733,7 +733,7 @@ class PGNode:
         """
         command = PGAutoCtl(self)
         out, err, ret = command.execute(
-            "show uri --monitor", "show", "uri", "--monitor"
+            "show uri --monitor", "show", "uri", "--formation", "monitor"
         )
         return out
 


### PR DESCRIPTION
Implement support for `--monitor` option and PG_AUTOCTL_MONITOR environment variable in many commands that don't need to have a local node already created. Those commands are:

    pg_autoctl create formation
    pg_autoctl drop formation

    pg_autoctl get|set formation settings
    pg_autoctl get|set formation number-sync-standbys
    pg_autoctl get|set node replication-quorum
    pg_autoctl get|set node candidate-priority

    pg_autoctl show uri
    pg_autoctl show events
    pg_autoctl show state
    pg_autoctl show settings
    pg_autoctl show standby-names

    pg_autoctl perform failover
    pg_autoctl perform switchover
    pg_autoctl perform promotion

The `make cluster` is also changed to use the PG_AUTOCTL_MONITOR environment variable rather than the monitor's PGDATA in the interactive terminal/session.

Fixes #437.
