### PR TITLE
Fix/consider timeline when reaching secondary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,7 @@ build-test:
 run-test: build-test
 	docker run					                \
 		--name $(TEST_CONTAINER_NAME)		    \
+		$(DOCKER_RUN_OPTS)			            \
 		$(TEST_CONTAINER_NAME)			        \
 		make -C /usr/src/pg_auto_failover test	\
 		TEST='${TEST}'

--- a/src/bin/pg_autoctl/cli_do_misc.c
+++ b/src/bin/pg_autoctl/cli_do_misc.c
@@ -560,4 +560,26 @@ keeper_cli_identify_system(int argc, char **argv)
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);
 	}
+
+	IdentifySystem *system = &(replicationSource.system);
+
+	fformat(stdout, "Current timeline:  %d\n", system->timeline);
+	fformat(stdout, "Current WAL LSN:   %s\n", system->xlogpos);
+
+	for (int index = 0; index < system->timelines.count; index++)
+	{
+		TimeLineHistoryEntry *entry = &(system->timelines.history[index]);
+
+		char startLSN[PG_LSN_MAXLENGTH] = { 0 };
+
+		sformat(startLSN, sizeof(startLSN), "%X/%X",
+				(uint32_t) (entry->begin >> 32),
+				(uint32_t) entry->begin);
+
+		fformat(stdout, "Timeline %d:   %18s .. %X/%X\n",
+				entry->tli,
+				startLSN,
+				(uint32_t) (entry->end >> 32),
+				(uint32_t) entry->end);
+	}
 }

--- a/src/bin/pg_autoctl/fsm.c
+++ b/src/bin/pg_autoctl/fsm.c
@@ -285,7 +285,7 @@ KeeperFSMTransition KeeperFSM[] = {
 	/*
 	 * We're asked to be a standby.
 	 */
-	{ CATCHINGUP_STATE, SECONDARY_STATE, COMMENT_CATCHINGUP_TO_SECONDARY, &fsm_maintain_replication_slots },
+	{ CATCHINGUP_STATE, SECONDARY_STATE, COMMENT_CATCHINGUP_TO_SECONDARY, &fsm_prepare_for_secondary },
 
 	/*
 	 * The standby is asked to prepare its own promotion

--- a/src/bin/pg_autoctl/fsm.h
+++ b/src/bin/pg_autoctl/fsm.h
@@ -41,7 +41,7 @@ bool fsm_prepare_replication(Keeper *keeper);
 bool fsm_disable_replication(Keeper *keeper);
 bool fsm_resume_as_primary(Keeper *keeper);
 bool fsm_rewind_or_init(Keeper *keeper);
-bool fsm_maintain_replication_slots(Keeper *keeper);
+bool fsm_prepare_for_secondary(Keeper *keeper);
 
 bool fsm_init_standby(Keeper *keeper);
 bool fsm_promote_standby(Keeper *keeper);

--- a/src/bin/pg_autoctl/pgctl.c
+++ b/src/bin/pg_autoctl/pgctl.c
@@ -2468,7 +2468,8 @@ pgctl_identify_system(ReplicationSource *replicationSource)
 		return false;
 	}
 
-	if (!pgsql_identify_system(&replicationClient))
+	if (!pgsql_identify_system(&replicationClient,
+							   &(replicationSource->system)))
 	{
 		/* errors have already been logged */
 		return false;

--- a/src/bin/pg_autoctl/pgsetup.h
+++ b/src/bin/pg_autoctl/pgsetup.h
@@ -40,6 +40,7 @@ typedef struct pg_control_data
 	uint32_t catalog_version_no;        /* see catversion.h */
 	uint64_t system_identifier;
 	char latestCheckpointLSN[PG_LSN_MAXLENGTH];
+	uint32_t timeline_id;
 } PostgresControlData;
 
 /*

--- a/src/bin/pg_autoctl/pgsql.c
+++ b/src/bin/pg_autoctl/pgsql.c
@@ -47,7 +47,8 @@ static void parsePgMetadata(void *ctx, PGresult *result);
 static void parsePgReachedTargetLSN(void *ctx, PGresult *result);
 static void parseReplicationSlotMaintain(void *ctx, PGresult *result);
 static void parsePgReachedTargetLSN(void *ctx, PGresult *result);
-static void parseIdentifySystem(void *ctx, PGresult *result);
+static void parseIdentifySystemResult(void *ctx, PGresult *result);
+static void parseTimelineHistoryResult(void *ctx, PGresult *result);
 
 
 /*
@@ -2798,15 +2799,21 @@ parsePgReachedTargetLSN(void *ctx, PGresult *result)
 }
 
 
-typedef struct IdentifySystem
+typedef struct IdentifySystemResult
 {
 	char sqlstate[6];
 	bool parsedOk;
-	uint64_t system_identifier;
-	int timeline;
-	char xlogpos[PG_LSN_MAXLENGTH];
-	char dbname[NAMEDATALEN];
-} IdentifySystem;
+	IdentifySystem *system;
+} IdentifySystemResult;
+
+
+typedef struct TimelineHistoryResult
+{
+	char sqlstate[6];
+	bool parsedOk;
+	char filename[MAXPGPATH];
+	char content[BUFSIZE * BUFSIZE]; /* 1MB should get us quite very far */
+} TimelineHistoryResult;
 
 
 /*
@@ -2815,12 +2822,8 @@ typedef struct IdentifySystem
  * contain the 'replication=1' parameter.
  */
 bool
-pgsql_identify_system(PGSQL *pgsql)
+pgsql_identify_system(PGSQL *pgsql, IdentifySystem *system)
 {
-	IdentifySystem context = { 0 };
-	char *sql = "IDENTIFY_SYSTEM";
-
-
 	PGconn *connection = pgsql_open_connection(pgsql);
 	if (connection == NULL)
 	{
@@ -2829,7 +2832,7 @@ pgsql_identify_system(PGSQL *pgsql)
 	}
 
 	/* extended query protocol not supported in a replication connection */
-	PGresult *result = PQexec(connection, sql);
+	PGresult *result = PQexec(connection, "IDENTIFY_SYSTEM");
 
 	if (!is_response_ok(result))
 	{
@@ -2842,23 +2845,72 @@ pgsql_identify_system(PGSQL *pgsql)
 		return false;
 	}
 
-	(void) parseIdentifySystem((void *) &context, result);
+	IdentifySystemResult isContext = { { 0 }, false, system };
+
+	(void) parseIdentifySystemResult((void *) &isContext, result);
 
 	PQclear(result);
 	clear_results(pgsql);
-	PQfinish(connection);
 
-	if (!context.parsedOk)
+	log_debug("IDENTIFY_SYSTEM: timeline %d, xlogpos %s, systemid %" PRIu64,
+			  system->timeline,
+			  system->xlogpos,
+			  system->identifier);
+
+	if (!isContext.parsedOk)
 	{
 		log_error("Failed to get result from IDENTIFY_SYSTEM");
 		return false;
 	}
 
-	log_debug("IDENTIFY_SYSTEM: system identifier %" PRIu64 ", "
-															"timeline %d, xlogpos %s",
-			  context.system_identifier,
-			  context.timeline,
-			  context.xlogpos);
+	/* while at it, we also run the TIMELINE_HISTORY command */
+	TimelineHistoryResult hContext = { 0 };
+
+	char sql[BUFSIZE] = { 0 };
+	sformat(sql, sizeof(sql), "TIMELINE_HISTORY %d", system->timeline);
+
+	result = PQexec(connection, sql);
+
+	if (!is_response_ok(result))
+	{
+		log_error("Failed to request TIMELINE_HISTORY: %s",
+				  PQerrorMessage(connection));
+		PQclear(result);
+		clear_results(pgsql);
+
+		PQfinish(connection);
+
+		return false;
+	}
+
+	(void) parseTimelineHistoryResult((void *) &hContext, result);
+
+	PQclear(result);
+	clear_results(pgsql);
+
+	/* now we're done with running SQL queries */
+	PQfinish(connection);
+
+	if (!hContext.parsedOk)
+	{
+		log_error("Failed to get result from TIMELINE_HISTORY");
+		return false;
+	}
+
+	if (!parseTimeLineHistory(hContext.filename, hContext.content, system))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	TimeLineHistoryEntry *current =
+		&(system->timelines.history[system->timelines.count - 1]);
+
+	log_debug("TIMELINE_HISTORY: \"%s\", timeline %d started at %X/%X",
+			  hContext.filename,
+			  current->tli,
+			  (uint32_t) (current->begin >> 32),
+			  (uint32_t) current->begin);
 
 	return true;
 }
@@ -2869,9 +2921,9 @@ pgsql_identify_system(PGSQL *pgsql)
  * two columns from pg_stat_replication: sync_state and currentLSN.
  */
 static void
-parseIdentifySystem(void *ctx, PGresult *result)
+parseIdentifySystemResult(void *ctx, PGresult *result)
 {
-	IdentifySystem *context = (IdentifySystem *) ctx;
+	IdentifySystemResult *context = (IdentifySystemResult *) ctx;
 
 	if (PQnfields(result) != 4)
 	{
@@ -2893,29 +2945,207 @@ parseIdentifySystem(void *ctx, PGresult *result)
 		return;
 	}
 
+	/* systemid (text) */
 	char *value = PQgetvalue(result, 0, 0);
-	if (!stringToUInt64(value, &(context->system_identifier)))
+	if (!stringToUInt64(value, &(context->system->identifier)))
 	{
 		log_error("Failed to parse system_identifier \"%s\"", value);
 		context->parsedOk = false;
 		return;
 	}
 
+	/* timeline (int4) */
 	value = PQgetvalue(result, 0, 1);
-	if (!stringToInt(value, &(context->timeline)))
+	if (!stringToUInt32(value, &(context->system->timeline)))
 	{
 		log_error("Failed to parse timeline \"%s\"", value);
 		context->parsedOk = false;
 		return;
 	}
 
+	/* xlogpos (text) */
 	value = PQgetvalue(result, 0, 2);
-	strlcpy(context->xlogpos, value, PG_LSN_MAXLENGTH);
+	strlcpy(context->system->xlogpos, value, PG_LSN_MAXLENGTH);
 
-	value = PQgetvalue(result, 0, 3);
-	strlcpy(context->dbname, value, NAMEDATALEN);
+	/* dbname (text) Database connected to or null */
+	if (!PQgetisnull(result, 0, 3))
+	{
+		value = PQgetvalue(result, 0, 3);
+		strlcpy(context->system->dbname, value, NAMEDATALEN);
+	}
 
 	context->parsedOk = true;
+}
+
+
+/*
+ * parseTimelineHistory parses the result of the TIMELINE_HISTORY replication
+ * command.
+ */
+static void
+parseTimelineHistoryResult(void *ctx, PGresult *result)
+{
+	TimelineHistoryResult *context = (TimelineHistoryResult *) ctx;
+
+	if (PQnfields(result) != 2)
+	{
+		log_error("Query returned %d columns, expected 2", PQnfields(result));
+		context->parsedOk = false;
+		return;
+	}
+
+	if (PQntuples(result) == 0)
+	{
+		log_debug("parseTimelineHistory: query returned no rows");
+		context->parsedOk = false;
+		return;
+	}
+
+	if (PQntuples(result) != 1)
+	{
+		log_error("Query returned %d rows, expected 1", PQntuples(result));
+		context->parsedOk = false;
+		return;
+	}
+
+	/* filename (text) */
+	char *value = PQgetvalue(result, 0, 0);
+	strlcpy(context->filename, value, sizeof(context->filename));
+
+	/* content (bytea) */
+	value = PQgetvalue(result, 0, 1);
+
+	if (strlen(value) >= sizeof(context->content))
+	{
+		log_error("Received a timeline history file of %ld bytes, "
+				  "pg_autoctl is limited to files of up to %lu bytes.",
+				  strlen(value),
+				  sizeof(context->content));
+		context->parsedOk = false;
+	}
+	strlcpy(context->content, value, sizeof(context->content));
+
+	context->parsedOk = true;
+}
+
+
+/*
+ * parseTimeLineHistory parses the content of a timeline history file.
+ */
+bool
+parseTimeLineHistory(const char *filename, const char *content,
+					 IdentifySystem *system)
+{
+	char *historyLines[BUFSIZE] = { 0 };
+	int lineCount = splitLines((char *) content, historyLines, BUFSIZE);
+	int lineNumber = 0;
+
+	if (lineCount >= PG_AUTOCTL_MAX_TIMELINES)
+	{
+		log_error("history file \"%s\" contains %d lines, "
+				  "pg_autoctl only supports up to %d lines",
+				  filename, lineCount, PG_AUTOCTL_MAX_TIMELINES - 1);
+		return false;
+	}
+
+	uint64_t prevend = InvalidXLogRecPtr;
+
+	system->timelines.count = 0;
+
+	TimeLineHistoryEntry *entry =
+		&(system->timelines.history[system->timelines.count]);
+
+	for (lineNumber = 0; lineNumber < lineCount; lineNumber++)
+	{
+		char *ptr = historyLines[lineNumber];
+
+		/* skip leading whitespace and check for # comment */
+		for (; *ptr; ptr++)
+		{
+			if (!isspace((unsigned char) *ptr))
+			{
+				break;
+			}
+		}
+
+		if (*ptr == '\0' || *ptr == '#')
+		{
+			continue;
+		}
+
+		log_trace("parseTimeLineHistory line %d is \"%s\"",
+				  lineNumber,
+				  historyLines[lineNumber]);
+
+		char *tabptr = strchr(historyLines[lineNumber], '\t');
+
+		if (tabptr == NULL)
+		{
+			log_error("Failed to parse history file line %d: \"%s\"",
+					  lineNumber, ptr);
+			return false;
+		}
+
+		*tabptr = '\0';
+
+		if (!stringToUInt(historyLines[lineNumber], &(entry->tli)))
+		{
+			log_error("Failed to parse history timeline \"%s\"", tabptr);
+			return false;
+		}
+
+		char *lsn = tabptr + 1;
+
+		for (char *lsnend = lsn; *lsnend; lsnend++)
+		{
+			if (!(isxdigit((unsigned char) *lsnend) || *lsnend == '/'))
+			{
+				*lsnend = '\0';
+				break;
+			}
+		}
+
+		if (!parseLSN(lsn, &(entry->end)))
+		{
+			log_error("Failed to parse history timeline %d LSN \"%s\"",
+					  entry->tli, lsn);
+			return false;
+		}
+
+		entry->begin = prevend;
+		prevend = entry->end;
+
+		log_trace("parseTimeLineHistory[%d]: tli %d [%X/%X %X/%X]",
+				  system->timelines.count,
+				  entry->tli,
+				  (uint32) (entry->begin >> 32),
+				  (uint32) entry->begin,
+				  (uint32) (entry->end >> 32),
+				  (uint32) entry->end);
+
+		entry = &(system->timelines.history[++system->timelines.count]);
+	}
+
+	/*
+	 * Create one more entry for the "tip" of the timeline, which has no entry
+	 * in the history file.
+	 */
+	entry->tli = system->timeline;
+	entry->begin = prevend;
+	entry->end = InvalidXLogRecPtr;
+
+	log_trace("parseTimeLineHistory[%d]: tli %d [%X/%X %X/%X]",
+			  system->timelines.count,
+			  entry->tli,
+			  (uint32) (entry->begin >> 32),
+			  (uint32) entry->begin,
+			  (uint32) (entry->end >> 32),
+			  (uint32) entry->end);
+
+	/* fix the off-by-one so that the count is a count, not an index */
+	++system->timelines.count;
+
+	return true;
 }
 
 

--- a/src/bin/pg_autoctl/pgsql.c
+++ b/src/bin/pg_autoctl/pgsql.c
@@ -2874,6 +2874,7 @@ pgsql_identify_system(PGSQL *pgsql, IdentifySystem *system)
 	if (!isContext.parsedOk)
 	{
 		log_error("Failed to get result from IDENTIFY_SYSTEM");
+		PQfinish(connection);
 		return false;
 	}
 
@@ -2904,18 +2905,17 @@ pgsql_identify_system(PGSQL *pgsql, IdentifySystem *system)
 		PQclear(result);
 		clear_results(pgsql);
 
-		/* now we're done with running SQL queries */
-		PQfinish(connection);
-
 		if (!hContext.parsedOk)
 		{
 			log_error("Failed to get result from TIMELINE_HISTORY");
+			PQfinish(connection);
 			return false;
 		}
 
 		if (!parseTimeLineHistory(hContext.filename, hContext.content, system))
 		{
 			/* errors have already been logged */
+			PQfinish(connection);
 			return false;
 		}
 
@@ -2928,6 +2928,9 @@ pgsql_identify_system(PGSQL *pgsql, IdentifySystem *system)
 				  (uint32_t) (current->begin >> 32),
 				  (uint32_t) current->begin);
 	}
+
+	/* now we're done with running SQL queries */
+	PQfinish(connection);
 
 	return true;
 }

--- a/src/bin/pg_autoctl/primary_standby.h
+++ b/src/bin/pg_autoctl/primary_standby.h
@@ -107,6 +107,7 @@ bool standby_follow_new_primary(LocalPostgresServer *postgres);
 bool standby_fetch_missing_wal(LocalPostgresServer *postgres);
 bool standby_restart_with_current_replication_source(LocalPostgresServer *postgres);
 bool standby_cleanup_as_primary(LocalPostgresServer *postgres);
+bool standby_check_timeline_with_upstream(LocalPostgresServer *postgres);
 
 
 #endif /* LOCAL_POSTGRES_H */


### PR DESCRIPTION
Check that we are on the same timeline as our upstream node.

When a node reports state SECONDARY it can be the target of a failover.
Because we want a single straight line history in streaming replication, we
need to ensure that standby nodes are on the same timeline as their upstream
node before transitioning to SECONDARY.

See #683 