### PR TITLE
Fix pg_autoctl show settings --json output.

### DIFF
--- a/src/bin/pg_autoctl/monitor.c
+++ b/src/bin/pg_autoctl/monitor.c
@@ -2794,7 +2794,7 @@ monitor_print_formation_settings_as_json(Monitor *monitor, char *formation)
 		" ), "
 		" f(json) as "
 		" ( "
-		"   select row_to_json(settings) "
+		"   select jsonb_agg(row_to_json(settings)) "
 		"     from settings "
 		"    where context = 'formation' "
 		" ), "


### PR DESCRIPTION
The formation context parts should also be an array, even when we know it
contains a single element for now.

Fixes #694 