### PR TITLE
Fix parsing pg version string for replication slots support on standby.

### DIFF
--- a/src/bin/pg_autoctl/cli_config.c
+++ b/src/bin/pg_autoctl/cli_config.c
@@ -334,11 +334,13 @@ cli_config_check_connections(PostgresSetup *pgSetup,
 
 	if (pg_setup_standby_slot_supported(pgSetup, LOG_WARN))
 	{
-		int major = pgSetup->control.pg_control_version / 100;
-		int minor = pgSetup->control.pg_control_version % 100;
-
-		log_info("Postgres version %d.%d allows using replication slots "
-				 "on the standby nodes", major, minor);
+		log_info("Postgres version \"%s\" allows using replication slots "
+				 "on the standby nodes", pgSetup->pg_version);
+	}
+	else
+	{
+		log_warn("Postgres version \"%s\" DOES NOT allow using replication "
+				 "slots on the standby nodes", pgSetup->pg_version);
 	}
 
 	/*

--- a/src/bin/pg_autoctl/parsing.c
+++ b/src/bin/pg_autoctl/parsing.c
@@ -159,6 +159,12 @@ parse_pg_version_string(const char *pg_version_string, int *pg_version)
 	int majorIdx = 0;
 	int minorIdx = 0;
 
+	if (pg_version_string == NULL)
+	{
+		log_debug("BUG: parse_pg_version_string got NULL");
+		return false;
+	}
+
 	for (int i = 0; pg_version_string[i] != '\0'; i++)
 	{
 		if (pg_version_string[i] == '.')

--- a/src/bin/pg_autoctl/parsing.c
+++ b/src/bin/pg_autoctl/parsing.c
@@ -116,10 +116,89 @@ regexp_first_match(const char *string, const char *regex)
  * Parse the version number output from pg_ctl --version:
  *    pg_ctl (PostgreSQL) 10.3
  */
-char *
-parse_version_number(const char *version_string)
+bool
+parse_version_number(const char *version_string,
+					 char *pg_version_string,
+					 int *pg_version)
 {
-	return regexp_first_match(version_string, "([[:digit:].]+)");
+	char *match = regexp_first_match(version_string, "([[:digit:].]+)");
+
+	if (match == NULL)
+	{
+		log_error("Failed to parse Postgres version number \"%s\"",
+				  version_string);
+		return false;
+	}
+
+	/* first, copy the version number in our expected result string buffer */
+	strlcpy(pg_version_string, match, sizeof(pg_version_string));
+
+	if (!parse_pg_version_string(pg_version_string, pg_version))
+	{
+		/* errors have already been logged */
+		free(match);
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * parse_pg_version_string parses a Postgres version string such as "12.6" into
+ * a single number in the same format as the pg_control_version, such as 1206.
+ */
+bool
+parse_pg_version_string(const char *pg_version_string, int *pg_version)
+{
+	/* now, parse the numbers into an integer, ala pg_control_version */
+	bool dotFound = false;
+	char major[INTSTRING_MAX_DIGITS] = { 0 };
+	char minor[INTSTRING_MAX_DIGITS] = { 0 };
+
+	int majorIdx = 0;
+	int minorIdx = 0;
+
+	for (int i = 0; pg_version_string[i] != '\0'; i++)
+	{
+		if (pg_version_string[i] == '.')
+		{
+			if (dotFound)
+			{
+				log_error("Failed to parse Postgres version number \"%s\"",
+						  pg_version_string);
+				return false;
+			}
+
+			dotFound = true;
+			continue;
+		}
+
+		if (dotFound)
+		{
+			minor[minorIdx++] = pg_version_string[i];
+		}
+		else
+		{
+			major[majorIdx++] = pg_version_string[i];
+		}
+	}
+
+	int maj = 0;
+	int min = 0;
+
+	if (!stringToInt(major, &maj) ||
+		!stringToInt(minor, &min))
+	{
+		log_error("Failed to parse Postgres version number \"%s\"",
+				  pg_version_string);
+		return false;
+	}
+
+	/* transform "12.6" into 1206, that is 12 * 100 + 6 */
+	*pg_version = (maj * 100) + min;
+
+	return true;
 }
 
 

--- a/src/bin/pg_autoctl/parsing.h
+++ b/src/bin/pg_autoctl/parsing.h
@@ -17,7 +17,12 @@
 #include "pgctl.h"
 
 char * regexp_first_match(const char *string, const char *re);
-char * parse_version_number(const char *version_string);
+
+bool parse_version_number(const char *version_string,
+						  char *pg_version_string,
+						  int *pg_version);
+
+bool parse_pg_version_string(const char *pg_version_string, int *pg_version);
 
 bool parse_controldata(PostgresControlData *pgControlData,
 					   const char *control_data_string);

--- a/src/bin/pg_autoctl/pgctl.c
+++ b/src/bin/pg_autoctl/pgctl.c
@@ -88,6 +88,8 @@ bool
 pg_ctl_version(PostgresSetup *pgSetup)
 {
 	Program prog = run_program(pgSetup->pg_ctl, "--version", NULL);
+	char pg_version_string[PG_VERSION_STRING_MAX] = { 0 };
+	int pg_version = 0;
 
 	if (prog.returnCode != 0)
 	{
@@ -98,16 +100,15 @@ pg_ctl_version(PostgresSetup *pgSetup)
 		return false;
 	}
 
-	char *version = parse_version_number(prog.stdOut);
-	free_program(&prog);
-
-	if (version == NULL)
+	if (!parse_version_number(prog.stdOut, pg_version_string, &pg_version))
 	{
+		/* errors have already been logged */
+		free_program(&prog);
 		return false;
 	}
+	free_program(&prog);
 
-	strlcpy(pgSetup->pg_version, version, PG_VERSION_STRING_MAX);
-	free(version);
+	strlcpy(pgSetup->pg_version, pg_version_string, PG_VERSION_STRING_MAX);
 
 	return true;
 }


### PR DESCRIPTION
The previous coding was wrong on several grounds:

First, pg_control_version only changes when there is a catalog
incompatibility in a given Postgres major version. For instance Postgres
12.6 still uses pg_control_verison 1201.

Second, the pg_setup_standby_slot_supported() function logic was missing
some cases and would return false even though replication slots are
supported on the standby nodes.

See #594 