### PR TITLE
Also spawn valgrind for pg_autoctl subprocesses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,8 +60,8 @@ ifeq ($(VALGRIND),)
 	BINPATH = ./src/bin/pg_autoctl/pg_autoctl
 	PG_AUTOCTL = PG_AUTOCTL_DEBUG=1 ./src/bin/pg_autoctl/pg_autoctl
 else
-	BINPATH = ./src/tools/pg_autoctl.valgrind
-	PG_AUTOCTL = PG_AUTOCTL_DEBUG=1 ./src/tools/pg_autoctl.valgrind
+	BINPATH = $(abspath $(PWD))/src/tools/pg_autoctl.valgrind
+	PG_AUTOCTL = PG_AUTOCTL_DEBUG=1 PG_AUTOCTL_DEBUG_BIN_PATH="$(BINPATH)" ./src/tools/pg_autoctl.valgrind
 endif
 
 

--- a/src/bin/pg_autoctl/cli_do_tmux.c
+++ b/src/bin/pg_autoctl/cli_do_tmux.c
@@ -855,7 +855,7 @@ prepare_tmux_script(TmuxOptions *options, PQExpBuffer script)
  * tmux_start_server starts a tmux session with the given script.
  */
 bool
-tmux_start_server(const char *scriptName)
+tmux_start_server(const char *scriptName, const char *binpath)
 {
 	char *args[8];
 	int argsIndex = 0;
@@ -866,6 +866,12 @@ tmux_start_server(const char *scriptName)
 	if (setenv("PG_AUTOCTL_DEBUG", "1", 1) != 0)
 	{
 		log_error("Failed to set environment PG_AUTOCTL_DEBUG: %m");
+		return false;
+	}
+
+	if (binpath && setenv("PG_AUTOCTL_DEBUG_BIN_PATH", binpath, 1) != 0)
+	{
+		log_error("Failed to set environment PG_AUTOCTL_DEBUG_BIN_PATH: %m");
 		return false;
 	}
 
@@ -1358,7 +1364,7 @@ cli_do_tmux_session(int argc, char **argv)
 	/*
 	 * Start a tmux session from the script.
 	 */
-	if (!tmux_start_server(scriptName))
+	if (!tmux_start_server(scriptName, options.binpath))
 	{
 		success = false;
 		log_fatal("Failed to start the tmux session, see above for details");

--- a/src/bin/pg_autoctl/cli_do_tmux.h
+++ b/src/bin/pg_autoctl/cli_do_tmux.h
@@ -92,7 +92,7 @@ void tmux_pg_autoctl_create_postgres(PQExpBuffer script,
 									 int candidatePriority,
 									 bool skipHBA);
 
-bool tmux_start_server(const char *scriptName);
+bool tmux_start_server(const char *scriptName, const char *binpath);
 bool pg_autoctl_getpid(const char *pgdata, pid_t *pid);
 
 bool tmux_has_session(const char *tmux_path, const char *sessionName);

--- a/src/bin/pg_autoctl/cli_do_tmux_azure.c
+++ b/src/bin/pg_autoctl/cli_do_tmux_azure.c
@@ -253,7 +253,7 @@ tmux_azure_start_or_attach_session(AzureRegionResources *azRegion)
 			return false;
 		}
 
-		if (!tmux_start_server(scriptName))
+		if (!tmux_start_server(scriptName, NULL))
 		{
 			log_fatal("Failed to start the tmux session, see above for details");
 			destroyPQExpBuffer(script);


### PR DESCRIPTION
This makes sure memory leaks in subprocesses are also detected
correctly.