### PR TITLE
Review find_extension_control_file() error handling.

### DIFF
--- a/src/bin/pg_autoctl/keeper_pg_init.c
+++ b/src/bin/pg_autoctl/keeper_pg_init.c
@@ -848,26 +848,28 @@ create_database_and_extension(Keeper *keeper)
 
 	/*
 	 * Ensure pg_stat_statements is available in the server extension dir used
-	 * to create the Postgres instance.
+	 * to create the Postgres instance. We only search for the control file to
+	 * offer better diagnostics in the logs in case the following CREATE
+	 * EXTENSION fails.
 	 */
 	if (!find_extension_control_file(config->pgSetup.pg_ctl,
 									 "pg_stat_statements"))
 	{
-		log_error("Failed to find extension control file for "
-				  "\"pg_stat_statements\"");
-		exit(EXIT_CODE_EXTENSION_MISSING);
+		log_warn("Failed to find extension control file for "
+				 "\"pg_stat_statements\"");
 	}
 
 	/*
 	 * Ensure citus extension is available in the server extension dir used to
-	 * create the Postgres instance.
+	 * create the Postgres instance. We only search for the control file to
+	 * offer better diagnostics in the logs in case the following CREATE
+	 * EXTENSION fails.
 	 */
 	if (IS_CITUS_INSTANCE_KIND(postgres->pgKind))
 	{
 		if (!find_extension_control_file(config->pgSetup.pg_ctl, "citus"))
 		{
-			log_error("Failed to find extension control file for \"citus\"");
-			exit(EXIT_CODE_EXTENSION_MISSING);
+			log_warn("Failed to find extension control file for \"citus\"");
 		}
 	}
 

--- a/src/bin/pg_autoctl/monitor.c
+++ b/src/bin/pg_autoctl/monitor.c
@@ -3986,19 +3986,19 @@ monitor_extension_update(Monitor *monitor, const char *targetVersion)
 	{
 		/*
 		 * Ensure "btree_gist" is available in the server extension dir used to
-		 * create the Postgres instance.
+		 * create the Postgres instance. We only search for the control file to
+		 * offer better diagnostics in the logs in case the following CREATE
+		 * EXTENSION fails.
 		 */
 		char *btreeGistExtName = "btree_gist";
 
 		if (!find_extension_control_file(monitor->config.pgSetup.pg_ctl,
 										 btreeGistExtName))
 		{
-			log_error("Failed to find extension control file for \"%s\"",
-					  btreeGistExtName);
+			log_warn("Failed to find extension control file for \"%s\"",
+					 btreeGistExtName);
 			log_info("You might have to install a PostgreSQL contrib package");
-			return false;
 		}
-
 
 		if (!pgsql_create_extension(pgsql, btreeGistExtName))
 		{

--- a/src/bin/pg_autoctl/monitor_pg_init.c
+++ b/src/bin/pg_autoctl/monitor_pg_init.c
@@ -206,14 +206,15 @@ monitor_install(const char *hostname,
 
 	/*
 	 * Ensure our extension "pgautofailvover" is available in the server
-	 * extension dir used to create the Postgres instance.
+	 * extension dir used to create the Postgres instance. We only search for
+	 * the control file to offer better diagnostics in the logs in case the
+	 * following CREATE EXTENSION fails.
 	 */
 	if (!find_extension_control_file(pgSetup.pg_ctl,
 									 PG_AUTOCTL_MONITOR_EXTENSION_NAME))
 	{
-		log_error("Failed to find extension control file for \"%s\"",
-				  PG_AUTOCTL_MONITOR_EXTENSION_NAME);
-		return false;
+		log_warn("Failed to find extension control file for \"%s\"",
+				 PG_AUTOCTL_MONITOR_EXTENSION_NAME);
 	}
 
 	if (!pgsql_create_extension(&postgres.sqlClient,

--- a/src/bin/pg_autoctl/pgctl.c
+++ b/src/bin/pg_autoctl/pgctl.c
@@ -664,7 +664,7 @@ find_extension_control_file(const char *pg_ctl, const char *extName)
 
 	if (!find_pg_config_from_pg_ctl(pg_ctl, pg_config_path, MAXPGPATH))
 	{
-		/* errors have already been logged */
+		log_warn("Failed to find pg_config from pg_ctl at \"%s\"", pg_ctl);
 		return false;
 	}
 
@@ -691,7 +691,8 @@ find_extension_control_file(const char *pg_ctl, const char *extName)
 		join_path_components(extension_path, extension_path, extension_control_file_name);
 		if (!file_exists(extension_path))
 		{
-			log_error("Failed to find extension control file \"%s\"", extension_path);
+			log_error("Failed to find extension control file \"%s\"",
+					  extension_path);
 			free_program(&prog);
 			return false;
 		}


### PR DESCRIPTION
Make this a warning only: this extra operation is meant to help diagnose the
situation when CREATE EXTENSION fails. We might fail to locate the control
file of the extension when Postgres would succeed, so we should still
proceed.

Fixes #585.
Fixes #645.