### PR TITLE
Implement a new configuration option listen_notifications_timeout.

### DIFF
--- a/docs/ref/pg_autoctl_perform_failover.rst
+++ b/docs/ref/pg_autoctl_perform_failover.rst
@@ -16,6 +16,7 @@ pg_auto_failover monitor::
   --pgdata      path to data directory
   --formation   formation to target, defaults to 'default'
   --group       group to target, defaults to 0
+  --wait        how many seconds to wait, default to 60
 
 Description
 -----------
@@ -51,6 +52,13 @@ Options
 
   Postgres group to target for the operation. Defaults to ``0``, only Citus
   formations may have more than one group.
+
+--wait
+
+  How many seconds to wait for notifications about the promotion. The
+  command stops when the promotion is finished (a node is primary), or when
+  the timeout has elapsed, whichever comes first. The value 0 (zero)
+  disables the timeout and allows the command to wait forever.
 
 Examples
 --------

--- a/docs/ref/pg_autoctl_perform_promotion.rst
+++ b/docs/ref/pg_autoctl_perform_promotion.rst
@@ -16,6 +16,7 @@ pg_auto_promotion monitor and targets given node::
   --pgdata      path to data directory
   --formation   formation to target, defaults to 'default'
   --name        node name to target, defaults to current node
+  --wait        how many seconds to wait, default to 60
 
 Description
 -----------
@@ -50,6 +51,13 @@ Options
 --name
 
   Name of the node that should be elected as the new primary node.
+
+--wait
+
+  How many seconds to wait for notifications about the promotion. The
+  command stops when the promotion is finished (a node is primary), or when
+  the timeout has elapsed, whichever comes first. The value 0 (zero)
+  disables the timeout and allows the command to wait forever.
 
 Examples
 --------

--- a/src/bin/pg_autoctl/cli_perform.c
+++ b/src/bin/pg_autoctl/cli_perform.c
@@ -101,6 +101,8 @@ cli_perform_failover_getopts(int argc, char **argv)
 	options.prepare_promotion_walreceiver = -1;
 	options.postgresql_restart_failure_timeout = -1;
 	options.postgresql_restart_failure_max_retries = -1;
+	options.listen_notifications_timeout =
+		PG_AUTOCTL_LISTEN_NOTIFICATIONS_TIMEOUT;
 
 	/* do not set a default formation, it should be found in the config file */
 
@@ -336,6 +338,8 @@ cli_perform_promotion_getopts(int argc, char **argv)
 	options.prepare_promotion_walreceiver = -1;
 	options.postgresql_restart_failure_timeout = -1;
 	options.postgresql_restart_failure_max_retries = -1;
+	options.listen_notifications_timeout =
+		PG_AUTOCTL_LISTEN_NOTIFICATIONS_TIMEOUT;
 
 	optind = 0;
 

--- a/src/bin/pg_autoctl/cli_perform.c
+++ b/src/bin/pg_autoctl/cli_perform.c
@@ -21,15 +21,18 @@
 
 static int cli_perform_failover_getopts(int argc, char **argv);
 static void cli_perform_failover(int argc, char **argv);
+
+static int cli_perform_promotion_getopts(int argc, char **argv);
 static void cli_perform_promotion(int argc, char **argv);
 
 CommandLine perform_failover_command =
 	make_command("failover",
 				 "Perform a failover for given formation and group",
 				 " [ --pgdata --formation --group ] ",
-				 "  --pgdata      path to data directory	 \n" \
-				 "  --formation   formation to target, defaults to 'default' \n" \
-				 "  --group       group to target, defaults to 0 \n",
+				 "  --pgdata      path to data directory\n"
+				 "  --formation   formation to target, defaults to 'default'\n"
+				 "  --group       group to target, defaults to 0\n"
+				 "  --wait        how many seconds to wait, default to 60 \n",
 				 cli_perform_failover_getopts,
 				 cli_perform_failover);
 
@@ -37,20 +40,22 @@ CommandLine perform_switchover_command =
 	make_command("switchover",
 				 "Perform a switchover for given formation and group",
 				 " [ --pgdata --formation --group ] ",
-				 "  --pgdata      path to data directory	 \n" \
-				 "  --formation   formation to target, defaults to 'default' \n" \
-				 "  --group       group to target, defaults to 0 \n",
+				 "  --pgdata      path to data directory\n"
+				 "  --formation   formation to target, defaults to 'default'\n"
+				 "  --group       group to target, defaults to 0\n"
+				 "  --wait        how many seconds to wait, default to 60 \n",
 				 cli_perform_failover_getopts,
 				 cli_perform_failover);
 
 CommandLine perform_promotion_command =
 	make_command("promotion",
 				 "Perform a failover that promotes a target node",
-				 " [ --pgdata --formation --group ] ",
-				 "  --pgdata      path to data directory	 \n" \
-				 "  --formation   formation to target, defaults to 'default' \n" \
-				 "  --name        node name to target, defaults to current node \n",
-				 cli_get_name_getopts,
+				 " [ --pgdata --formation --group ] --name <node name>",
+				 "  --pgdata      path to data directory\n"
+				 "  --formation   formation to target, defaults to 'default' \n"
+				 "  --name        node name to target, defaults to current node\n"
+				 "  --wait        how many seconds to wait, default to 60 \n",
+				 cli_perform_promotion_getopts,
 				 cli_perform_promotion);
 
 CommandLine *perform_subcommands[] = {
@@ -81,6 +86,7 @@ cli_perform_failover_getopts(int argc, char **argv)
 		{ "monitor", required_argument, NULL, 'm' },
 		{ "formation", required_argument, NULL, 'f' },
 		{ "group", required_argument, NULL, 'g' },
+		{ "wait", required_argument, NULL, 'w' },
 		{ "version", no_argument, NULL, 'V' },
 		{ "verbose", no_argument, NULL, 'v' },
 		{ "quiet", no_argument, NULL, 'q' },
@@ -141,6 +147,18 @@ cli_perform_failover_getopts(int argc, char **argv)
 					exit(EXIT_CODE_BAD_ARGS);
 				}
 				log_trace("--group %d", options.groupId);
+				break;
+			}
+
+			case 'w':
+			{
+				if (!stringToInt(optarg, &options.listen_notifications_timeout))
+				{
+					log_fatal("--wait argument is not a valid timeout: \"%s\"",
+							  optarg);
+					exit(EXIT_CODE_BAD_ARGS);
+				}
+				log_trace("--wait %d", options.listen_notifications_timeout);
 				break;
 			}
 
@@ -272,15 +290,215 @@ cli_perform_failover(int argc, char **argv)
 	}
 
 	/* process state changes notification until we have a new primary */
-	if (!monitor_wait_until_some_node_reported_state(&monitor,
-													 config.formation,
-													 config.groupId,
-													 config.pgSetup.pgKind,
-													 PRIMARY_STATE))
+	if (!monitor_wait_until_some_node_reported_state(
+			&monitor,
+			config.formation,
+			config.groupId,
+			config.pgSetup.pgKind,
+			PRIMARY_STATE,
+			config.listen_notifications_timeout))
 	{
 		log_error("Failed to wait until a new primary has been notified");
 		exit(EXIT_CODE_INTERNAL_ERROR);
 	}
+}
+
+
+/*
+ * cli_perform_promotion_getopts parses the command line options for the
+ * command `pg_autoctl perform promotion` command.
+ */
+static int
+cli_perform_promotion_getopts(int argc, char **argv)
+{
+	KeeperConfig options = { 0 };
+	int c, option_index = 0, errors = 0;
+	int verboseCount = 0;
+
+	static struct option long_options[] = {
+		{ "pgdata", required_argument, NULL, 'D' },
+		{ "monitor", required_argument, NULL, 'm' },
+		{ "formation", required_argument, NULL, 'f' },
+		{ "name", required_argument, NULL, 'a' },
+		{ "wait", required_argument, NULL, 'w' },
+		{ "json", no_argument, NULL, 'J' },
+		{ "version", no_argument, NULL, 'V' },
+		{ "verbose", no_argument, NULL, 'v' },
+		{ "quiet", no_argument, NULL, 'q' },
+		{ "help", no_argument, NULL, 'h' },
+		{ NULL, 0, NULL, 0 }
+	};
+
+	/* set default values for our options, when we have some */
+	options.groupId = -1;
+	options.network_partition_timeout = -1;
+	options.prepare_promotion_catchup = -1;
+	options.prepare_promotion_walreceiver = -1;
+	options.postgresql_restart_failure_timeout = -1;
+	options.postgresql_restart_failure_max_retries = -1;
+
+	optind = 0;
+
+	/*
+	 * The only command lines that are using keeper_cli_getopt_pgdata are
+	 * terminal ones: they don't accept subcommands. In that case our option
+	 * parsing can happen in any order and we don't need getopt_long to behave
+	 * in a POSIXLY_CORRECT way.
+	 *
+	 * The unsetenv() call allows getopt_long() to reorder arguments for us.
+	 */
+	unsetenv("POSIXLY_CORRECT");
+
+	while ((c = getopt_long(argc, argv, "D:f:g:n:Vvqh",
+							long_options, &option_index)) != -1)
+	{
+		switch (c)
+		{
+			case 'D':
+			{
+				strlcpy(options.pgSetup.pgdata, optarg, MAXPGPATH);
+				log_trace("--pgdata %s", options.pgSetup.pgdata);
+				break;
+			}
+
+			case 'm':
+			{
+				if (!validate_connection_string(optarg))
+				{
+					log_fatal("Failed to parse --monitor connection string, "
+							  "see above for details.");
+					exit(EXIT_CODE_BAD_ARGS);
+				}
+				strlcpy(options.monitor_pguri, optarg, MAXCONNINFO);
+				log_trace("--monitor %s", options.monitor_pguri);
+				break;
+			}
+
+			case 'f':
+			{
+				strlcpy(options.formation, optarg, NAMEDATALEN);
+				log_trace("--formation %s", options.formation);
+				break;
+			}
+
+			case 'a':
+			{
+				/* { "name", required_argument, NULL, 'a' }, */
+				strlcpy(options.name, optarg, _POSIX_HOST_NAME_MAX);
+				log_trace("--name %s", options.name);
+				break;
+			}
+
+			case 'w':
+			{
+				/* { "wait", required_argument, NULL, 'w' }, */
+				if (!stringToInt(optarg, &options.listen_notifications_timeout))
+				{
+					log_fatal("--wait argument is not a valid timeout: \"%s\"",
+							  optarg);
+					exit(EXIT_CODE_BAD_ARGS);
+				}
+				log_trace("--wait %d", options.listen_notifications_timeout);
+				break;
+			}
+
+			case 'V':
+			{
+				/* keeper_cli_print_version prints version and exits. */
+				keeper_cli_print_version(argc, argv);
+				break;
+			}
+
+			case 'v':
+			{
+				++verboseCount;
+				switch (verboseCount)
+				{
+					case 1:
+					{
+						log_set_level(LOG_INFO);
+						break;
+					}
+
+					case 2:
+					{
+						log_set_level(LOG_DEBUG);
+						break;
+					}
+
+					default:
+					{
+						log_set_level(LOG_TRACE);
+						break;
+					}
+				}
+				break;
+			}
+
+			case 'q':
+			{
+				log_set_level(LOG_ERROR);
+				break;
+			}
+
+			case 'h':
+			{
+				commandline_help(stderr);
+				exit(EXIT_CODE_QUIT);
+				break;
+			}
+
+			case 'J':
+			{
+				outputJSON = true;
+				log_trace("--json");
+				break;
+			}
+
+			default:
+			{
+				/* getopt_long already wrote an error message */
+				errors++;
+			}
+		}
+	}
+
+	if (errors > 0)
+	{
+		commandline_help(stderr);
+		exit(EXIT_CODE_BAD_ARGS);
+	}
+
+	/* now that we have the command line parameters, prepare the options */
+	/* when we have a monitor URI we don't need PGDATA */
+	if (cli_use_monitor_option(&options))
+	{
+		if (!IS_EMPTY_STRING_BUFFER(options.pgSetup.pgdata))
+		{
+			log_warn("Given --monitor URI, the --pgdata option is ignored");
+			log_info("Connecting to monitor at \"%s\"", options.monitor_pguri);
+
+			/* the rest of the program needs pgdata actually empty */
+			bzero((void *) options.pgSetup.pgdata,
+				  sizeof(options.pgSetup.pgdata));
+		}
+	}
+	else
+	{
+		(void) prepare_keeper_options(&options);
+	}
+
+	/* ensure --formation, or get it from the configuration file */
+	if (!cli_common_ensure_formation(&options))
+	{
+		/* errors have already been logged */
+		exit(EXIT_CODE_BAD_ARGS);
+	}
+
+	/* publish our option parsing in the global variable */
+	keeperOptions = options;
+
+	return optind;
 }
 
 
@@ -332,11 +550,13 @@ cli_perform_promotion(int argc, char **argv)
 	if (monitor_perform_promotion(monitor, config->formation, config->name))
 	{
 		/* process state changes notification until we have a new primary */
-		if (!monitor_wait_until_some_node_reported_state(monitor,
-														 config->formation,
-														 groupId,
-														 nodeKind,
-														 PRIMARY_STATE))
+		if (!monitor_wait_until_some_node_reported_state(
+				monitor,
+				config->formation,
+				groupId,
+				nodeKind,
+				PRIMARY_STATE,
+				config->listen_notifications_timeout))
 		{
 			log_error("Failed to wait until a new primary has been notified");
 			exit(EXIT_CODE_INTERNAL_ERROR);

--- a/src/bin/pg_autoctl/demoapp.c
+++ b/src/bin/pg_autoctl/demoapp.c
@@ -440,11 +440,13 @@ demoapp_process_perform_switchover(DemoAppOptions *demoAppOptions)
 		}
 
 		/* process state changes notification until we have a new primary */
-		if (!monitor_wait_until_some_node_reported_state(&monitor,
-														 formation,
-														 groupId,
-														 NODE_KIND_UNKNOWN,
-														 PRIMARY_STATE))
+		if (!monitor_wait_until_some_node_reported_state(
+				&monitor,
+				formation,
+				groupId,
+				NODE_KIND_UNKNOWN,
+				PRIMARY_STATE,
+				PG_AUTOCTL_LISTEN_NOTIFICATIONS_TIMEOUT))
 		{
 			log_error("Failed to wait until a new primary has been notified");
 			continue;

--- a/src/bin/pg_autoctl/keeper_config.c
+++ b/src/bin/pg_autoctl/keeper_config.c
@@ -176,6 +176,12 @@
 							&(config->postgresql_restart_failure_max_retries), \
 							POSTGRESQL_FAILS_TO_START_RETRIES)
 
+#define OPTION_TIMEOUT_LISTEN_NOTIFICATIONS(config) \
+	make_int_option_default("timeout", "listen_notifications_timeout", \
+							NULL, false, \
+							&(config->listen_notifications_timeout), \
+							PG_AUTOCTL_LISTEN_NOTIFICATIONS_TIMEOUT)
+
 #define OPTION_CITUS_ROLE(config) \
 	make_strbuf_option_default("citus", "role", NULL, false, NAMEDATALEN, \
 							   config->citusRoleStr, DEFAULT_CITUS_ROLE)
@@ -219,6 +225,7 @@
 		OPTION_TIMEOUT_PREPARE_PROMOTION_WALRECEIVER(config), \
 		OPTION_TIMEOUT_POSTGRESQL_RESTART_FAILURE_TIMEOUT(config), \
 		OPTION_TIMEOUT_POSTGRESQL_RESTART_FAILURE_MAX_RETRIES(config), \
+		OPTION_TIMEOUT_LISTEN_NOTIFICATIONS(config), \
  \
 		OPTION_CITUS_ROLE(config), \
 		OPTION_CITUS_CLUSTER_NAME(config), \

--- a/src/bin/pg_autoctl/keeper_config.h
+++ b/src/bin/pg_autoctl/keeper_config.h
@@ -66,6 +66,7 @@ typedef struct KeeperConfig
 	int prepare_promotion_walreceiver;
 	int postgresql_restart_failure_timeout;
 	int postgresql_restart_failure_max_retries;
+	int listen_notifications_timeout;
 } KeeperConfig;
 
 #define PG_AUTOCTL_MONITOR_IS_DISABLED(config) \

--- a/src/bin/pg_autoctl/monitor.c
+++ b/src/bin/pg_autoctl/monitor.c
@@ -3741,7 +3741,8 @@ monitor_wait_until_some_node_reported_state(Monitor *monitor,
 											const char *formation,
 											int groupId,
 											PgInstanceKind nodeKind,
-											NodeState targetState)
+											NodeState targetState,
+											int timeout)
 {
 	PGconn *connection = monitor->notificationClient.connection;
 
@@ -3774,7 +3775,7 @@ monitor_wait_until_some_node_reported_state(Monitor *monitor,
 	{
 		uint64_t now = time(NULL);
 
-		if ((now - start) > PG_AUTOCTL_LISTEN_NOTIFICATIONS_TIMEOUT)
+		if ((now - start) > timeout)
 		{
 			log_error("Failed to receive monitor's notifications");
 			break;
@@ -3782,7 +3783,7 @@ monitor_wait_until_some_node_reported_state(Monitor *monitor,
 
 		if (!monitor_process_notifications(
 				monitor,
-				PG_AUTOCTL_LISTEN_NOTIFICATIONS_TIMEOUT * 1000,
+				timeout * 1000,
 				channels,
 				(void *) &context,
 				&monitor_check_report_state))

--- a/src/bin/pg_autoctl/monitor.c
+++ b/src/bin/pg_autoctl/monitor.c
@@ -3768,22 +3768,37 @@ monitor_wait_until_some_node_reported_state(Monitor *monitor,
 		return false;
 	}
 
+	/* when timeout <= 0 we just never stop waiting */
+	if (timeout > 0)
+	{
+		log_info("Waiting %d secs for a notification with "
+				 "state \"%s\" in formation \"%s\" and group %d",
+				 timeout, NodeStateToString(targetState), formation, groupId);
+	}
+
 	(void) monitor_report_state_print_headers(monitor, formation, groupId,
 											  nodeKind, &nodesArray, &headers);
 
 	while (!context.failoverIsDone)
 	{
-		uint64_t now = time(NULL);
-
-		if ((now - start) > timeout)
+		/* when timeout <= 0 we just never stop waiting */
+		if (timeout > 0)
 		{
-			log_error("Failed to receive monitor's notifications");
-			break;
+			uint64_t now = time(NULL);
+
+			if ((now - start) > timeout)
+			{
+				log_error("Failed to receive monitor's notifications");
+				break;
+			}
 		}
+
+		int thisLoopTimeout =
+			timeout > 0 ? timeout : PG_AUTOCTL_LISTEN_NOTIFICATIONS_TIMEOUT;
 
 		if (!monitor_process_notifications(
 				monitor,
-				timeout * 1000,
+				thisLoopTimeout * 1000,
 				channels,
 				(void *) &context,
 				&monitor_check_report_state))

--- a/src/bin/pg_autoctl/monitor.h
+++ b/src/bin/pg_autoctl/monitor.h
@@ -195,7 +195,8 @@ bool monitor_wait_until_some_node_reported_state(Monitor *monitor,
 												 const char *formation,
 												 int groupId,
 												 PgInstanceKind nodeKind,
-												 NodeState targetState);
+												 NodeState targetState,
+												 int timeout);
 bool monitor_wait_until_node_reported_state(Monitor *monitor,
 											const char *formation,
 											int groupId,


### PR DESCRIPTION
Also implement a new command line parameter --wait for the pg_autoctl
perform promotion|switchover|failover commands.

Fixes #604.