### PR TITLE
Check that a "replication" connection is possible before pg_rewind.

### DIFF
--- a/src/bin/pg_autoctl/fsm_transition.c
+++ b/src/bin/pg_autoctl/fsm_transition.c
@@ -932,6 +932,7 @@ fsm_rewind_or_init(Keeper *keeper)
 {
 	KeeperConfig *config = &(keeper->config);
 	LocalPostgresServer *postgres = &(keeper->postgres);
+	ReplicationSource *upstream = &(postgres->replicationSource);
 
 	NodeAddress *primaryNode = NULL;
 
@@ -955,6 +956,19 @@ fsm_rewind_or_init(Keeper *keeper)
 										 keeper->state.current_node_id))
 	{
 		/* can't happen at the moment */
+		return false;
+	}
+
+	/* first, make sure we can connect with "replication" */
+	if (!pgctl_identify_system(upstream))
+	{
+		log_error("Failed to connect to the primary node %d \"%s\" (%s:%d) "
+				  "with a replication connection string. "
+				  "See above for details",
+				  primaryNode->nodeId,
+				  primaryNode->name,
+				  primaryNode->host,
+				  primaryNode->port);
 		return false;
 	}
 

--- a/src/bin/pg_autoctl/primary_standby.c
+++ b/src/bin/pg_autoctl/primary_standby.c
@@ -990,6 +990,19 @@ primary_rewind_to_standby(LocalPostgresServer *postgres)
 		return false;
 	}
 
+	/* first, make sure we can connect with "replication" */
+	if (!pgctl_identify_system(replicationSource))
+	{
+		log_error("Failed to connect to the primary node %d \"%s\" (%s:%d) "
+				  "with a replication connection string. "
+				  "See above for details",
+				  primaryNode->nodeId,
+				  primaryNode->name,
+				  primaryNode->host,
+				  primaryNode->port);
+		return false;
+	}
+
 	if (!pg_rewind(pgSetup->pgdata, pgSetup->pg_ctl, replicationSource))
 	{
 		log_error("Failed to rewind old data directory");


### PR DESCRIPTION
If the upstream server isn't ready for a replication connection being made,
then both pg_rewind and then pg_basebackup will fail. The current code would
attribute the error to pg_rewind itself though, and continue with a full
base backup, where it might be possible to connect and rewind later.