### PR TITLE
Add pg_logging_init for PG version 12 and above

### DIFF
--- a/src/bin/pg_autoctl/main.c
+++ b/src/bin/pg_autoctl/main.c
@@ -53,7 +53,7 @@ main(int argc, char **argv)
 
 	/*
 	 * Since PG 12, we need to call pg_logging_init before any calls to pg_log_*
-	 * otherwise, we get a segfault. Although we doesn't use pg_log_* directly,
+	 * otherwise, we get a segfault. Although we don't use pg_log_* directly,
 	 * functions from the common library such as rmtree do use them.
 	 * Logging change introduced in PG 12: https://git.postgresql.org/cgit/postgresql.git/commit/?id=cc8d41511721d25d557fc02a46c053c0a602fed0
 	 */

--- a/src/bin/pg_autoctl/main.c
+++ b/src/bin/pg_autoctl/main.c
@@ -55,7 +55,7 @@ main(int argc, char **argv)
 	 * Since PG 12, we need to call pg_logging_init before any calls to pg_log_*
 	 * otherwise, we get a segfault. Although we doesn't use pg_log_* directly,
 	 * functions from the common library such as rmtree do use them.
-	 * Logging change introduced in PG 12: https://git.io/JqvcN
+	 * Logging change introduced in PG 12: https://git.postgresql.org/cgit/postgresql.git/commit/?id=cc8d41511721d25d557fc02a46c053c0a602fed0
 	 */
 	#if (PG_VERSION_NUM >= 120000)
 	pg_logging_init(argv[0]);

--- a/src/bin/pg_autoctl/main.c
+++ b/src/bin/pg_autoctl/main.c
@@ -18,6 +18,9 @@
 #include "keeper_config.h"
 #include "lock_utils.h"
 #include "string_utils.h"
+#if (PG_VERSION_NUM >= 120000)
+#include "common/logging.h"
+#endif
 
 char pg_autoctl_argv0[MAXPGPATH];
 char pg_autoctl_program[MAXPGPATH];
@@ -47,6 +50,16 @@ main(int argc, char **argv)
 
 	/* set our logging infrastructure */
 	(void) set_logger();
+
+	/*
+	 * Since PG 12, we need to call pg_logging_init before any calls to pg_log_*
+	 * otherwise, we get a segfault. Although we doesn't use pg_log_* directly,
+	 * functions from the common library such as rmtree do use them.
+	 * Logging change introduced in PG 12: https://git.io/JqvcN
+	 */
+	#if (PG_VERSION_NUM >= 120000)
+	pg_logging_init(argv[0]);
+	#endif
 
 	/* register our logging clean-up atexit */
 	atexit(log_semaphore_unlink_atexit);


### PR DESCRIPTION
I have tested the change locally on pg versions 10, 11, 12 and 13, `rmtree` no longer segfaults for PG versions >= 12.
How I tested it:
1) Get monitor and primary up and running.
2) When setting up the secondary we set PGDATA to a mount point so if we `rmtree` it, we'll get a busy device error. 
`rmtree` logs that error using `pg_log_warn` which would segfault if we don't call `pg_logging_init` before hand.

None of the testing is automated, it was done with a finicky docker-compose setup and manually executing commands on the secondary node's container.
If we want to add a test case for this, I don't know how to do it in the existing testing framework.  