### PR TITLE
Fix/pgsql connection leaks

### DIFF
--- a/src/bin/pg_autoctl/cli_enable_disable.c
+++ b/src/bin/pg_autoctl/cli_enable_disable.c
@@ -505,7 +505,7 @@ cli_enable_maintenance(int argc, char **argv)
 	 */
 	if (keeper.state.current_role != MAINTENANCE_STATE)
 	{
-		if (!pgsql_listen(&(keeper.monitor.pgsql), channels))
+		if (!pgsql_listen(&(keeper.monitor.notificationClient), channels))
 		{
 			log_error("Failed to listen to state changes from the monitor");
 			exit(EXIT_CODE_MONITOR);
@@ -610,7 +610,7 @@ cli_disable_maintenance(int argc, char **argv)
 		exit(EXIT_CODE_MONITOR);
 	}
 
-	if (!pgsql_listen(&(keeper.monitor.pgsql), channels))
+	if (!pgsql_listen(&(keeper.monitor.notificationClient), channels))
 	{
 		log_error("Failed to listen to state changes from the monitor");
 		exit(EXIT_CODE_MONITOR);

--- a/src/bin/pg_autoctl/cli_get_set_properties.c
+++ b/src/bin/pg_autoctl/cli_get_set_properties.c
@@ -687,7 +687,7 @@ set_node_candidate_priority(Keeper *keeper, int candidatePriority)
 	{
 		char *channels[] = { "state", NULL };
 
-		if (!pgsql_listen(&(keeper->monitor.pgsql), channels))
+		if (!pgsql_listen(&(keeper->monitor.notificationClient), channels))
 		{
 			log_error("Failed to listen to state changes from the monitor");
 			return false;
@@ -750,7 +750,7 @@ set_node_replication_quorum(Keeper *keeper, bool replicationQuorum)
 	{
 		char *channels[] = { "state", NULL };
 
-		if (!pgsql_listen(&(keeper->monitor.pgsql), channels))
+		if (!pgsql_listen(&(keeper->monitor.notificationClient), channels))
 		{
 			log_error("Failed to listen to state changes from the monitor");
 			return false;
@@ -812,7 +812,7 @@ set_formation_number_sync_standbys(Monitor *monitor,
 	{
 		char *channels[] = { "state", NULL };
 
-		if (!pgsql_listen(&(monitor->pgsql), channels))
+		if (!pgsql_listen(&(monitor->notificationClient), channels))
 		{
 			log_error("Failed to listen to state changes from the monitor");
 			return false;

--- a/src/bin/pg_autoctl/cli_perform.c
+++ b/src/bin/pg_autoctl/cli_perform.c
@@ -258,7 +258,7 @@ cli_perform_failover(int argc, char **argv)
 	(void) cli_set_groupId(&monitor, &config);
 
 	/* start listening to the state changes before we call perform_failover */
-	if (!pgsql_listen(&(monitor.pgsql), channels))
+	if (!pgsql_listen(&(monitor.notificationClient), channels))
 	{
 		log_error("Failed to listen to state changes from the monitor");
 		exit(EXIT_CODE_MONITOR);
@@ -318,7 +318,7 @@ cli_perform_promotion(int argc, char **argv)
 	}
 
 	/* start listening to the state changes before we call perform_promotion */
-	if (!pgsql_listen(&(monitor->pgsql), channels))
+	if (!pgsql_listen(&(monitor->notificationClient), channels))
 	{
 		log_error("Failed to listen to state changes from the monitor");
 		exit(EXIT_CODE_MONITOR);

--- a/src/bin/pg_autoctl/keeper.c
+++ b/src/bin/pg_autoctl/keeper.c
@@ -1291,7 +1291,7 @@ keeper_register_and_init(Keeper *keeper, NodeState initialState)
 		 * the registration (process killed, crash, etc), then the server
 		 * issues a ROLLBACK for us upon disconnection.
 		 */
-		if (!pgsql_execute(&(monitor->pgsql), "BEGIN"))
+		if (!pgsql_begin(&(monitor->pgsql)))
 		{
 			log_error("Failed to open a SQL transaction to register this node");
 
@@ -1403,7 +1403,7 @@ keeper_register_and_init(Keeper *keeper, NodeState initialState)
 		goto rollback;
 	}
 
-	if (!pgsql_execute(&(monitor->pgsql), "COMMIT"))
+	if (!pgsql_commit(&(monitor->pgsql)))
 	{
 		log_error("Failed to COMMIT register_node transaction on the "
 				  "monitor, see above for details");
@@ -1426,7 +1426,7 @@ rollback:
 	 */
 	unlink_file(config->pathnames.state);
 
-	if (!pgsql_execute(&(monitor->pgsql), "ROLLBACK"))
+	if (!pgsql_rollback(&(monitor->pgsql)))
 	{
 		log_error("Failed to ROLLBACK failed register_node transaction "
 				  " on the monitor, see above for details.");

--- a/src/bin/pg_autoctl/keeper.c
+++ b/src/bin/pg_autoctl/keeper.c
@@ -2380,6 +2380,7 @@ keeper_reload_configuration(Keeper *keeper, bool firstLoop, bool doInit)
 
 		/* disconnect to the current monitor if we're connected */
 		(void) pgsql_finish(&(keeper->monitor.pgsql));
+		(void) pgsql_finish(&(keeper->monitor.notificationClient));
 
 		if (keeper_config_read_file(&newConfig,
 									missingPgdataIsOk,

--- a/src/bin/pg_autoctl/keeper_pg_init.c
+++ b/src/bin/pg_autoctl/keeper_pg_init.c
@@ -548,12 +548,15 @@ wait_until_primary_is_ready(Keeper *keeper,
 			KeeperStateData *keeperState = &(keeper->state);
 			int timeoutMs = PG_AUTOCTL_KEEPER_SLEEP_TIME * 1000;
 
+			(void) pgsql_listen(&(monitor->notificationClient), &((char *) { 0 }));
+
 			(void) monitor_wait_for_state_change(monitor,
 												 keeper->config.formation,
 												 keeperState->current_group,
 												 keeperState->current_node_id,
 												 timeoutMs,
 												 &groupStateHasChanged);
+			pgsql_finish(&(monitor->notificationClient));
 		}
 
 		if (!monitor_node_active(&(keeper->monitor),

--- a/src/bin/pg_autoctl/keeper_pg_init.c
+++ b/src/bin/pg_autoctl/keeper_pg_init.c
@@ -548,7 +548,9 @@ wait_until_primary_is_ready(Keeper *keeper,
 			KeeperStateData *keeperState = &(keeper->state);
 			int timeoutMs = PG_AUTOCTL_KEEPER_SLEEP_TIME * 1000;
 
-			(void) pgsql_listen(&(monitor->notificationClient), &((char *) { 0 }));
+			char *channels[] = { "state", NULL };
+
+			(void) pgsql_listen(&(monitor->notificationClient), channels);
 
 			(void) monitor_wait_for_state_change(monitor,
 												 keeper->config.formation,

--- a/src/bin/pg_autoctl/monitor.c
+++ b/src/bin/pg_autoctl/monitor.c
@@ -194,6 +194,12 @@ monitor_init(Monitor *monitor, char *url)
 		return false;
 	}
 
+	if (!pgsql_init(&monitor->notificationClient, url, PGSQL_CONN_MONITOR))
+	{
+		/* URL must be invalid, pgsql_init logged an error */
+		return false;
+	}
+
 	return true;
 }
 
@@ -205,12 +211,12 @@ monitor_init(Monitor *monitor, char *url)
 void
 monitor_setup_notifications(Monitor *monitor, int groupId, int nodeId)
 {
-	monitor->pgsql.notificationGroupId = groupId;
-	monitor->pgsql.notificationNodeId = nodeId;
-	monitor->pgsql.notificationReceived = false;
+	monitor->notificationClient.notificationGroupId = groupId;
+	monitor->notificationClient.notificationNodeId = nodeId;
+	monitor->notificationClient.notificationReceived = false;
 
 	/* install our notification handler */
-	monitor->pgsql.notificationProcessFunction =
+	monitor->notificationClient.notificationProcessFunction =
 		&monitor_process_state_notification;
 }
 
@@ -223,9 +229,9 @@ monitor_setup_notifications(Monitor *monitor, int groupId, int nodeId)
 bool
 monitor_has_received_notifications(Monitor *monitor)
 {
-	bool ret = monitor->pgsql.notificationReceived;
+	bool ret = monitor->notificationClient.notificationReceived;
 
-	monitor->pgsql.notificationReceived = false;
+	monitor->notificationClient.notificationReceived = false;
 
 	return ret;
 }
@@ -277,6 +283,12 @@ monitor_local_init(Monitor *monitor)
 	pg_setup_get_local_connection_string(pgSetup, connInfo);
 
 	if (!pgsql_init(&monitor->pgsql, connInfo, PGSQL_CONN_LOCAL))
+	{
+		/* URL must be invalid, pgsql_init logged an error */
+		return false;
+	}
+
+	if (!pgsql_init(&monitor->notificationClient, connInfo, PGSQL_CONN_LOCAL))
 	{
 		/* URL must be invalid, pgsql_init logged an error */
 		return false;
@@ -421,9 +433,6 @@ monitor_print_nodes_as_json(Monitor *monitor, char *formation, int groupId)
 		}
 		return false;
 	}
-
-	/* disconnect from PostgreSQL now */
-	pgsql_finish(&monitor->pgsql);
 
 	if (!context.parsedOk)
 	{
@@ -573,9 +582,6 @@ monitor_print_other_nodes_as_json(Monitor *monitor,
 		}
 		return false;
 	}
-
-	/* disconnect from PostgreSQL now */
-	pgsql_finish(&monitor->pgsql);
 
 	if (!context.parsedOk)
 	{
@@ -1045,14 +1051,8 @@ monitor_get_node_replication_settings(Monitor *monitor,
 		log_error("Failed to retrieve node settings for node \"%s\".",
 				  settings->name);
 
-		/* disconnect from monitor */
-		pgsql_finish(&monitor->pgsql);
-
 		return false;
 	}
-
-	/* disconnect from monitor */
-	pgsql_finish(&monitor->pgsql);
 
 	if (!parseContext.parsedOK)
 	{
@@ -1148,9 +1148,6 @@ monitor_get_formation_number_sync_standbys(Monitor *monitor, char *formation,
 		log_error("Failed to retrieve settings for formation \"%s\".",
 				  formation);
 
-		/* disconnect from monitor */
-		pgsql_finish(&monitor->pgsql);
-
 		return false;
 	}
 
@@ -1193,10 +1190,6 @@ monitor_set_formation_number_sync_standbys(Monitor *monitor, char *formation,
 	{
 		log_error("Failed to update number-sync-standbys for formation \"%s\".",
 				  formation);
-
-		/* disconnect from monitor */
-		pgsql_finish(&monitor->pgsql);
-
 		return false;
 	}
 
@@ -1233,9 +1226,6 @@ monitor_remove(Monitor *monitor, char *host, int port)
 		log_error("Failed to remove node %s:%d from the monitor", host, port);
 		return false;
 	}
-
-	/* disconnect from PostgreSQL now */
-	pgsql_finish(&monitor->pgsql);
 
 	if (!context.parsedOk)
 	{
@@ -1683,9 +1673,6 @@ monitor_print_state(Monitor *monitor, char *formation, int group)
 		return false;
 	}
 
-	/* disconnect from PostgreSQL now */
-	pgsql_finish(&monitor->pgsql);
-
 	if (!context.parsedOK)
 	{
 		log_error("Failed to parse current state from the monitor");
@@ -1995,9 +1982,6 @@ monitor_print_state_as_json(Monitor *monitor, char *formation, int group)
 		return false;
 	}
 
-	/* disconnect from PostgreSQL now */
-	pgsql_finish(&monitor->pgsql);
-
 	if (!context.parsedOk)
 	{
 		log_error("Failed to parse current state from the monitor");
@@ -2084,9 +2068,6 @@ monitor_print_last_events(Monitor *monitor, char *formation, int group, int coun
 		return false;
 	}
 
-	/* disconnect from PostgreSQL now */
-	pgsql_finish(&monitor->pgsql);
-
 	if (!context.parsedOK)
 	{
 		return false;
@@ -2164,9 +2145,6 @@ monitor_print_last_events_as_json(Monitor *monitor,
 				  count);
 		return false;
 	}
-
-	/* disconnect from PostgreSQL now */
-	pgsql_finish(&monitor->pgsql);
 
 	if (!context.parsedOk)
 	{
@@ -2270,10 +2248,6 @@ monitor_create_formation(Monitor *monitor,
 		return false;
 	}
 
-	/* disconnect from PostgreSQL now */
-	pgsql_finish(&monitor->pgsql);
-
-
 	return true;
 }
 
@@ -2338,9 +2312,6 @@ monitor_disable_secondary_for_formation(Monitor *monitor, const char *formation)
 		return false;
 	}
 
-	/* disconnect from PostgreSQL now */
-	pgsql_finish(&monitor->pgsql);
-
 	return true;
 }
 
@@ -2368,9 +2339,6 @@ monitor_drop_formation(Monitor *monitor, char *formation)
 				  formation);
 		return false;
 	}
-
-	/* disconnect from PostgreSQL now */
-	pgsql_finish(&monitor->pgsql);
 
 	return true;
 }
@@ -2438,9 +2406,6 @@ monitor_formation_uri(Monitor *monitor,
 	strlcpy(connectionString, context.strVal, size);
 	free(context.strVal);
 
-	/* disconnect from PostgreSQL now */
-	pgsql_finish(&monitor->pgsql);
-
 	return true;
 }
 
@@ -2494,9 +2459,6 @@ monitor_print_every_formation_uri(Monitor *monitor, const SSLOptions *ssl)
 		/* errors have already been logged */
 		return false;
 	}
-
-	/* disconnect from PostgreSQL now */
-	pgsql_finish(&monitor->pgsql);
 
 	return true;
 }
@@ -2559,9 +2521,6 @@ monitor_print_every_formation_uri_as_json(Monitor *monitor,
 		}
 		return false;
 	}
-
-	/* disconnect from PostgreSQL now */
-	pgsql_finish(&monitor->pgsql);
 
 	fformat(stream, "%s\n", context.strVal);
 	free(context.strVal);
@@ -2660,9 +2619,6 @@ monitor_print_formation_settings(Monitor *monitor, char *formation)
 		log_error("Failed to retrieve current state from the monitor");
 		return false;
 	}
-
-	/* disconnect from PostgreSQL now */
-	pgsql_finish(&monitor->pgsql);
 
 	if (!context.parsedOK)
 	{
@@ -2812,9 +2768,6 @@ monitor_print_formation_settings_as_json(Monitor *monitor, char *formation)
 		log_error("Failed to retrieve current state from the monitor");
 		return false;
 	}
-
-	/* disconnect from PostgreSQL now */
-	pgsql_finish(&monitor->pgsql);
 
 	if (!context.parsedOk)
 	{
@@ -3021,9 +2974,6 @@ monitor_set_group_system_identifier(Monitor *monitor,
 		return false;
 	}
 
-	/* disconnect from PostgreSQL now */
-	pgsql_finish(&monitor->pgsql);
-
 	if (!context.parsedOk)
 	{
 		/* *INDENT-OFF* */
@@ -3224,7 +3174,7 @@ monitor_process_notifications(Monitor *monitor,
 							  void *notificationContext,
 							  NotificationProcessingFunction processor)
 {
-	PGconn *connection = monitor->pgsql.connection;
+	PGconn *connection = monitor->notificationClient.connection;
 	PGnotify *notify;
 
 
@@ -3255,7 +3205,7 @@ monitor_process_notifications(Monitor *monitor,
 		return false;
 	}
 
-	if (!pgsql_listen(&(monitor->pgsql), channels))
+	if (!pgsql_listen(&(monitor->notificationClient), channels))
 	{
 		/* restore signal masks (un block them) now */
 		(void) unblock_signals(&sig_mask_orig);
@@ -3263,7 +3213,7 @@ monitor_process_notifications(Monitor *monitor,
 		return false;
 	}
 
-	if (monitor->pgsql.connection == NULL)
+	if (monitor->notificationClient.connection == NULL)
 	{
 		log_warn("Lost connection.");
 
@@ -3279,7 +3229,7 @@ monitor_process_notifications(Monitor *monitor,
 	 *
 	 * https://www.postgresql.org/docs/current/libpq-example.html#LIBPQ-EXAMPLE-2
 	 */
-	int sock = PQsocket(monitor->pgsql.connection);
+	int sock = PQsocket(monitor->notificationClient.connection);
 
 	if (sock < 0)
 	{
@@ -3472,7 +3422,7 @@ bool
 monitor_wait_until_primary_applied_settings(Monitor *monitor,
 											const char *formation)
 {
-	PGconn *connection = monitor->pgsql.connection;
+	PGconn *connection = monitor->notificationClient.connection;
 	ApplySettingsNotificationContext context = {
 		(char *) formation,
 		false,
@@ -3515,7 +3465,7 @@ monitor_wait_until_primary_applied_settings(Monitor *monitor,
 	}
 
 	/* disconnect from monitor */
-	pgsql_finish(&monitor->pgsql);
+	pgsql_finish(&monitor->notificationClient);
 
 	return context.applySettingsTransitionDone;
 }
@@ -3562,7 +3512,7 @@ monitor_wait_for_state_change(Monitor *monitor,
 							  int timeoutMs,
 							  bool *stateHasChanged)
 {
-	PGconn *connection = monitor->pgsql.connection;
+	PGconn *connection = monitor->notificationClient.connection;
 
 	WaitForStateChangeNotificationContext context = {
 		(char *) formation,
@@ -3723,7 +3673,7 @@ monitor_wait_until_some_node_reported_state(Monitor *monitor,
 											PgInstanceKind nodeKind,
 											NodeState targetState)
 {
-	PGconn *connection = monitor->pgsql.connection;
+	PGconn *connection = monitor->notificationClient.connection;
 
 	NodeAddressArray nodesArray = { 0 };
 	NodeAddressHeaders headers = { 0 };
@@ -3773,7 +3723,7 @@ monitor_wait_until_some_node_reported_state(Monitor *monitor,
 	}
 
 	/* disconnect from monitor */
-	pgsql_finish(&monitor->pgsql);
+	pgsql_finish(&monitor->notificationClient);
 
 	return context.failoverIsDone;
 }
@@ -3856,7 +3806,7 @@ monitor_wait_until_node_reported_state(Monitor *monitor,
 									   PgInstanceKind nodeKind,
 									   NodeState targetState)
 {
-	PGconn *connection = monitor->pgsql.connection;
+	PGconn *connection = monitor->notificationClient.connection;
 
 	NodeAddressArray nodesArray = { 0 };
 	NodeAddressHeaders headers = { 0 };
@@ -3907,7 +3857,7 @@ monitor_wait_until_node_reported_state(Monitor *monitor,
 	}
 
 	/* disconnect from monitor */
-	pgsql_finish(&monitor->pgsql);
+	pgsql_finish(&monitor->notificationClient);
 
 	return context.done;
 }
@@ -4162,6 +4112,7 @@ monitor_ensure_extension_version(Monitor *monitor,
 
 		/* avoid spurious error messages about losing our connection */
 		pgsql_finish(&(monitor->pgsql));
+		pgsql_finish(&(monitor->notificationClient));
 
 		if (!ensure_postgres_service_is_stopped(postgres))
 		{

--- a/src/bin/pg_autoctl/monitor.h
+++ b/src/bin/pg_autoctl/monitor.h
@@ -21,6 +21,7 @@
 typedef struct Monitor
 {
 	PGSQL pgsql;
+	PGSQL notificationClient;
 	MonitorConfig config;
 } Monitor;
 

--- a/src/bin/pg_autoctl/pgsql.c
+++ b/src/bin/pg_autoctl/pgsql.c
@@ -981,6 +981,8 @@ pgsql_execute_with_params(PGSQL *pgsql, const char *sql, int paramCount,
 
 	PQclear(result);
 	clear_results(pgsql);
+	PQfinish(pgsql->connection);
+	pgsql->connection = NULL;
 
 	return true;
 }

--- a/src/bin/pg_autoctl/pgsql.h
+++ b/src/bin/pg_autoctl/pgsql.h
@@ -122,6 +122,7 @@ typedef struct PGSQL
 	PGconn *connection;
 	ConnectionRetryPolicy retryPolicy;
 	PGConnStatus status;
+	bool explicitTransactionOpened;
 
 	ProcessNotificationFunction notificationProcessFunction;
 	int notificationGroupId;
@@ -259,6 +260,10 @@ int pgsql_compute_connection_retry_sleep_time(ConnectionRetryPolicy *retryPolicy
 bool pgsql_retry_policy_expired(ConnectionRetryPolicy *retryPolicy);
 
 void pgsql_finish(PGSQL *pgsql);
+bool pgsql_begin(PGSQL *pgsql);
+bool pgsql_commit(PGSQL *pgsql);
+bool pgsql_rollback(PGSQL *pgsql);
+
 void parseSingleValueResult(void *ctx, PGresult *result);
 void fetchedRows(void *ctx, PGresult *result);
 bool pgsql_execute(PGSQL *pgsql, const char *sql);

--- a/src/bin/pg_autoctl/service_keeper.c
+++ b/src/bin/pg_autoctl/service_keeper.c
@@ -809,7 +809,9 @@ keeper_node_active(Keeper *keeper, bool doInit)
 	 * Finally make establish a connection for notifications in case it had
 	 * closed before
 	 */
-	(void) pgsql_listen(&(keeper->monitor.notificationClient), &((char *) { 0 }));
+	char *channels[] = { "state", NULL };
+
+	(void) pgsql_listen(&(keeper->monitor.notificationClient), channels);
 
 	return true;
 }

--- a/src/bin/pg_autoctl/service_keeper.c
+++ b/src/bin/pg_autoctl/service_keeper.c
@@ -590,6 +590,10 @@ keeper_node_active_loop(Keeper *keeper, pid_t start_pid)
 		}
 	}
 
+	/* One last check that we do not have any connections open */
+	pgsql_finish(&(keeper->monitor.pgsql));
+	pgsql_finish(&(keeper->monitor.notificationClient));
+
 	return true;
 }
 
@@ -800,6 +804,12 @@ keeper_node_active(Keeper *keeper, bool doInit)
 			return false;
 		}
 	}
+
+	/*
+	 * Finally make establish a connection for notifications in case it had
+	 * closed before
+	 */
+	(void) pgsql_listen(&(keeper->monitor.notificationClient), &((char *) { 0 }));
 
 	return true;
 }

--- a/src/bin/pg_autoctl/service_keeper.c
+++ b/src/bin/pg_autoctl/service_keeper.c
@@ -287,7 +287,8 @@ keeper_node_active_loop(Keeper *keeper, pid_t start_pid)
 												 &groupStateHasChanged);
 
 			/* when no state change has been notified, close the connection */
-			if (!groupStateHasChanged)
+			if (!groupStateHasChanged &&
+				!keeper->monitor.pgsql.explicitTransactionOpened)
 			{
 				pgsql_finish(&(keeper->monitor.pgsql));
 			}
@@ -591,7 +592,11 @@ keeper_node_active_loop(Keeper *keeper, pid_t start_pid)
 	}
 
 	/* One last check that we do not have any connections open */
-	pgsql_finish(&(keeper->monitor.pgsql));
+	if (!keeper->monitor.pgsql.explicitTransactionOpened)
+	{
+		pgsql_finish(&(keeper->monitor.pgsql));
+	}
+
 	pgsql_finish(&(keeper->monitor.notificationClient));
 
 	return true;


### PR DESCRIPTION
Based on the work from Georgios at https://github.com/citusdata/pg_auto_failover/pull/582 ; with some of the fixes I asked for and the `pgsql_begin` (commit, rollback) api that tracks opened transactions to avoid automatic connection closing in those cases.