### PR TITLE
Add opt-in security flags

### DIFF
--- a/src/bin/pg_autoctl/Makefile
+++ b/src/bin/pg_autoctl/Makefile
@@ -45,6 +45,12 @@ DEFAULT_CFLAGS += -Wno-declaration-after-statement
 DEFAULT_CFLAGS += -Wno-missing-braces
 DEFAULT_CFLAGS += $(COMMON_LIBS)
 
+ifdef USE_SECURITY_FLAGS
+# Flags taken from: https://liquid.microsoft.com/Web/Object/Read/ms.security/Requirements/Microsoft.Security.SystemsADM.10203#guide
+SECURITY_CFLAGS=-fstack-protector-strong -D_FORTIFY_SOURCE=2 -O2 -z noexecstack -fpie -Wl,-pie -Wl,-z,relro -Wl,-z,now -Wformat -Wformat-security -Werror=format-security
+DEFAULT_CFLAGS += $(SECURITY_CFLAGS)
+endif
+
 override CFLAGS := $(DEFAULT_CFLAGS) $(CFLAGS)
 
 LIBS  = -L $(shell $(PG_CONFIG) --pkglibdir)

--- a/src/monitor/Makefile
+++ b/src/monitor/Makefile
@@ -33,9 +33,22 @@ DEFAULT_CFLAGS += -Wno-declaration-after-statement
 
 # Needed for OSX
 DEFAULT_CFLAGS += -Wno-missing-braces
+
+ifdef USE_SECURITY_FLAGS
+# Flags taken from: https://liquid.microsoft.com/Web/Object/Read/ms.security/Requirements/Microsoft.Security.SystemsADM.10203#guide
+SECURITY_CFLAGS=-fstack-protector-strong -D_FORTIFY_SOURCE=2 -O2 -z noexecstack -fpic -shared -Wl,-z,relro -Wl,-z,now -Wformat -Wformat-security -Werror=format-security
+DEFAULT_CFLAGS += $(SECURITY_CFLAGS)
+endif
+
 override CFLAGS := $(DEFAULT_CFLAGS) $(CFLAGS)
 
 include $(PGXS)
+
+ifdef USE_SECURITY_FLAGS
+# Flags taken from: https://liquid.microsoft.com/Web/Object/Read/ms.security/Requirements/Microsoft.Security.SystemsADM.10203#guide
+SECURITY_BITCODE_CFLAGS=-fsanitize=safe-stack -fstack-protector-strong -flto -fPIC -Wformat -Wformat-security -Werror=format-security
+override BITCODE_CFLAGS := $(BITCODE_CFLAGS) $(SECURITY_BITCODE_CFLAGS)
+endif
 
 cleanup-before-install:
 	rm -f $(DESTDIR)$(datadir)/$(datamoduledir)/pgautofailover*


### PR DESCRIPTION
Microsoft has a set of guidelines for hardening GNU/Linux executables and linkables. If a`USE_SECURITY_FLAGS` command line option or environment variable is defined, we add some flags to both compiler and llvm linker flags.

Note that the CFLAGS for shared libraries and executables are different. Hence different set of security flags in Makefiles.

`make USE_SECURITY_FLAGS=1` or `USE_SECURITY_FLAGS=1 make` will build the project with the security flags.