### PR TITLE
Plug connection leaks found during profiling

### DIFF
--- a/src/bin/pg_autoctl/cli_enable_disable.c
+++ b/src/bin/pg_autoctl/cli_enable_disable.c
@@ -505,7 +505,7 @@ cli_enable_maintenance(int argc, char **argv)
 	 */
 	if (keeper.state.current_role != MAINTENANCE_STATE)
 	{
-		if (!pgsql_listen(&(keeper.monitor.pgsql), channels))
+		if (!pgsql_listen(&(keeper.monitor.notificationClient), channels))
 		{
 			log_error("Failed to listen to state changes from the monitor");
 			exit(EXIT_CODE_MONITOR);
@@ -610,7 +610,7 @@ cli_disable_maintenance(int argc, char **argv)
 		exit(EXIT_CODE_MONITOR);
 	}
 
-	if (!pgsql_listen(&(keeper.monitor.pgsql), channels))
+	if (!pgsql_listen(&(keeper.monitor.notificationClient), channels))
 	{
 		log_error("Failed to listen to state changes from the monitor");
 		exit(EXIT_CODE_MONITOR);

--- a/src/bin/pg_autoctl/cli_get_set_properties.c
+++ b/src/bin/pg_autoctl/cli_get_set_properties.c
@@ -689,7 +689,7 @@ set_node_candidate_priority(Keeper *keeper, int candidatePriority)
 	{
 		char *channels[] = { "state", NULL };
 
-		if (!pgsql_listen(&(keeper->monitor.pgsql), channels))
+		if (!pgsql_listen(&(keeper->monitor.notificationClient), channels))
 		{
 			log_error("Failed to listen to state changes from the monitor");
 			return false;
@@ -752,7 +752,7 @@ set_node_replication_quorum(Keeper *keeper, bool replicationQuorum)
 	{
 		char *channels[] = { "state", NULL };
 
-		if (!pgsql_listen(&(keeper->monitor.pgsql), channels))
+		if (!pgsql_listen(&(keeper->monitor.notificationClient), channels))
 		{
 			log_error("Failed to listen to state changes from the monitor");
 			return false;
@@ -814,7 +814,7 @@ set_formation_number_sync_standbys(Monitor *monitor,
 	{
 		char *channels[] = { "state", NULL };
 
-		if (!pgsql_listen(&(monitor->pgsql), channels))
+		if (!pgsql_listen(&(monitor->notificationClient), channels))
 		{
 			log_error("Failed to listen to state changes from the monitor");
 			return false;

--- a/src/bin/pg_autoctl/cli_perform.c
+++ b/src/bin/pg_autoctl/cli_perform.c
@@ -258,7 +258,7 @@ cli_perform_failover(int argc, char **argv)
 	(void) cli_set_groupId(&monitor, &config);
 
 	/* start listening to the state changes before we call perform_failover */
-	if (!pgsql_listen(&(monitor.pgsql), channels))
+	if (!pgsql_listen(&(monitor.notificationClient), channels))
 	{
 		log_error("Failed to listen to state changes from the monitor");
 		exit(EXIT_CODE_MONITOR);
@@ -318,7 +318,7 @@ cli_perform_promotion(int argc, char **argv)
 	}
 
 	/* start listening to the state changes before we call perform_promotion */
-	if (!pgsql_listen(&(monitor->pgsql), channels))
+	if (!pgsql_listen(&(monitor->notificationClient), channels))
 	{
 		log_error("Failed to listen to state changes from the monitor");
 		exit(EXIT_CODE_MONITOR);

--- a/src/bin/pg_autoctl/keeper.c
+++ b/src/bin/pg_autoctl/keeper.c
@@ -1291,7 +1291,7 @@ keeper_register_and_init(Keeper *keeper, NodeState initialState)
 		 * the registration (process killed, crash, etc), then the server
 		 * issues a ROLLBACK for us upon disconnection.
 		 */
-		if (!pgsql_execute(&(monitor->pgsql), "BEGIN"))
+		if (!pgsql_begin(&(monitor->pgsql)))
 		{
 			log_error("Failed to open a SQL transaction to register this node");
 
@@ -1343,7 +1343,7 @@ keeper_register_and_init(Keeper *keeper, NodeState initialState)
 		 * The current transaction is dead: we caugth an ERROR from the
 		 * call to pgautofailover.register_node().
 		 */
-		if (!pgsql_execute(&(monitor->pgsql), "ROLLBACK"))
+		if (!pgsql_rollback(&(monitor->pgsql)))
 		{
 			log_error("Failed to ROLLBACK failed register_node transaction "
 					  " on the monitor, see above for details.");
@@ -1403,7 +1403,7 @@ keeper_register_and_init(Keeper *keeper, NodeState initialState)
 		goto rollback;
 	}
 
-	if (!pgsql_execute(&(monitor->pgsql), "COMMIT"))
+	if (!pgsql_commit(&(monitor->pgsql)))
 	{
 		log_error("Failed to COMMIT register_node transaction on the "
 				  "monitor, see above for details");
@@ -1426,7 +1426,7 @@ rollback:
 	 */
 	unlink_file(config->pathnames.state);
 
-	if (!pgsql_execute(&(monitor->pgsql), "ROLLBACK"))
+	if (!pgsql_rollback(&(monitor->pgsql)))
 	{
 		log_error("Failed to ROLLBACK failed register_node transaction "
 				  " on the monitor, see above for details.");

--- a/src/bin/pg_autoctl/keeper.c
+++ b/src/bin/pg_autoctl/keeper.c
@@ -2380,6 +2380,7 @@ keeper_reload_configuration(Keeper *keeper, bool firstLoop, bool doInit)
 
 		/* disconnect to the current monitor if we're connected */
 		(void) pgsql_finish(&(keeper->monitor.pgsql));
+		(void) pgsql_finish(&(keeper->monitor.notificationClient));
 
 		if (keeper_config_read_file(&newConfig,
 									missingPgdataIsOk,

--- a/src/bin/pg_autoctl/keeper_pg_init.c
+++ b/src/bin/pg_autoctl/keeper_pg_init.c
@@ -547,9 +547,8 @@ wait_until_primary_is_ready(Keeper *keeper,
 			Monitor *monitor = &(keeper->monitor);
 			KeeperStateData *keeperState = &(keeper->state);
 			int timeoutMs = PG_AUTOCTL_KEEPER_SLEEP_TIME * 1000;
-			char *emptyChannelList[] = { NULL };
 
-			(void) pgsql_listen(&(monitor->notificationClient), emptyChannelList);
+			(void) pgsql_prepare_to_wait(&(monitor->notificationClient));
 			(void) monitor_wait_for_state_change(monitor,
 												 keeper->config.formation,
 												 keeperState->current_group,
@@ -560,7 +559,7 @@ wait_until_primary_is_ready(Keeper *keeper,
 			/* when no state change has been notified, close the connection */
 			if (!groupStateHasChanged &&
 				monitor->notificationClient.connectionStatementType ==
-				PGSQL_CONNECTION_SINGLE_STATEMENT)
+				PGSQL_CONNECTION_MULTI_STATEMENT)
 			{
 				pgsql_finish(&(monitor->notificationClient));
 			}

--- a/src/bin/pg_autoctl/keeper_pg_init.c
+++ b/src/bin/pg_autoctl/keeper_pg_init.c
@@ -547,9 +547,9 @@ wait_until_primary_is_ready(Keeper *keeper,
 			Monitor *monitor = &(keeper->monitor);
 			KeeperStateData *keeperState = &(keeper->state);
 			int timeoutMs = PG_AUTOCTL_KEEPER_SLEEP_TIME * 1000;
-			char *emptyChannel[] = { 0 };
+			char *emptyChannelList[] = { NULL };
 
-			(void) pgsql_listen(&(monitor->pgsql), emptyChannel);
+			(void) pgsql_listen(&(monitor->pgsql), emptyChannelList);
 			(void) monitor_wait_for_state_change(monitor,
 												 keeper->config.formation,
 												 keeperState->current_group,

--- a/src/bin/pg_autoctl/keeper_pg_init.c
+++ b/src/bin/pg_autoctl/keeper_pg_init.c
@@ -547,13 +547,19 @@ wait_until_primary_is_ready(Keeper *keeper,
 			Monitor *monitor = &(keeper->monitor);
 			KeeperStateData *keeperState = &(keeper->state);
 			int timeoutMs = PG_AUTOCTL_KEEPER_SLEEP_TIME * 1000;
+			char *emptyChannel[] = { 0 };
 
+			(void) pgsql_listen(&(monitor->pgsql), emptyChannel);
 			(void) monitor_wait_for_state_change(monitor,
 												 keeper->config.formation,
 												 keeperState->current_group,
 												 keeperState->current_node_id,
 												 timeoutMs,
 												 &groupStateHasChanged);
+			if (groupStateHasChanged)
+			{
+				pgsql_finish(&(monitor->pgsql));
+			}
 		}
 
 		if (!monitor_node_active(&(keeper->monitor),

--- a/src/bin/pg_autoctl/monitor.c
+++ b/src/bin/pg_autoctl/monitor.c
@@ -4094,8 +4094,13 @@ monitor_ensure_extension_version(Monitor *monitor,
 					  "on the monitor, see above for details",
 					  PG_AUTOCTL_MONITOR_EXTENSION_NAME,
 					  extensionVersion);
+			/* explicitly close the dbOwner connection to the monitor */
+			pgsql_finish(&(dbOwnerMonitor.pgsql));
 			return false;
 		}
+
+		/* explicitly close the dbOwner connection to the monitor */
+		pgsql_finish(&(dbOwnerMonitor.pgsql));
 
 		if (!monitor_get_extension_version(monitor, version))
 		{
@@ -4206,6 +4211,9 @@ prepare_connection_to_current_system_user(Monitor *source, Monitor *target)
 		PQconninfoFree(conninfo);
 		return false;
 	}
+
+	/* Finally mark the connection as multi statement */
+	target->pgsql.connectionStatementType = PGSQL_CONNECTION_MULTI_STATEMENT;
 
 	PQconninfoFree(conninfo);
 

--- a/src/bin/pg_autoctl/monitor.c
+++ b/src/bin/pg_autoctl/monitor.c
@@ -194,6 +194,12 @@ monitor_init(Monitor *monitor, char *url)
 		return false;
 	}
 
+	if (!pgsql_init(&monitor->notificationClient, url, PGSQL_CONN_MONITOR))
+	{
+		/* URL must be invalid, pgsql_init logged an error */
+		return false;
+	}
+
 	return true;
 }
 
@@ -205,12 +211,12 @@ monitor_init(Monitor *monitor, char *url)
 void
 monitor_setup_notifications(Monitor *monitor, int groupId, int nodeId)
 {
-	monitor->pgsql.notificationGroupId = groupId;
-	monitor->pgsql.notificationNodeId = nodeId;
-	monitor->pgsql.notificationReceived = false;
+	monitor->notificationClient.notificationGroupId = groupId;
+	monitor->notificationClient.notificationNodeId = nodeId;
+	monitor->notificationClient.notificationReceived = false;
 
 	/* install our notification handler */
-	monitor->pgsql.notificationProcessFunction =
+	monitor->notificationClient.notificationProcessFunction =
 		&monitor_process_state_notification;
 }
 
@@ -223,9 +229,9 @@ monitor_setup_notifications(Monitor *monitor, int groupId, int nodeId)
 bool
 monitor_has_received_notifications(Monitor *monitor)
 {
-	bool ret = monitor->pgsql.notificationReceived;
+	bool ret = monitor->notificationClient.notificationReceived;
 
-	monitor->pgsql.notificationReceived = false;
+	monitor->notificationClient.notificationReceived = false;
 
 	return ret;
 }
@@ -277,6 +283,12 @@ monitor_local_init(Monitor *monitor)
 	pg_setup_get_local_connection_string(pgSetup, connInfo);
 
 	if (!pgsql_init(&monitor->pgsql, connInfo, PGSQL_CONN_LOCAL))
+	{
+		/* URL must be invalid, pgsql_init logged an error */
+		return false;
+	}
+
+	if (!pgsql_init(&monitor->notificationClient, connInfo, PGSQL_CONN_LOCAL))
 	{
 		/* URL must be invalid, pgsql_init logged an error */
 		return false;
@@ -421,9 +433,6 @@ monitor_print_nodes_as_json(Monitor *monitor, char *formation, int groupId)
 		}
 		return false;
 	}
-
-	/* disconnect from PostgreSQL now */
-	pgsql_finish(&monitor->pgsql);
 
 	if (!context.parsedOk)
 	{
@@ -573,9 +582,6 @@ monitor_print_other_nodes_as_json(Monitor *monitor,
 		}
 		return false;
 	}
-
-	/* disconnect from PostgreSQL now */
-	pgsql_finish(&monitor->pgsql);
 
 	if (!context.parsedOk)
 	{
@@ -1045,14 +1051,8 @@ monitor_get_node_replication_settings(Monitor *monitor,
 		log_error("Failed to retrieve node settings for node \"%s\".",
 				  settings->name);
 
-		/* disconnect from monitor */
-		pgsql_finish(&monitor->pgsql);
-
 		return false;
 	}
-
-	/* disconnect from monitor */
-	pgsql_finish(&monitor->pgsql);
 
 	if (!parseContext.parsedOK)
 	{
@@ -1148,9 +1148,6 @@ monitor_get_formation_number_sync_standbys(Monitor *monitor, char *formation,
 		log_error("Failed to retrieve settings for formation \"%s\".",
 				  formation);
 
-		/* disconnect from monitor */
-		pgsql_finish(&monitor->pgsql);
-
 		return false;
 	}
 
@@ -1193,10 +1190,6 @@ monitor_set_formation_number_sync_standbys(Monitor *monitor, char *formation,
 	{
 		log_error("Failed to update number-sync-standbys for formation \"%s\".",
 				  formation);
-
-		/* disconnect from monitor */
-		pgsql_finish(&monitor->pgsql);
-
 		return false;
 	}
 
@@ -1233,9 +1226,6 @@ monitor_remove(Monitor *monitor, char *host, int port)
 		log_error("Failed to remove node %s:%d from the monitor", host, port);
 		return false;
 	}
-
-	/* disconnect from PostgreSQL now */
-	pgsql_finish(&monitor->pgsql);
 
 	if (!context.parsedOk)
 	{
@@ -1683,9 +1673,6 @@ monitor_print_state(Monitor *monitor, char *formation, int group)
 		return false;
 	}
 
-	/* disconnect from PostgreSQL now */
-	pgsql_finish(&monitor->pgsql);
-
 	if (!context.parsedOK)
 	{
 		log_error("Failed to parse current state from the monitor");
@@ -1995,9 +1982,6 @@ monitor_print_state_as_json(Monitor *monitor, char *formation, int group)
 		return false;
 	}
 
-	/* disconnect from PostgreSQL now */
-	pgsql_finish(&monitor->pgsql);
-
 	if (!context.parsedOk)
 	{
 		log_error("Failed to parse current state from the monitor");
@@ -2084,9 +2068,6 @@ monitor_print_last_events(Monitor *monitor, char *formation, int group, int coun
 		return false;
 	}
 
-	/* disconnect from PostgreSQL now */
-	pgsql_finish(&monitor->pgsql);
-
 	if (!context.parsedOK)
 	{
 		return false;
@@ -2164,9 +2145,6 @@ monitor_print_last_events_as_json(Monitor *monitor,
 				  count);
 		return false;
 	}
-
-	/* disconnect from PostgreSQL now */
-	pgsql_finish(&monitor->pgsql);
 
 	if (!context.parsedOk)
 	{
@@ -2270,10 +2248,6 @@ monitor_create_formation(Monitor *monitor,
 		return false;
 	}
 
-	/* disconnect from PostgreSQL now */
-	pgsql_finish(&monitor->pgsql);
-
-
 	return true;
 }
 
@@ -2338,9 +2312,6 @@ monitor_disable_secondary_for_formation(Monitor *monitor, const char *formation)
 		return false;
 	}
 
-	/* disconnect from PostgreSQL now */
-	pgsql_finish(&monitor->pgsql);
-
 	return true;
 }
 
@@ -2368,9 +2339,6 @@ monitor_drop_formation(Monitor *monitor, char *formation)
 				  formation);
 		return false;
 	}
-
-	/* disconnect from PostgreSQL now */
-	pgsql_finish(&monitor->pgsql);
 
 	return true;
 }
@@ -2438,9 +2406,6 @@ monitor_formation_uri(Monitor *monitor,
 	strlcpy(connectionString, context.strVal, size);
 	free(context.strVal);
 
-	/* disconnect from PostgreSQL now */
-	pgsql_finish(&monitor->pgsql);
-
 	return true;
 }
 
@@ -2494,9 +2459,6 @@ monitor_print_every_formation_uri(Monitor *monitor, const SSLOptions *ssl)
 		/* errors have already been logged */
 		return false;
 	}
-
-	/* disconnect from PostgreSQL now */
-	pgsql_finish(&monitor->pgsql);
 
 	return true;
 }
@@ -2559,9 +2521,6 @@ monitor_print_every_formation_uri_as_json(Monitor *monitor,
 		}
 		return false;
 	}
-
-	/* disconnect from PostgreSQL now */
-	pgsql_finish(&monitor->pgsql);
 
 	fformat(stream, "%s\n", context.strVal);
 	free(context.strVal);
@@ -2660,9 +2619,6 @@ monitor_print_formation_settings(Monitor *monitor, char *formation)
 		log_error("Failed to retrieve formation settings from the monitor");
 		return false;
 	}
-
-	/* disconnect from PostgreSQL now */
-	pgsql_finish(&monitor->pgsql);
 
 	if (!context.parsedOK)
 	{
@@ -2820,9 +2776,6 @@ monitor_print_formation_settings_as_json(Monitor *monitor, char *formation)
 		log_error("Failed to retrieve current state from the monitor");
 		return false;
 	}
-
-	/* disconnect from PostgreSQL now */
-	pgsql_finish(&monitor->pgsql);
 
 	if (!context.parsedOk)
 	{
@@ -3029,9 +2982,6 @@ monitor_set_group_system_identifier(Monitor *monitor,
 		return false;
 	}
 
-	/* disconnect from PostgreSQL now */
-	pgsql_finish(&monitor->pgsql);
-
 	if (!context.parsedOk)
 	{
 		/* *INDENT-OFF* */
@@ -3232,7 +3182,7 @@ monitor_process_notifications(Monitor *monitor,
 							  void *notificationContext,
 							  NotificationProcessingFunction processor)
 {
-	PGconn *connection = monitor->pgsql.connection;
+	PGconn *connection = monitor->notificationClient.connection;
 	PGnotify *notify;
 
 
@@ -3263,7 +3213,7 @@ monitor_process_notifications(Monitor *monitor,
 		return false;
 	}
 
-	if (!pgsql_listen(&(monitor->pgsql), channels))
+	if (!pgsql_listen(&(monitor->notificationClient), channels))
 	{
 		/* restore signal masks (un block them) now */
 		(void) unblock_signals(&sig_mask_orig);
@@ -3271,7 +3221,7 @@ monitor_process_notifications(Monitor *monitor,
 		return false;
 	}
 
-	if (monitor->pgsql.connection == NULL)
+	if (monitor->notificationClient.connection == NULL)
 	{
 		log_warn("Lost connection.");
 
@@ -3287,7 +3237,7 @@ monitor_process_notifications(Monitor *monitor,
 	 *
 	 * https://www.postgresql.org/docs/current/libpq-example.html#LIBPQ-EXAMPLE-2
 	 */
-	int sock = PQsocket(monitor->pgsql.connection);
+	int sock = PQsocket(monitor->notificationClient.connection);
 
 	if (sock < 0)
 	{
@@ -3480,7 +3430,7 @@ bool
 monitor_wait_until_primary_applied_settings(Monitor *monitor,
 											const char *formation)
 {
-	PGconn *connection = monitor->pgsql.connection;
+	PGconn *connection = monitor->notificationClient.connection;
 	ApplySettingsNotificationContext context = {
 		(char *) formation,
 		false,
@@ -3523,7 +3473,7 @@ monitor_wait_until_primary_applied_settings(Monitor *monitor,
 	}
 
 	/* disconnect from monitor */
-	pgsql_finish(&monitor->pgsql);
+	pgsql_finish(&monitor->notificationClient);
 
 	return context.applySettingsTransitionDone;
 }
@@ -3570,7 +3520,7 @@ monitor_wait_for_state_change(Monitor *monitor,
 							  int timeoutMs,
 							  bool *stateHasChanged)
 {
-	PGconn *connection = monitor->pgsql.connection;
+	PGconn *connection = monitor->notificationClient.connection;
 
 	WaitForStateChangeNotificationContext context = {
 		(char *) formation,
@@ -3731,7 +3681,7 @@ monitor_wait_until_some_node_reported_state(Monitor *monitor,
 											PgInstanceKind nodeKind,
 											NodeState targetState)
 {
-	PGconn *connection = monitor->pgsql.connection;
+	PGconn *connection = monitor->notificationClient.connection;
 
 	NodeAddressArray nodesArray = { 0 };
 	NodeAddressHeaders headers = { 0 };
@@ -3781,7 +3731,7 @@ monitor_wait_until_some_node_reported_state(Monitor *monitor,
 	}
 
 	/* disconnect from monitor */
-	pgsql_finish(&monitor->pgsql);
+	pgsql_finish(&monitor->notificationClient);
 
 	return context.failoverIsDone;
 }
@@ -3864,7 +3814,7 @@ monitor_wait_until_node_reported_state(Monitor *monitor,
 									   PgInstanceKind nodeKind,
 									   NodeState targetState)
 {
-	PGconn *connection = monitor->pgsql.connection;
+	PGconn *connection = monitor->notificationClient.connection;
 
 	NodeAddressArray nodesArray = { 0 };
 	NodeAddressHeaders headers = { 0 };
@@ -3915,7 +3865,7 @@ monitor_wait_until_node_reported_state(Monitor *monitor,
 	}
 
 	/* disconnect from monitor */
-	pgsql_finish(&monitor->pgsql);
+	pgsql_finish(&monitor->notificationClient);
 
 	return context.done;
 }
@@ -4170,6 +4120,7 @@ monitor_ensure_extension_version(Monitor *monitor,
 
 		/* avoid spurious error messages about losing our connection */
 		pgsql_finish(&(monitor->pgsql));
+		pgsql_finish(&(monitor->notificationClient));
 
 		if (!ensure_postgres_service_is_stopped(postgres))
 		{

--- a/src/bin/pg_autoctl/monitor.c
+++ b/src/bin/pg_autoctl/monitor.c
@@ -4094,6 +4094,7 @@ monitor_ensure_extension_version(Monitor *monitor,
 					  "on the monitor, see above for details",
 					  PG_AUTOCTL_MONITOR_EXTENSION_NAME,
 					  extensionVersion);
+
 			/* explicitly close the dbOwner connection to the monitor */
 			pgsql_finish(&(dbOwnerMonitor.pgsql));
 			return false;

--- a/src/bin/pg_autoctl/monitor.h
+++ b/src/bin/pg_autoctl/monitor.h
@@ -21,6 +21,7 @@
 typedef struct Monitor
 {
 	PGSQL pgsql;
+	PGSQL notificationClient;
 	MonitorConfig config;
 } Monitor;
 

--- a/src/bin/pg_autoctl/monitor_pg_init.c
+++ b/src/bin/pg_autoctl/monitor_pg_init.c
@@ -199,9 +199,6 @@ monitor_install(const char *hostname,
 		return false;
 	}
 
-	/* we're done with that connection to "postgres" database */
-	pgsql_finish(&postgres.sqlClient);
-
 	/* now, connect to the newly created database to create our extension */
 	strlcpy(pgSetup.dbname, PG_AUTOCTL_MONITOR_DBNAME, NAMEDATALEN);
 	pg_setup_get_local_connection_string(&pgSetup, connInfo);
@@ -241,8 +238,6 @@ monitor_install(const char *hostname,
 			return false;
 		}
 	}
-
-	pgsql_finish(&postgres.sqlClient);
 
 	log_info("Your pg_auto_failover monitor instance is now ready on port %d.",
 			 pgSetup.pgport);

--- a/src/bin/pg_autoctl/pgsql.c
+++ b/src/bin/pg_autoctl/pgsql.c
@@ -860,6 +860,7 @@ pgsql_begin(PGSQL *pgsql)
 	return pgsql_execute(pgsql, "BEGIN");
 }
 
+
 /*
  * pgsql_rollback is responsible for issuing a 'ROLLBACK' query to an already
  * opened transaction, usually via a previous pgsql_begin() command.
@@ -893,6 +894,7 @@ pgsql_rollback(PGSQL *pgsql)
 
 	return result;
 }
+
 
 /*
  * pgsql_commit is responsible for issuing a 'COMMIT' query to an already
@@ -2029,7 +2031,7 @@ pgsql_create_database(PGSQL *pgsql, const char *dbname, const char *owner)
 	clear_results(pgsql);
 	if (pgsql->connectionStatementType == PGSQL_CONNECTION_SINGLE_STATEMENT)
 	{
-			pgsql_finish(pgsql);
+		pgsql_finish(pgsql);
 	}
 
 	return true;
@@ -2091,7 +2093,7 @@ pgsql_create_extension(PGSQL *pgsql, const char *name)
 	clear_results(pgsql);
 	if (pgsql->connectionStatementType == PGSQL_CONNECTION_SINGLE_STATEMENT)
 	{
-			pgsql_finish(pgsql);
+		pgsql_finish(pgsql);
 	}
 
 	return true;
@@ -2226,7 +2228,7 @@ pgsql_create_user(PGSQL *pgsql, const char *userName, const char *password,
 	clear_results(pgsql);
 	if (pgsql->connectionStatementType == PGSQL_CONNECTION_SINGLE_STATEMENT)
 	{
-			pgsql_finish(pgsql);
+		pgsql_finish(pgsql);
 	}
 
 	/* restore the normal notice message processing, if needed. */

--- a/src/bin/pg_autoctl/pgsql.c
+++ b/src/bin/pg_autoctl/pgsql.c
@@ -2914,6 +2914,34 @@ pgsql_listen(PGSQL *pgsql, char *channels[])
 
 
 /*
+ * Preapre a multi statement connection which can later be used in wait for
+ * notification functions.
+ *
+ * Contrarry to pgsql_listen, this function, only prepares the connection and it
+ * is the user's responsibility to define which channels to listen to.
+ */
+bool
+pgsql_prepare_to_wait(PGSQL *pgsql)
+{
+	/*
+	 * mark the connection as multi statement since it is going to be used by
+	 * for processing notifications
+	 */
+	pgsql->connectionStatementType = PGSQL_CONNECTION_MULTI_STATEMENT;
+
+	/* open a connection upfront since it is needed by PQescape functions */
+	PGconn *connection = pgsql_open_connection(pgsql);
+	if (connection == NULL)
+	{
+		/* error message was logged in pgsql_open_connection */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
  * pgsql_alter_extension_update_to executes ALTER EXTENSION ... UPDATE TO ...
  */
 bool

--- a/src/bin/pg_autoctl/pgsql.c
+++ b/src/bin/pg_autoctl/pgsql.c
@@ -421,6 +421,8 @@ pgsql_finish(PGSQL *pgsql)
 		 * status.
 		 */
 	}
+
+	pgsql->connectionStatementType = PGSQL_CONNECTION_SINGLE_STATEMENT;
 }
 
 
@@ -468,6 +470,13 @@ pgsql_open_connection(PGSQL *pgsql)
 	/* we might be connected already */
 	if (pgsql->connection != NULL)
 	{
+		if (pgsql->connectionStatementType != PGSQL_CONNECTION_MULTI_STATEMENT)
+		{
+			log_error("BUG: requested to open an already open connection in "
+					  "non PGSQL_CONNECTION_MULTI_STATEMENT mode");
+			pgsql_finish(pgsql);
+			return NULL;
+		}
 		return pgsql->connection;
 	}
 
@@ -832,6 +841,99 @@ pgAutoCtlDebugNoticeProcessor(void *arg, const char *message)
 
 
 /*
+ * pgsql_begin is responsible for opening a mutli statement connection and
+ * opening a transaction block by issuing a 'BEGIN' query.
+ */
+bool
+pgsql_begin(PGSQL *pgsql)
+{
+	PGconn *connection;
+
+	pgsql->connectionStatementType = PGSQL_CONNECTION_MULTI_STATEMENT;
+	connection = pgsql_open_connection(pgsql);
+	if (connection == NULL)
+	{
+		/* error message was logged in pgsql_open_connection */
+		return false;
+	}
+
+	return pgsql_execute(pgsql, "BEGIN");
+}
+
+/*
+ * pgsql_rollback is responsible for issuing a 'ROLLBACK' query to an already
+ * opened transaction, usually via a previous pgsql_begin() command.
+ *
+ * It closes the connection but leaves the error contents, if any, for the user
+ * to examine should it is wished for.
+ */
+bool
+pgsql_rollback(PGSQL *pgsql)
+{
+	bool result;
+
+	if (pgsql->connectionStatementType != PGSQL_CONNECTION_MULTI_STATEMENT ||
+		pgsql->connection == NULL)
+	{
+		log_error("BUG: call to pgsql_rollback without holding an open "
+				  "multi statement connection");
+		return false;
+	}
+
+	result = pgsql_execute(pgsql, "ROLLBACK");
+
+	/*
+	 * Connection might be be closed during the pgsql_execute(), notably in case
+	 * of error. Be explicit and close it regardless though.
+	 */
+	if (pgsql->connection)
+	{
+		pgsql_finish(pgsql);
+	}
+
+	return result;
+}
+
+/*
+ * pgsql_commit is responsible for issuing a 'COMMIT' query to an already
+ * opened transaction, usually via a previous pgsql_begin() command.
+ *
+ * It closes the connection but leaves the error contents, if any, for the user
+ * to examine should it is wished for.
+ */
+bool
+pgsql_commit(PGSQL *pgsql)
+{
+	bool result;
+
+	if (pgsql->connectionStatementType != PGSQL_CONNECTION_MULTI_STATEMENT ||
+		pgsql->connection == NULL)
+	{
+		log_error("BUG: call to pgsql_commit() without holding an open "
+				  "multi statement connection");
+		if (pgsql->connection)
+		{
+			pgsql_finish(pgsql);
+		}
+		return false;
+	}
+
+	result = pgsql_execute(pgsql, "COMMIT");
+
+	/*
+	 * Connection might be be closed during the pgsql_execute(), notably in case
+	 * of error. Be explicit and close it regardless though.
+	 */
+	if (pgsql->connection)
+	{
+		pgsql_finish(pgsql);
+	}
+
+	return result;
+}
+
+
+/*
  * pgsql_execute opens a connection, runs a given SQL command, and closes
  * the connection again.
  *
@@ -981,6 +1083,11 @@ pgsql_execute_with_params(PGSQL *pgsql, const char *sql, int paramCount,
 
 	PQclear(result);
 	clear_results(pgsql);
+	if (pgsql->connectionStatementType == PGSQL_CONNECTION_SINGLE_STATEMENT)
+	{
+		PQfinish(pgsql->connection);
+		pgsql->connection = NULL;
+	}
 
 	return true;
 }
@@ -1920,6 +2027,10 @@ pgsql_create_database(PGSQL *pgsql, const char *dbname, const char *owner)
 
 	PQclear(result);
 	clear_results(pgsql);
+	if (pgsql->connectionStatementType == PGSQL_CONNECTION_SINGLE_STATEMENT)
+	{
+			pgsql_finish(pgsql);
+	}
 
 	return true;
 }
@@ -1978,6 +2089,10 @@ pgsql_create_extension(PGSQL *pgsql, const char *name)
 
 	PQclear(result);
 	clear_results(pgsql);
+	if (pgsql->connectionStatementType == PGSQL_CONNECTION_SINGLE_STATEMENT)
+	{
+			pgsql_finish(pgsql);
+	}
 
 	return true;
 }
@@ -2109,6 +2224,10 @@ pgsql_create_user(PGSQL *pgsql, const char *userName, const char *password,
 
 	PQclear(result);
 	clear_results(pgsql);
+	if (pgsql->connectionStatementType == PGSQL_CONNECTION_SINGLE_STATEMENT)
+	{
+			pgsql_finish(pgsql);
+	}
 
 	/* restore the normal notice message processing, if needed. */
 	PQsetNoticeProcessor(connection, previousNoticeProcessor, NULL);
@@ -2740,6 +2859,12 @@ pgsql_listen(PGSQL *pgsql, char *channels[])
 {
 	PGresult *result = NULL;
 	char sql[BUFSIZE];
+
+	/*
+	 * mark the connection as multi statement since it is going to be used by
+	 * for processing notifications
+	 */
+	pgsql->connectionStatementType = PGSQL_CONNECTION_MULTI_STATEMENT;
 
 	/* open a connection upfront since it is needed by PQescape functions */
 	PGconn *connection = pgsql_open_connection(pgsql);

--- a/src/bin/pg_autoctl/pgsql.h
+++ b/src/bin/pg_autoctl/pgsql.h
@@ -94,6 +94,20 @@ typedef struct ConnectionRetryPolicy
 	int attempts;               /* how many attempts have been made so far */
 } ConnectionRetryPolicy;
 
+/*
+ * Denote if the connetion is going to be used for one, or multiple statements.
+ * This is used by psql_* functions to know if a connection is to be closed
+ * after successful completion, or if the the connection is to be maintained
+ * open for further queries.
+ *
+ * A common use case for maintaining a connection open, is while wishing to open
+ * and maintain a transaction block. Another, is while listening for events.
+ */
+typedef enum
+{
+	PGSQL_CONNECTION_SINGLE_STATEMENT = 0,
+	PGSQL_CONNECTION_MULTI_STATEMENT
+} ConnectionStatementType;
 
 /*
  * Allow higher level code to distinguish between failure to connect to the
@@ -118,6 +132,7 @@ typedef bool (*ProcessNotificationFunction)(int notificationGroupId,
 typedef struct PGSQL
 {
 	ConnectionType connectionType;
+	ConnectionStatementType connectionStatementType;
 	char connectionString[MAXCONNINFO];
 	PGconn *connection;
 	ConnectionRetryPolicy retryPolicy;
@@ -261,6 +276,9 @@ bool pgsql_retry_policy_expired(ConnectionRetryPolicy *retryPolicy);
 void pgsql_finish(PGSQL *pgsql);
 void parseSingleValueResult(void *ctx, PGresult *result);
 void fetchedRows(void *ctx, PGresult *result);
+bool pgsql_begin(PGSQL *pgsql);
+bool pgsql_commit(PGSQL *pgsql);
+bool pgsql_rollback(PGSQL *pgsql);
 bool pgsql_execute(PGSQL *pgsql, const char *sql);
 bool pgsql_execute_with_params(PGSQL *pgsql, const char *sql, int paramCount,
 							   const Oid *paramTypes, const char **paramValues,

--- a/src/bin/pg_autoctl/pgsql.h
+++ b/src/bin/pg_autoctl/pgsql.h
@@ -328,6 +328,7 @@ bool pgsql_has_reached_target_lsn(PGSQL *pgsql, char *targetLSN,
 								  char *currentLSN, bool *hasReachedLSN);
 bool pgsql_identify_system(PGSQL *pgsql);
 bool pgsql_listen(PGSQL *pgsql, char *channels[]);
+bool pgsql_prepare_to_wait(PGSQL *pgsql);
 
 bool pgsql_alter_extension_update_to(PGSQL *pgsql,
 									 const char *extname, const char *version);

--- a/src/bin/pg_autoctl/service_keeper.c
+++ b/src/bin/pg_autoctl/service_keeper.c
@@ -623,7 +623,7 @@ keeper_node_active(Keeper *keeper, bool doInit)
 	bool forceCacheInvalidation = false;
 	bool reportPgIsRunning = ReportPgIsRunning(keeper);
 
-	char *emptyChannelList = { NULL };
+	char *emptyChannelList[] = { NULL };
 
 	/*
 	 * First, connect to the monitor and check we're compatible with the

--- a/src/bin/pg_autoctl/service_keeper.c
+++ b/src/bin/pg_autoctl/service_keeper.c
@@ -623,7 +623,7 @@ keeper_node_active(Keeper *keeper, bool doInit)
 	bool forceCacheInvalidation = false;
 	bool reportPgIsRunning = ReportPgIsRunning(keeper);
 
-	char *emptyChannel[] = { 0 };
+	char *emptyChannelList = { NULL };
 
 	/*
 	 * First, connect to the monitor and check we're compatible with the
@@ -807,7 +807,7 @@ keeper_node_active(Keeper *keeper, bool doInit)
 	}
 
 	/* Finally establish a connection for notifications if none present */
-	(void) pgsql_listen(&(keeper->monitor.pgsql), emptyChannel);
+	(void) pgsql_listen(&(keeper->monitor.pgsql), emptyChannelList);
 
 	return true;
 }

--- a/src/bin/pg_autoctl/service_keeper.c
+++ b/src/bin/pg_autoctl/service_keeper.c
@@ -590,6 +590,9 @@ keeper_node_active_loop(Keeper *keeper, pid_t start_pid)
 		}
 	}
 
+	/* One last check that we do not have any connections open */
+	pgsql_finish(&(keeper->monitor.pgsql));
+
 	return true;
 }
 
@@ -619,6 +622,8 @@ keeper_node_active(Keeper *keeper, bool doInit)
 
 	bool forceCacheInvalidation = false;
 	bool reportPgIsRunning = ReportPgIsRunning(keeper);
+
+	char *emptyChannel[] = { 0 };
 
 	/*
 	 * First, connect to the monitor and check we're compatible with the
@@ -800,6 +805,9 @@ keeper_node_active(Keeper *keeper, bool doInit)
 			return false;
 		}
 	}
+
+	/* Finally establish a connection for notifications if none present */
+	(void) pgsql_listen(&(keeper->monitor.pgsql), emptyChannel);
 
 	return true;
 }

--- a/src/bin/pg_autoctl/service_keeper.c
+++ b/src/bin/pg_autoctl/service_keeper.c
@@ -287,9 +287,11 @@ keeper_node_active_loop(Keeper *keeper, pid_t start_pid)
 												 &groupStateHasChanged);
 
 			/* when no state change has been notified, close the connection */
-			if (!groupStateHasChanged)
+			if (!groupStateHasChanged &&
+				monitor->notificationClient.connectionStatementType ==
+				PGSQL_CONNECTION_SINGLE_STATEMENT)
 			{
-				pgsql_finish(&(keeper->monitor.pgsql));
+				pgsql_finish(&(monitor->notificationClient));
 			}
 		}
 		else if (doSleep && config->monitorDisabled)
@@ -393,7 +395,6 @@ keeper_node_active_loop(Keeper *keeper, pid_t start_pid)
 				continue;
 			}
 		}
-
 		/*
 		 * If the monitor is not disabled, call the node_active function on the
 		 * monitor and update the keeper data structure accordingy, refreshing
@@ -807,7 +808,7 @@ keeper_node_active(Keeper *keeper, bool doInit)
 	}
 
 	/* Finally establish a connection for notifications if none present */
-	(void) pgsql_listen(&(keeper->monitor.pgsql), emptyChannelList);
+	(void) pgsql_listen(&(keeper->monitor.notificationClient), emptyChannelList);
 
 	return true;
 }


### PR DESCRIPTION
It seems that pgsql_execute_with_params() during its lifetime has been
inconsistently altered. The latest version notes in the comments that the
connection is not persistant to facilitate error handling. However that was not
entirely true and several parts of the code assumed it to not be true. Others
assumed to be true and failed to release the connection once used.

For the sake of clarity, the function will now explicitly close the connection
that has used, regardless of wether it is a new or existing connection. That
simplifies most of the code and plugs the connection leaks.

It also unconvers an inconsistency on the connections used for notification. The
code mixed the connection it was using to listen to events from the monitor and
with others. A new PGconn member has been added in the monitor struct to
distinguish between the two distinct cases.