### PR TITLE
Use PGDATA owner for the systemd service file.

### DIFF
--- a/src/bin/pg_autoctl/cli_systemd.c
+++ b/src/bin/pg_autoctl/cli_systemd.c
@@ -137,6 +137,12 @@ cli_systemd_getopt(int argc, char **argv)
 
 	cli_common_get_set_pgdata_or_exit(&(options.pgSetup));
 
+	if (!pg_setup_set_absolute_pgdata(&(options.pgSetup)))
+	{
+		/* errors have already been logged */
+		exit(EXIT_CODE_BAD_CONFIG);
+	}
+
 	if (!keeper_config_set_pathnames_from_pgdata(&options.pathnames,
 												 options.pgSetup.pgdata))
 	{
@@ -164,12 +170,12 @@ cli_systemd_cat_service_file(int argc, char **argv)
 	(void) systemd_config_init(&config, pgSetup.pgdata);
 
 	log_info("HINT: to complete a systemd integration, "
-			 "run the following commands:");
-	log_info("pg_autoctl -q show systemd --pgdata \"%s\" | sudo tee %s",
+			 "run the following commands (as root):");
+	log_info("pg_autoctl -q show systemd --pgdata \"%s\" | tee %s",
 			 config.pgSetup.pgdata, config.pathnames.systemd);
-	log_info("sudo systemctl daemon-reload");
-	log_info("sudo systemctl enable pgautofailover");
-	log_info("sudo systemctl start pgautofailover");
+	log_info("systemctl daemon-reload");
+	log_info("systemctl enable pgautofailover");
+	log_info("systemctl start pgautofailover");
 
 	if (!systemd_config_write(stdout, &config))
 	{

--- a/src/bin/pg_autoctl/systemd_config.c
+++ b/src/bin/pg_autoctl/systemd_config.c
@@ -10,6 +10,7 @@
 #include <pwd.h>
 #include <stdbool.h>
 #include <sys/types.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 #include "postgres_fe.h"
@@ -83,7 +84,6 @@
 void
 systemd_config_init(SystemdServiceConfig *config, const char *pgdata)
 {
-	char *user = pg_setup_get_username(&(config->pgSetup));
 	IniOption systemdOptions[] = SET_INI_OPTIONS_ARRAY(config);
 
 	/* time to setup config->pathnames.systemd */
@@ -95,8 +95,24 @@ systemd_config_init(SystemdServiceConfig *config, const char *pgdata)
 	 * new directory, at pg_basebackup time. It turns out that systemd does not
 	 * like that, at all. Let's assign WorkingDirectory to a safe place, like
 	 * the HOME of the USER running the service.
+	 *
+	 * Also we expect to be running the service with the user that owns the
+	 * PGDATA directory, rather than the current user. After all, the command
+	 *
+	 *   $ pg_autoctl show systemd -q | sudo tee /etc/systemd/system/...
+	 *
+	 * Might be ran as root.
 	 */
-	struct passwd *pw = getpwnam(user);
+	struct stat pgdataStat;
+
+	if (stat(config->pgSetup.pgdata, &pgdataStat) != 0)
+	{
+		log_error("Failed to grab file stat(1) for \"%s\": %m",
+				  config->pgSetup.pgdata);
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+
+	struct passwd *pw = getpwuid(pgdataStat.st_uid);
 	if (pw)
 	{
 		log_debug("username found in passwd: %s's HOME is \"%s\"",
@@ -108,8 +124,8 @@ systemd_config_init(SystemdServiceConfig *config, const char *pgdata)
 	sformat(config->EnvironmentPGDATA, BUFSIZE,
 			"'PGDATA=%s'", config->pgSetup.pgdata);
 
-	/* adjust the user to the current system user */
-	strlcpy(config->User, user, NAMEDATALEN);
+	/* adjust the user to the owner of PGDATA */
+	strlcpy(config->User, pw->pw_name, NAMEDATALEN);
 
 	/* adjust the program to the current full path of argv[0] */
 	sformat(config->ExecStart, BUFSIZE, "%s run", pg_autoctl_program);


### PR DESCRIPTION
The current user might be root or another interactive system user so that
it's possible to use sudo to write the systemd unit files. Typically, the
"postgres" user is not granted sudo privileges, and that's a good thing.

With this changes, if pg_autoctl show systemd is used from the root account
with a --pgdata created by the "postgres" user, we expect to obtain the
proper systemd unit file.