### PR TITLE
Fix links to our documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # pg_auto_failover
 
 [![Slack Status](http://slack.citusdata.com/badge.svg)](https://slack.citusdata.com)
-[![Documentation Status](https://readthedocs.org/projects/pg-auto-failover/badge/?version=latest)](https://pg-auto-failover.readthedocs.io/en/master/?badge=master)
+[![Documentation Status](https://readthedocs.org/projects/pg-auto-failover/badge/?version=master)](https://pg-auto-failover.readthedocs.io/en/master/?badge=master)
 
 pg_auto_failover is an extension and service for PostgreSQL that monitors
 and manages automated failover for a Postgres cluster. It is optimized for
@@ -53,7 +53,7 @@ authentication options.
 ## Documentation
 
 Please check out project
-[documentation](https://pg-auto-failover.readthedocs.io/en/latest/) for how
+[documentation](https://pg-auto-failover.readthedocs.io/en/master/) for how
 to guides and troubleshooting information.
 
 ## Installing pg_auto_failover from packages


### PR DESCRIPTION
We don't use "latest" anymore because that might be confusion (latest stable
version?), we use "master" now, the name of the git default branch.

Fixes #640.