### PR TITLE
Feature crash recovery before pg rewind

### DIFF
--- a/src/bin/pg_autoctl/cli_do_misc.c
+++ b/src/bin/pg_autoctl/cli_do_misc.c
@@ -489,6 +489,42 @@ keeper_cli_rewind_old_primary(int argc, char **argv)
 
 
 void
+keeper_cli_maybe_do_crash_recovery(int argc, char **argv)
+{
+	const bool missing_pgdata_is_ok = false;
+	const bool pg_not_running_is_ok = true;
+
+	KeeperConfig config = keeperOptions;
+	LocalPostgresServer postgres = { 0 };
+
+	keeper_config_init(&config, missing_pgdata_is_ok, pg_not_running_is_ok);
+	local_postgres_init(&postgres, &(config.pgSetup));
+
+	if (!standby_init_replication_source(&postgres,
+										 NULL, /* primaryNode is done */
+										 PG_AUTOCTL_REPLICA_USERNAME,
+										 config.replication_password,
+										 config.replication_slot_name,
+										 config.maximum_backup_rate,
+										 config.backupDirectory,
+										 NULL, /* no targetLSN */
+										 config.pgSetup.ssl,
+										 0))
+	{
+		/* can't happen at the moment */
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+
+	if (!postgres_maybe_do_crash_recovery(&postgres))
+	{
+		log_fatal("Failed to implement postgres crash recovery, "
+				  "see above for details");
+		exit(EXIT_CODE_PGSQL);
+	}
+}
+
+
+void
 keeper_cli_promote_standby(int argc, char **argv)
 {
 	const bool missing_pgdata_is_ok = false;

--- a/src/bin/pg_autoctl/cli_do_root.c
+++ b/src/bin/pg_autoctl/cli_do_root.c
@@ -129,6 +129,14 @@ CommandLine do_standby_rewind =
 				 keeper_cli_keeper_setup_getopts,
 				 keeper_cli_rewind_old_primary);
 
+CommandLine do_standby_crash_recovery =
+	make_command("crash-recovery",
+				 "Setup postgres for crash-recovery and start postgres",
+				 " [ --pgdata ... ]",
+				 KEEPER_CLI_WORKER_SETUP_OPTIONS,
+				 keeper_cli_keeper_setup_getopts,
+				 keeper_cli_maybe_do_crash_recovery);
+
 CommandLine do_standby_promote =
 	make_command("promote",
 				 "Promote a standby server to become writable",
@@ -140,6 +148,7 @@ CommandLine do_standby_promote =
 CommandLine *do_standby[] = {
 	&do_standby_init,
 	&do_standby_rewind,
+	&do_standby_crash_recovery,
 	&do_standby_promote,
 	NULL
 };

--- a/src/bin/pg_autoctl/cli_do_root.h
+++ b/src/bin/pg_autoctl/cli_do_root.h
@@ -96,6 +96,7 @@ void keeper_cli_create_replication_user(int argc, char **argv);
 void keeper_cli_add_standby_to_hba(int argc, char **argv);
 void keeper_cli_init_standby(int argc, char **argv);
 void keeper_cli_rewind_old_primary(int argc, char **argv);
+void keeper_cli_maybe_do_crash_recovery(int argc, char **argv);
 void keeper_cli_promote_standby(int argc, char **argv);
 void keeper_cli_receiwal(int argc, char **argv);
 void keeper_cli_identify_system(int argc, char **argv);

--- a/src/bin/pg_autoctl/cli_service.c
+++ b/src/bin/pg_autoctl/cli_service.c
@@ -345,7 +345,8 @@ cli_getopt_pgdata_and_mode(int argc, char **argv)
 
 				if (stop_signal != SIGTERM)
 				{
-					log_fatal("Please use either --fast or --immediate, not both");
+					log_fatal("Please use only one of either "
+							  " --sigkill, --fast or --immediate");
 					exit(EXIT_CODE_BAD_ARGS);
 				}
 				stop_signal = SIGKILL;

--- a/src/bin/pg_autoctl/parsing.c
+++ b/src/bin/pg_autoctl/parsing.c
@@ -226,6 +226,7 @@ parse_controldata(PostgresControlData *pgControlData,
 {
 	if (!parse_controldata_field_dbstate(control_data_string,
 										 &(pgControlData->state)) ||
+
 		!parse_controldata_field_uint32(control_data_string,
 										"pg_control version number",
 										&(pgControlData->pg_control_version)) ||

--- a/src/bin/pg_autoctl/pgctl.c
+++ b/src/bin/pg_autoctl/pgctl.c
@@ -1449,7 +1449,7 @@ pg_ctl_initdb(const char *pg_ctl, const char *pgdata)
  */
 bool
 pg_ctl_postgres(const char *pg_ctl, const char *pgdata, int pgport,
-				char *listen_addresses)
+				char *listen_addresses, bool listen)
 {
 	char postgres[MAXPGPATH];
 	char logfile[MAXPGPATH];
@@ -1473,10 +1473,15 @@ pg_ctl_postgres(const char *pg_ctl, const char *pgdata, int pgport,
 	args[argsIndex++] = "-p";
 	args[argsIndex++] = (char *) intToString(pgport).strValue;
 
-	if (!IS_EMPTY_STRING_BUFFER(listen_addresses))
+	if (listen)
 	{
 		args[argsIndex++] = "-h";
 		args[argsIndex++] = (char *) listen_addresses;
+	}
+	else
+	{
+		args[argsIndex++] = "-h";
+		args[argsIndex++] = "";
 	}
 
 	if (env_exists("PG_REGRESS_SOCK_DIR"))

--- a/src/bin/pg_autoctl/pgctl.c
+++ b/src/bin/pg_autoctl/pgctl.c
@@ -1475,6 +1475,12 @@ pg_ctl_postgres(const char *pg_ctl, const char *pgdata, int pgport,
 
 	if (listen)
 	{
+		if (IS_EMPTY_STRING_BUFFER(listen_addresses))
+		{
+			log_error("BUG: pg_ctl_postgres is given an empty listen_addresses "
+					  "with argument listen set to true");
+			return false;
+		}
 		args[argsIndex++] = "-h";
 		args[argsIndex++] = (char *) listen_addresses;
 	}

--- a/src/bin/pg_autoctl/pgctl.h
+++ b/src/bin/pg_autoctl/pgctl.h
@@ -52,7 +52,7 @@ bool pg_rewind(const char *pgdata,
 
 bool pg_ctl_initdb(const char *pg_ctl, const char *pgdata);
 bool pg_ctl_postgres(const char *pg_ctl, const char *pgdata, int pgport,
-					 char *listen_addresses);
+					 char *listen_addresses, bool listen);
 bool pg_log_startup(const char *pgdata, int logLevel);
 bool pg_log_recovery_setup(const char *pgdata, int logLevel);
 bool pg_ctl_stop(const char *pg_ctl, const char *pgdata);

--- a/src/bin/pg_autoctl/pgsetup.c
+++ b/src/bin/pg_autoctl/pgsetup.c
@@ -700,6 +700,8 @@ fprintf_pg_setup(FILE *stream, PostgresSetup *pgSetup)
 	fformat(stream, "pid:                   %d\n", pgSetup->pidFile.pid);
 	fformat(stream, "is in recovery:        %s\n",
 			pgSetup->is_in_recovery ? "yes" : "no");
+	fformat(stream, "Control cluster state: %s\n",
+			dbstateToString(pgSetup->control.state));
 	fformat(stream, "Control Version:       %u\n",
 			pgSetup->control.pg_control_version);
 	fformat(stream, "Catalog Version:       %u\n",
@@ -1986,4 +1988,49 @@ pgsetup_hba_level_to_string(HBAEditLevel hbaLevel)
 
 	log_error("BUG: hbaLevel %d is unknown", hbaLevel);
 	return "unknown";
+}
+
+
+/*
+ * dbstateToString returns a string from a pgControlFile state enum.
+ */
+const char *
+dbstateToString(DBState state)
+{
+	switch (state)
+	{
+		case DB_STARTUP:
+		{
+			return _("starting up");
+		}
+
+		case DB_SHUTDOWNED:
+		{
+			return _("shut down");
+		}
+
+		case DB_SHUTDOWNED_IN_RECOVERY:
+		{
+			return _("shut down in recovery");
+		}
+
+		case DB_SHUTDOWNING:
+		{
+			return _("shutting down");
+		}
+
+		case DB_IN_CRASH_RECOVERY:
+		{
+			return _("in crash recovery");
+		}
+
+		case DB_IN_ARCHIVE_RECOVERY:
+		{
+			return _("in archive recovery");
+		}
+
+		case DB_IN_PRODUCTION:
+			return _("in production");
+	}
+	return _("unrecognized status code");
 }

--- a/src/bin/pg_autoctl/pgsetup.c
+++ b/src/bin/pg_autoctl/pgsetup.c
@@ -2001,36 +2001,36 @@ dbstateToString(DBState state)
 	{
 		case DB_STARTUP:
 		{
-			return _("starting up");
+			return "starting up";
 		}
 
 		case DB_SHUTDOWNED:
 		{
-			return _("shut down");
+			return "shut down";
 		}
 
 		case DB_SHUTDOWNED_IN_RECOVERY:
 		{
-			return _("shut down in recovery");
+			return "shut down in recovery";
 		}
 
 		case DB_SHUTDOWNING:
 		{
-			return _("shutting down");
+			return "shutting down";
 		}
 
 		case DB_IN_CRASH_RECOVERY:
 		{
-			return _("in crash recovery");
+			return "in crash recovery";
 		}
 
 		case DB_IN_ARCHIVE_RECOVERY:
 		{
-			return _("in archive recovery");
+			return "in archive recovery";
 		}
 
 		case DB_IN_PRODUCTION:
-			return _("in production");
+			return "in production";
 	}
-	return _("unrecognized status code");
+	return "unrecognized status code";
 }

--- a/src/bin/pg_autoctl/pgsetup.h
+++ b/src/bin/pg_autoctl/pgsetup.h
@@ -28,6 +28,20 @@
 #define PG_LSN_MAXLENGTH 18
 
 /*
+ * System status indicator. From postgres:src/include/catalog/pg_control.h
+ */
+typedef enum DBState
+{
+	DB_STARTUP = 0,
+	DB_SHUTDOWNED,
+	DB_SHUTDOWNED_IN_RECOVERY,
+	DB_SHUTDOWNING,
+	DB_IN_CRASH_RECOVERY,
+	DB_IN_ARCHIVE_RECOVERY,
+	DB_IN_PRODUCTION
+} DBState;
+
+/*
  * To be able to check if a minor upgrade should be scheduled, and to check for
  * system WAL compatiblity, we use some parts of the pg_controldata output.
  *
@@ -36,9 +50,10 @@
  */
 typedef struct pg_control_data
 {
+	uint64_t system_identifier;
 	uint32_t pg_control_version;        /* PG_CONTROL_VERSION */
 	uint32_t catalog_version_no;        /* see catversion.h */
-	uint64_t system_identifier;
+	DBState state;                      /* see enum above */
 	char latestCheckpointLSN[PG_LSN_MAXLENGTH];
 	uint32_t timeline_id;
 } PostgresControlData;
@@ -249,5 +264,6 @@ bool pg_setup_standby_slot_supported(PostgresSetup *pgSetup, int logLevel);
 
 HBAEditLevel pgsetup_parse_hba_level(const char *level);
 char * pgsetup_hba_level_to_string(HBAEditLevel hbaLevel);
+const char * dbstateToString(DBState state);
 
 #endif /* PGSETUP_H */

--- a/src/bin/pg_autoctl/pgsql.h
+++ b/src/bin/pg_autoctl/pgsql.h
@@ -230,6 +230,8 @@ typedef struct ReplicationSource
 	char backupDir[MAXCONNINFO];
 	char applicationName[MAXCONNINFO];
 	char targetLSN[PG_LSN_MAXLENGTH];
+	char targetAction[NAMEDATALEN];
+	char targetTimeline[NAMEDATALEN];
 	SSLOptions sslOptions;
 	IdentifySystem system;
 } ReplicationSource;

--- a/src/bin/pg_autoctl/primary_standby.c
+++ b/src/bin/pg_autoctl/primary_standby.c
@@ -6,6 +6,7 @@
  * Licensed under the PostgreSQL License.
  *
  */
+#include <sys/wait.h>
 #include <time.h>
 #include <unistd.h>
 

--- a/src/bin/pg_autoctl/primary_standby.c
+++ b/src/bin/pg_autoctl/primary_standby.c
@@ -1044,7 +1044,7 @@ primary_rewind_to_standby(LocalPostgresServer *postgres)
 
 
 /*
- * postgres_maybedo_crash_recovery implements a round of Postgres crash
+ * postgres_maybe_do_crash_recovery implements a round of Postgres crash
  * recovery for the local instance of Postgres when pg_rewind would otherwise
  * fail because of its internal checks.
  */
@@ -1154,9 +1154,9 @@ postgres_maybe_do_crash_recovery(LocalPostgresServer *postgres)
 				(void) pg_ctl_postgres(pgSetup->pg_ctl,
 									   pgSetup->pgdata,
 									   pgSetup->pgport,
+									   pgSetup->listen_addresses,
 
 				                       /* do not open the service just yet */
-									   pgSetup->listen_addresses,
 									   false);
 
 				/* unexpected */

--- a/src/bin/pg_autoctl/primary_standby.c
+++ b/src/bin/pg_autoctl/primary_standby.c
@@ -998,7 +998,14 @@ primary_rewind_to_standby(LocalPostgresServer *postgres)
 		return false;
 	}
 
-	/* first, make sure we can connect with "replication" */
+	if (!postgres_maybe_do_crash_recovery(postgres))
+	{
+		log_error("Failed to implement Postgres crash recovery "
+				  "before calling pg_rewind");
+		return false;
+	}
+
+	/* before pg_rewind, make sure we can connect with "replication" */
 	if (!pgctl_identify_system(replicationSource))
 	{
 		log_error("Failed to connect to the primary node %d \"%s\" (%s:%d) "
@@ -1008,7 +1015,6 @@ primary_rewind_to_standby(LocalPostgresServer *postgres)
 				  primaryNode->name,
 				  primaryNode->host,
 				  primaryNode->port);
-		return false;
 	}
 
 	if (!pg_rewind(pgSetup->pgdata, pgSetup->pg_ctl, replicationSource))
@@ -1030,6 +1036,168 @@ primary_rewind_to_standby(LocalPostgresServer *postgres)
 	{
 		log_error("Failed to start postgres after rewind");
 		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * postgres_maybedo_crash_recovery implements a round of Postgres crash
+ * recovery for the local instance of Postgres when pg_rewind would otherwise
+ * fail because of its internal checks.
+ */
+bool
+postgres_maybe_do_crash_recovery(LocalPostgresServer *postgres)
+{
+	PostgresSetup *pgSetup = &(postgres->postgresSetup);
+	ReplicationSource *replicationSource = &(postgres->replicationSource);
+
+	/* we don't log the output for pg_ctl_status here */
+	int status = pg_ctl_status(pgSetup->pg_ctl, pgSetup->pgdata, false);
+
+	if (status != PG_CTL_STATUS_NOT_RUNNING)
+	{
+		log_error("Failed to prepare for crash recovery: "
+				  "Postgres is not stopped");
+		return false;
+	}
+
+	/*
+	 * pg_rewind fails when the target cluster (meaning the local Postgres
+	 * instance) is either running or has not been shutdown correctly. Time to
+	 * use pg_controldata and see if the DBState there is to pg_rewind liking.
+	 */
+	const bool missingPgdataIsOk = false;
+
+	if (!pg_controldata(pgSetup, missingPgdataIsOk))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/*
+	 * We know that Postgres is not running thanks to pg_ctl_status, and we
+	 * just grabbed the output from pg_controldata. We can now implement the
+	 * same pre-condition checks as in Postgres pg_rewind.c.
+	 */
+	if (pgSetup->control.state != DB_SHUTDOWNED &&
+		pgSetup->control.state != DB_SHUTDOWNED_IN_RECOVERY)
+	{
+		/*
+		 * Before calling pg_rewind, attempt crash recovery on the Postgres
+		 * instance and then shutdown.
+		 */
+		ReplicationSource crashRecoveryReplicationSource = { 0 };
+
+		log_info("Postgres needs to enter crash recovery before pg_rewind.");
+
+		crashRecoveryReplicationSource = *replicationSource;
+
+		/* we target the earlier consistent state possible, or 'immediate' */
+		strlcpy(crashRecoveryReplicationSource.targetLSN,
+				"immediate",
+				sizeof(crashRecoveryReplicationSource.targetLSN));
+
+		/* the default target action is "pause", we need "shutdown" here */
+		strlcpy(crashRecoveryReplicationSource.targetAction,
+				"shutdown",
+				sizeof(crashRecoveryReplicationSource.targetAction));
+
+		strlcpy(crashRecoveryReplicationSource.targetTimeline,
+				"current",
+				sizeof(crashRecoveryReplicationSource.targetTimeline));
+
+		if (!pg_setup_standby_mode(pgSetup->control.pg_control_version,
+								   pgSetup->pgdata,
+								   pgSetup->pg_ctl,
+								   &crashRecoveryReplicationSource))
+		{
+			log_error("Failed to setup for crash recovery "
+					  "in preparation for pg_rewind");
+			return false;
+		}
+
+		/*
+		 * Now that the configuration file is ready and asks for Postgres
+		 * shutdown when reaching crash recovery time, we start postgres as a
+		 * sub-process here and wait for it to terminate.
+		 */
+		fflush(stdout);
+		fflush(stderr);
+
+		/* time to create the node_active sub-process */
+		pid_t fpid = fork();
+
+		switch (fpid)
+		{
+			case -1:
+			{
+				log_error("Failed to fork the postgres supervisor process");
+				return false;
+			}
+
+			case 0:
+			{
+				/* execv() the postgres binary directly, as a sub-process */
+				(void) pg_ctl_postgres(pgSetup->pg_ctl,
+									   pgSetup->pgdata,
+									   pgSetup->pgport,
+									   pgSetup->listen_addresses);
+
+				/* unexpected */
+				log_fatal("BUG: returned from service_keeper_runprogram()");
+				exit(EXIT_CODE_INTERNAL_ERROR);
+			}
+
+			default:
+			{
+				/* wait until postgres crash recovery is done */
+				int wpid, status;
+
+				do {
+					/* check every 250ms if postgres is done now */
+					pg_usleep(250 * 1000);
+
+					wpid = waitpid(fpid, &status, WNOHANG);
+
+					if (wpid == -1)
+					{
+						log_warn("Failed to wait until Postgres is done: %m");
+					}
+				} while (wpid != fpid);
+
+				if (WIFEXITED(status) && WEXITSTATUS(status) == EXIT_CODE_QUIT)
+				{
+					log_info("Postgres has finished crash recovery.");
+				}
+				else if (WIFEXITED(status))
+				{
+					int returnCode = WEXITSTATUS(status);
+
+					log_warn("Postgres has finished crash recovery with "
+							 "exit code %d",
+							 returnCode);
+
+					(void) pg_log_startup(pgSetup->pgdata, LOG_INFO);
+				}
+				else if (WIFSTOPPED(status))
+				{
+					log_error("Postgres process has been signaled and stopped");
+				}
+
+				if (!pg_controldata(pgSetup, missingPgdataIsOk))
+				{
+					/* errors have already been logged */
+					return false;
+				}
+
+				log_info("Postgres control state: %s",
+						 dbstateToString(pgSetup->control.state));
+				log_info("Latest checkpoint LSN: %s",
+						 pgSetup->control.latestCheckpointLSN);
+			}
+		}
 	}
 
 	return true;

--- a/src/bin/pg_autoctl/primary_standby.c
+++ b/src/bin/pg_autoctl/primary_standby.c
@@ -1143,7 +1143,10 @@ postgres_maybe_do_crash_recovery(LocalPostgresServer *postgres)
 				(void) pg_ctl_postgres(pgSetup->pg_ctl,
 									   pgSetup->pgdata,
 									   pgSetup->pgport,
-									   pgSetup->listen_addresses);
+
+				                       /* do not open the service just yet */
+									   pgSetup->listen_addresses,
+									   false);
 
 				/* unexpected */
 				log_fatal("BUG: returned from service_keeper_runprogram()");

--- a/src/bin/pg_autoctl/primary_standby.h
+++ b/src/bin/pg_autoctl/primary_standby.h
@@ -99,6 +99,7 @@ bool standby_init_database(LocalPostgresServer *postgres,
 						   const char *hostname,
 						   bool skipBaseBackup);
 bool primary_rewind_to_standby(LocalPostgresServer *postgres);
+bool postgres_maybe_do_crash_recovery(LocalPostgresServer *postgres);
 bool standby_promote(LocalPostgresServer *postgres);
 bool check_postgresql_settings(LocalPostgresServer *postgres,
 							   bool *settings_are_ok);

--- a/src/bin/pg_autoctl/service_postgres.c
+++ b/src/bin/pg_autoctl/service_postgres.c
@@ -63,11 +63,14 @@ service_postgres_start(void *context, pid_t *pid)
 
 			log_trace("service_postgres_start: EXEC postgres");
 
+			bool listen = true;
+
 			/* execv() the postgres binary directly, as a sub-process */
 			(void) pg_ctl_postgres(pgSetup->pg_ctl,
 								   pgSetup->pgdata,
 								   pgSetup->pgport,
-								   pgSetup->listen_addresses);
+								   pgSetup->listen_addresses,
+								   listen);
 
 			/* unexpected */
 			log_fatal("BUG: returned from service_keeper_runprogram()");


### PR DESCRIPTION
Implement crash recovery (target immediate, timeline current).

When pg_rewind would fail because the target PGDATA was not shutdown
properly, have Postgres do a round of crash recovery to clean-up the data
directory and only then resort to pg_rewind.

Now pg_rewind can fail for other reasons:

    INFO  pg_rewind: connected to server
    INFO  pg_rewind: servers diverged at WAL location 0/2C000060 on timeline 21
    INFO  pg_rewind: fatal: could not find previous WAL record at 0/2C000060: invalid record length at 0/2C000060: wanted 24, got 0

See #653 