### PR TITLE
Fix memory management issue in monitor_register_node.

### DIFF
--- a/src/bin/pg_autoctl/keeper.c
+++ b/src/bin/pg_autoctl/keeper.c
@@ -1352,6 +1352,9 @@ keeper_register_and_init(Keeper *keeper, NodeState initialState)
 		(void) pg_usleep(sleepTimeMs * 1000);
 	}
 
+	/* we might have been assigned a new name */
+	strlcpy(config->name, assignedState.name, sizeof(config->name));
+
 	/* initialize FSM state from monitor's answer */
 	log_info("Writing keeper state file at \"%s\"", config->pathnames.state);
 

--- a/src/bin/pg_autoctl/monitor.h
+++ b/src/bin/pg_autoctl/monitor.h
@@ -26,6 +26,7 @@ typedef struct Monitor
 
 typedef struct MonitorAssignedState
 {
+	char name[_POSIX_HOST_NAME_MAX];
 	int nodeId;
 	int groupId;
 	NodeState state;


### PR DESCRIPTION
We should refrain from calling strlcpy() on one of the function arguments.