### PR TITLE
Complete transition of a second (or greater) failed primary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ TESTS_MULTI  = test_multi_async
 TESTS_MULTI += test_multi_ifdown
 TESTS_MULTI += test_multi_maintenance
 TESTS_MULTI += test_multi_standbys
+TESTS_MULTI += test_multi_alternate_primary_failures
 
 # TEST indicates the testfile to run
 TEST ?=

--- a/src/monitor/node_metadata.c
+++ b/src/monitor/node_metadata.c
@@ -448,8 +448,8 @@ GetPrimaryOrDemotedNodeInGroup(char *formationId, int32 groupId)
 		AutoFailoverNode *currentNode = (AutoFailoverNode *) lfirst(nodeCell);
 
 		if (StateBelongsToPrimary(currentNode->reportedState) &&
-			(IsBeingDemotedPrimary(primaryNode) == false ||
-			 IsDemotedPrimary(currentNode) == false))
+			(!IsBeingDemotedPrimary(primaryNode) ||
+			 !IsDemotedPrimary(currentNode)))
 		{
 			primaryNode = currentNode;
 		}

--- a/src/monitor/node_metadata.c
+++ b/src/monitor/node_metadata.c
@@ -438,15 +438,20 @@ GetPrimaryOrDemotedNodeInGroup(char *formationId, int32 groupId)
 		return primaryNode;
 	}
 
-	/* maybe we have a primary that is draining or has been demoted? */
+	/*
+	 * Maybe we have a primary that is draining or has been demoted?
+	 * In case there are more than one of those, choose the one that is
+	 * currently being demoted.
+	 */
 	foreach(nodeCell, groupNodeList)
 	{
 		AutoFailoverNode *currentNode = (AutoFailoverNode *) lfirst(nodeCell);
 
-		if (StateBelongsToPrimary(currentNode->reportedState))
+		if (StateBelongsToPrimary(currentNode->reportedState) &&
+			(IsBeingDemotedPrimary(primaryNode) == false ||
+			IsDemotedPrimary(currentNode) == false))
 		{
 			primaryNode = currentNode;
-			break;
 		}
 	}
 
@@ -1538,6 +1543,31 @@ StateBelongsToPrimary(ReplicationState state)
 		   state == REPLICATION_STATE_PREPARE_MAINTENANCE;
 }
 
+/*
+ * IsBeingDemotedPrimary returns true when a given node is currently going
+ * through a demotion.
+ */
+bool
+IsBeingDemotedPrimary(AutoFailoverNode *node)
+{
+	return node != NULL &&
+			(node->reportedState == REPLICATION_STATE_PRIMARY &&
+			(node->goalState == REPLICATION_STATE_DRAINING ||
+			 node->goalState == REPLICATION_STATE_DEMOTE_TIMEOUT ||
+			 node->goalState == REPLICATION_STATE_PREPARE_MAINTENANCE));
+}
+
+/*
+ * IsDemotedPrimary returns true when a node has completed a process of
+ * demotion.
+ */
+bool
+IsDemotedPrimary(AutoFailoverNode *node)
+{
+	return node != NULL &&
+			(node->reportedState == REPLICATION_STATE_PRIMARY &&
+			 node->goalState == REPLICATION_STATE_DEMOTED);
+}
 
 /*
  * IsBeingPromoted returns whether a standby node is going through the process

--- a/src/monitor/node_metadata.c
+++ b/src/monitor/node_metadata.c
@@ -449,7 +449,7 @@ GetPrimaryOrDemotedNodeInGroup(char *formationId, int32 groupId)
 
 		if (StateBelongsToPrimary(currentNode->reportedState) &&
 			(IsBeingDemotedPrimary(primaryNode) == false ||
-			IsDemotedPrimary(currentNode) == false))
+			 IsDemotedPrimary(currentNode) == false))
 		{
 			primaryNode = currentNode;
 		}
@@ -1543,6 +1543,7 @@ StateBelongsToPrimary(ReplicationState state)
 		   state == REPLICATION_STATE_PREPARE_MAINTENANCE;
 }
 
+
 /*
  * IsBeingDemotedPrimary returns true when a given node is currently going
  * through a demotion.
@@ -1551,11 +1552,12 @@ bool
 IsBeingDemotedPrimary(AutoFailoverNode *node)
 {
 	return node != NULL &&
-			(node->reportedState == REPLICATION_STATE_PRIMARY &&
+		   (node->reportedState == REPLICATION_STATE_PRIMARY &&
 			(node->goalState == REPLICATION_STATE_DRAINING ||
 			 node->goalState == REPLICATION_STATE_DEMOTE_TIMEOUT ||
 			 node->goalState == REPLICATION_STATE_PREPARE_MAINTENANCE));
 }
+
 
 /*
  * IsDemotedPrimary returns true when a node has completed a process of
@@ -1565,9 +1567,10 @@ bool
 IsDemotedPrimary(AutoFailoverNode *node)
 {
 	return node != NULL &&
-			(node->reportedState == REPLICATION_STATE_PRIMARY &&
-			 node->goalState == REPLICATION_STATE_DEMOTED);
+		   (node->reportedState == REPLICATION_STATE_PRIMARY &&
+			node->goalState == REPLICATION_STATE_DEMOTED);
 }
+
 
 /*
  * IsBeingPromoted returns whether a standby node is going through the process

--- a/src/monitor/node_metadata.h
+++ b/src/monitor/node_metadata.h
@@ -219,6 +219,8 @@ extern bool CanTakeWritesInState(ReplicationState state);
 extern bool CanInitiateFailover(ReplicationState state);
 extern bool StateBelongsToPrimary(ReplicationState state);
 extern bool IsBeingPromoted(AutoFailoverNode *node);
+extern bool IsBeingDemotedPrimary(AutoFailoverNode *node);
+extern bool IsDemotedPrimary(AutoFailoverNode *node);
 extern bool CandidateNodeIsReadyToStreamWAL(AutoFailoverNode *node);
 extern bool IsParticipatingInPromotion(AutoFailoverNode *node);
 extern bool IsInWaitOrJoinState(AutoFailoverNode *node);

--- a/tests/test_multi_alternate_primary_failures.py
+++ b/tests/test_multi_alternate_primary_failures.py
@@ -136,6 +136,8 @@ def test_005_001_fail_primary_again():
     )
     assert node3.wait_until_assigned_state(target_state="demoted", timeout=120)
     assert node1.wait_until_assigned_state(target_state="primary", timeout=120)
+    assert node1.wait_until_state(target_state="primary", timeout=120)
+    assert node2.wait_until_state(target_state="secondary", timeout=120)
 
 
 def test_005_002_fail_primary_again():
@@ -152,7 +154,7 @@ def test_005_002_fail_primary_again():
     )
 
 
-def test_007_001_bring_up_first_failed_primary():
+def test_006_001_bring_up_first_failed_primary():
     # Restart node3
     node3.run()
     node3.wait_until_pg_is_running()
@@ -162,7 +164,7 @@ def test_007_001_bring_up_first_failed_primary():
     assert node2.wait_until_state(target_state="primary")
 
 
-def test_007_002_bring_up_first_failed_primary():
+def test_006_002_bring_up_first_failed_primary():
     # Restart node1
     node1.run()
     node1.wait_until_pg_is_running()

--- a/tests/test_multi_alternate_primary_failures.py
+++ b/tests/test_multi_alternate_primary_failures.py
@@ -131,8 +131,11 @@ def test_005_001_fail_primary_again():
     assert node3.get_state().assigned == "primary"
     node3.fail()
 
-    assert node3.wait_until_assigned_state(target_state="demoted")
-    assert node1.wait_until_assigned_state(target_state="primary")
+    assert node3.wait_until_assigned_state(
+        target_state="demote_timeout", timeout=120
+    )
+    assert node3.wait_until_assigned_state(target_state="demoted", timeout=120)
+    assert node1.wait_until_assigned_state(target_state="primary", timeout=120)
 
 
 def test_005_002_fail_primary_again():
@@ -140,8 +143,13 @@ def test_005_002_fail_primary_again():
     assert node1.get_state().assigned == "primary"
     node1.fail()
 
-    assert node1.wait_until_assigned_state(target_state="demoted")
-    assert node2.wait_until_assigned_state(target_state="wait_primary")
+    assert node1.wait_until_assigned_state(
+        target_state="demote_timeout", timeout=120
+    )
+    assert node1.wait_until_assigned_state(target_state="demoted", timeout=120)
+    assert node2.wait_until_assigned_state(
+        target_state="wait_primary", timeout=120
+    )
 
 
 def test_007_001_bring_up_first_failed_primary():

--- a/tests/test_multi_alternate_primary_failures.py
+++ b/tests/test_multi_alternate_primary_failures.py
@@ -23,7 +23,7 @@ def teardown_module():
 def test_000_create_monitor():
     global monitor
     monitor = cluster.create_monitor(
-        "/tmp/multinode_alternate_primary_failures/monitor"
+        "/tmp/multi_alternate_primary_failures/monitor"
     )
     monitor.run()
     monitor.wait_until_pg_is_running()
@@ -32,7 +32,7 @@ def test_000_create_monitor():
 def test_001_init_primary():
     global node1
     node1 = cluster.create_datanode(
-        "/tmp/multinode_alternate_primary_failures/node1"
+        "/tmp/multi_alternate_primary_failures/node1"
     )
     node1.create()
     node1.run()
@@ -43,7 +43,7 @@ def test_002_001_add_two_standbys():
     global node2
 
     node2 = cluster.create_datanode(
-        "/tmp/multinode_alternate_primary_failures/node2"
+        "/tmp/multi_alternate_primary_failures/node2"
     )
     node2.create()
     node2.run()
@@ -63,7 +63,7 @@ def test_002_002_add_two_standbys():
     global node3
 
     node3 = cluster.create_datanode(
-        "/tmp/multinode_alternate_primary_failures/node3"
+        "/tmp/multi_alternate_primary_failures/node3"
     )
     node3.create()
     node3.run()

--- a/tests/test_multinode_alternate_primary_failures.py
+++ b/tests/test_multinode_alternate_primary_failures.py
@@ -22,22 +22,29 @@ def teardown_module():
 
 def test_000_create_monitor():
     global monitor
-    monitor = cluster.create_monitor("/tmp/multinode_alternate_primary_failures/monitor")
+    monitor = cluster.create_monitor(
+        "/tmp/multinode_alternate_primary_failures/monitor"
+    )
     monitor.run()
     monitor.wait_until_pg_is_running()
 
 
 def test_001_init_primary():
     global node1
-    node1 = cluster.create_datanode("/tmp/multinode_alternate_primary_failures/node1")
+    node1 = cluster.create_datanode(
+        "/tmp/multinode_alternate_primary_failures/node1"
+    )
     node1.create()
     node1.run()
     assert node1.wait_until_state(target_state="single")
 
+
 def test_002_001_add_two_standbys():
     global node2
 
-    node2 = cluster.create_datanode("/tmp/multinode_alternate_primary_failures/node2")
+    node2 = cluster.create_datanode(
+        "/tmp/multinode_alternate_primary_failures/node2"
+    )
     node2.create()
     node2.run()
 
@@ -55,7 +62,9 @@ def test_002_001_add_two_standbys():
 def test_002_002_add_two_standbys():
     global node3
 
-    node3 = cluster.create_datanode("/tmp/multinode_alternate_primary_failures/node3")
+    node3 = cluster.create_datanode(
+        "/tmp/multinode_alternate_primary_failures/node3"
+    )
     node3.create()
     node3.run()
 
@@ -81,6 +90,7 @@ def test_003_001_stop_primary():
     assert node1.wait_until_assigned_state(target_state="demoted")
     assert node2.wait_until_state(target_state="primary")
 
+
 def test_003_002_stop_primary():
     # verify that node2 is primary and stop it
     assert node2.get_state().assigned == "primary"
@@ -90,6 +100,7 @@ def test_003_002_stop_primary():
     assert node2.wait_until_assigned_state(target_state="demoted")
     assert node3.wait_until_state(target_state="wait_primary")
 
+
 def test_004_001_bringup_last_failed_primary():
     # Restart node2
     node2.run()
@@ -98,6 +109,7 @@ def test_004_001_bringup_last_failed_primary():
     # Now node 2 should become secondary
     assert node2.wait_until_state(target_state="secondary")
     assert node3.wait_until_state(target_state="primary")
+
 
 def test_004_002_bringup_last_failed_primary():
     # Restart node1
@@ -113,6 +125,7 @@ def test_004_002_bringup_last_failed_primary():
     assert node2.has_needed_replication_slots()
     assert node3.has_needed_replication_slots()
 
+
 def test_005_001_fail_primary_again():
     # verify that node3 is primary and stop it
     assert node3.get_state().assigned == "primary"
@@ -120,6 +133,7 @@ def test_005_001_fail_primary_again():
 
     assert node3.wait_until_assigned_state(target_state="demoted")
     assert node1.wait_until_assigned_state(target_state="primary")
+
 
 def test_005_002_fail_primary_again():
     # verify that node3 is primary and stop it
@@ -129,6 +143,7 @@ def test_005_002_fail_primary_again():
     assert node1.wait_until_assigned_state(target_state="demoted")
     assert node2.wait_until_assigned_state(target_state="wait_primary")
 
+
 def test_007_001_bring_up_first_failed_primary():
     # Restart node3
     node3.run()
@@ -137,6 +152,7 @@ def test_007_001_bring_up_first_failed_primary():
     # Now node 3 should become secondary
     assert node3.wait_until_state(target_state="secondary")
     assert node2.wait_until_state(target_state="primary")
+
 
 def test_007_002_bring_up_first_failed_primary():
     # Restart node1

--- a/tests/test_multinode_alternate_primary_failures.py
+++ b/tests/test_multinode_alternate_primary_failures.py
@@ -136,7 +136,7 @@ def test_005_001_fail_primary_again():
 
 
 def test_005_002_fail_primary_again():
-    # verify that node3 is primary and stop it
+    # verify that node1 is primary and stop it
     assert node1.get_state().assigned == "primary"
     node1.fail()
 

--- a/tests/test_multinode_alternate_primary_failures.py
+++ b/tests/test_multinode_alternate_primary_failures.py
@@ -1,0 +1,149 @@
+import pgautofailover_utils as pgautofailover
+from nose.tools import raises, eq_
+import time
+
+import os.path
+
+cluster = None
+monitor = None
+node1 = None
+node2 = None
+node3 = None
+
+
+def setup_module():
+    global cluster
+    cluster = pgautofailover.Cluster()
+
+
+def teardown_module():
+    cluster.destroy()
+
+
+def test_000_create_monitor():
+    global monitor
+    monitor = cluster.create_monitor("/tmp/multinode_alternate_primary_failures/monitor")
+    monitor.run()
+    monitor.wait_until_pg_is_running()
+
+
+def test_001_init_primary():
+    global node1
+    node1 = cluster.create_datanode("/tmp/multinode_alternate_primary_failures/node1")
+    node1.create()
+    node1.run()
+    assert node1.wait_until_state(target_state="single")
+
+def test_002_001_add_two_standbys():
+    global node2
+
+    node2 = cluster.create_datanode("/tmp/multinode_alternate_primary_failures/node2")
+    node2.create()
+    node2.run()
+
+    node2.wait_until_pg_is_running()
+
+    assert node2.wait_until_state(target_state="secondary")
+
+    assert node1.has_needed_replication_slots()
+    assert node2.has_needed_replication_slots()
+
+    # with one standby, we have number_sync_standbys set to 0 still
+    assert node1.get_number_sync_standbys() == 0
+
+
+def test_002_002_add_two_standbys():
+    global node3
+
+    node3 = cluster.create_datanode("/tmp/multinode_alternate_primary_failures/node3")
+    node3.create()
+    node3.run()
+
+    node3.wait_until_pg_is_running()
+
+    assert node3.wait_until_state(target_state="secondary")
+    assert node1.wait_until_state(target_state="primary")
+
+    assert node1.has_needed_replication_slots()
+    assert node2.has_needed_replication_slots()
+    assert node3.has_needed_replication_slots()
+
+    # with two standbys, we have number_sync_standbys set to 1
+    assert node1.get_number_sync_standbys() == 1
+
+
+def test_003_001_stop_primary():
+    # verify that node1 is primary and stop it
+    assert node1.get_state().assigned == "primary"
+    node1.fail()
+
+    # wait for node2 to become the new primary
+    assert node1.wait_until_assigned_state(target_state="demoted")
+    assert node2.wait_until_state(target_state="primary")
+
+def test_003_002_stop_primary():
+    # verify that node2 is primary and stop it
+    assert node2.get_state().assigned == "primary"
+    node2.fail()
+
+    # wait for node3 to become the new write node
+    assert node2.wait_until_assigned_state(target_state="demoted")
+    assert node3.wait_until_state(target_state="wait_primary")
+
+def test_004_001_bringup_last_failed_primary():
+    # Restart node2
+    node2.run()
+    node2.wait_until_pg_is_running()
+
+    # Now node 2 should become secondary
+    assert node2.wait_until_state(target_state="secondary")
+    assert node3.wait_until_state(target_state="primary")
+
+def test_004_002_bringup_last_failed_primary():
+    # Restart node1
+    node1.run()
+    node3.wait_until_pg_is_running()
+
+    # Now node 1 should become secondary
+    assert node1.wait_until_state(target_state="secondary")
+    assert node2.get_state().assigned == "secondary"
+    assert node3.get_state().assigned == "primary"
+
+    assert node1.has_needed_replication_slots()
+    assert node2.has_needed_replication_slots()
+    assert node3.has_needed_replication_slots()
+
+def test_005_001_fail_primary_again():
+    # verify that node3 is primary and stop it
+    assert node3.get_state().assigned == "primary"
+    node3.fail()
+
+    assert node3.wait_until_assigned_state(target_state="demoted")
+    assert node1.wait_until_assigned_state(target_state="primary")
+
+def test_005_002_fail_primary_again():
+    # verify that node3 is primary and stop it
+    assert node1.get_state().assigned == "primary"
+    node1.fail()
+
+    assert node1.wait_until_assigned_state(target_state="demoted")
+    assert node2.wait_until_assigned_state(target_state="wait_primary")
+
+def test_007_001_bring_up_first_failed_primary():
+    # Restart node3
+    node3.run()
+    node3.wait_until_pg_is_running()
+
+    # Now node 3 should become secondary
+    assert node3.wait_until_state(target_state="secondary")
+    assert node2.wait_until_state(target_state="primary")
+
+def test_007_002_bring_up_first_failed_primary():
+    # Restart node1
+    node1.run()
+    node1.wait_until_pg_is_running()
+
+    # Now node 3 should become secondary
+    assert node1.wait_until_state(target_state="secondary")
+    assert node3.get_state().assigned == "secondary"
+    assert node2.get_state().assigned == "primary"


### PR DESCRIPTION
Assume that there exists a healthy three datanode cluster having datanodes named
node1, node2, node3. Assume that node1 is the primary and it fails. The cluster
will correctly demote node1 and promote node2 to primary. When node2 fails, the
cluster would fail to reach a stable state due to node2 getting stuck in
draining state.

The culrpit is GetPrimaryOrDemotedNodeInGroup which contains logic to try to
find a demoted primary in case that a healty primary is not existing. To do
that, it traverses an ordered by name list of nodes in the group. When it finds
the first node that is either a demoted or draining or taken out for
maintainance primary, it chooses it and stops looking further. In the example
above, note that the ordered by name list starts with node1, which would satisfy
the criterion and node2 will never be selected.

To fix that, continue looping through the nodes. Assuming that there can be only
one primary active at any time, hence only one primary that is currently going
through demotion process, then choose that one.

Add a specific test case for it.

Fixes issue #704