### PR TITLE
Fix how many nodes need to report their LSN to perform a failover.

### DIFF
--- a/src/bin/pg_autoctl/fsm.c
+++ b/src/bin/pg_autoctl/fsm.c
@@ -241,6 +241,11 @@ KeeperFSMTransition KeeperFSM[] = {
 	{ DEMOTE_TIMEOUT_STATE, DEMOTED_STATE, COMMENT_DEMOTE_TIMEOUT_TO_DEMOTED,  &fsm_stop_postgres},
 
 	/*
+	 * wait_primary stops reporting, is (supposed) dead now
+	 */
+	{ WAIT_PRIMARY_STATE, DEMOTED_STATE, COMMENT_PRIMARY_TO_DEMOTED, &fsm_stop_postgres },
+
+	/*
 	 * was demoted after a failure, but standby was forcibly removed
 	 */
 	{ DEMOTED_STATE, SINGLE_STATE, COMMENT_DEMOTED_TO_SINGLE, &fsm_resume_as_primary },

--- a/src/bin/pg_autoctl/fsm.c
+++ b/src/bin/pg_autoctl/fsm.c
@@ -144,6 +144,12 @@
 #define COMMENT_SECONDARY_TO_REPORT_LSN \
 	"Reporting the last write-ahead log location received"
 
+#define COMMENT_DRAINING_TO_REPORT_LSN \
+	"Reporting the last write-ahead log location after draining"
+
+#define COMMENT_DEMOTED_TO_REPORT_LSN \
+	"Reporting the last write-ahead log location after being demoted"
+
 #define COMMENT_REPORT_LSN_TO_PREP_PROMOTION \
 	"Stop traffic to primary, " \
 	"wait for it to finish draining."
@@ -350,6 +356,13 @@ KeeperFSMTransition KeeperFSM[] = {
 	{ REPORT_LSN_STATE, JOIN_SECONDARY_STATE, COMMENT_REPORT_LSN_TO_JOIN_SECONDARY, &fsm_checkpoint_and_stop_postgres },
 	{ REPORT_LSN_STATE, SECONDARY_STATE, COMMENT_REPORT_LSN_TO_JOIN_SECONDARY, &fsm_follow_new_primary },
 	{ JOIN_SECONDARY_STATE, SECONDARY_STATE, COMMENT_JOIN_SECONDARY_TO_SECONDARY, &fsm_follow_new_primary },
+
+	/*
+	 * When an old primary gets back online and reaches draining/draining, if a
+	 * failover is on-going then have it join the selection process.
+	 */
+	{ DRAINING_STATE, REPORT_LSN_STATE, COMMENT_DRAINING_TO_REPORT_LSN, &fsm_report_lsn },
+	{ DEMOTED_STATE, REPORT_LSN_STATE, COMMENT_DEMOTED_TO_REPORT_LSN, &fsm_report_lsn },
 
 	/*
 	 * When adding a new node and there is no primary, but there are existing

--- a/src/monitor/group_state_machine.c
+++ b/src/monitor/group_state_machine.c
@@ -1285,10 +1285,10 @@ ProceedGroupStateForMSFailover(AutoFailoverNode *activeNode,
 
 		LogAndNotifyMessage(
 			message, BUFSIZE,
-			"Failover still in progress with %d candidates having reported "
-			"their LSN: %d nodes are required in the quorum to satisfy "
-			"number_sync_standbys=%d in formation \"%s\", "
-			"activeNode is " NODE_FORMAT
+			"Failover still in progress with %d candidates that participate "
+			"in the quorum having reported their LSN: %d nodes are required "
+			"in the quorum to satisfy number_sync_standbys=%d in "
+			"formation \"%s\", activeNode is " NODE_FORMAT
 			" and reported state \"%s\"",
 			candidateList.quorumCandidateCount,
 			minCandidates,

--- a/src/monitor/group_state_machine.c
+++ b/src/monitor/group_state_machine.c
@@ -1282,7 +1282,7 @@ ProceedGroupStateForMSFailover(AutoFailoverNode *activeNode,
 			message, BUFSIZE,
 			"Failover still in progress with %d candidates having reported "
 			"their LSN: %d nodes are required in the quorum to satisfy "
-			"number_sync_standbys = %d in formation \"%s\", "
+			"number_sync_standbys=%d in formation \"%s\", "
 			"activeNode is " NODE_FORMAT
 			" and reported state \"%s\"",
 			candidateList.candidateCount,
@@ -1483,8 +1483,7 @@ BuildCandidateList(List *nodesGroupList, CandidateList *candidateList)
 		 */
 		if ((IsStateIn(node->reportedState, secondaryStates) &&
 			 IsStateIn(node->goalState, secondaryStates)) ||
-			(((IsCurrentState(node, REPLICATION_STATE_DRAINING) &&
-			   IsDrainTimeExpired(node)) ||
+			((IsCurrentState(node, REPLICATION_STATE_DRAINING) ||
 			  IsCurrentState(node, REPLICATION_STATE_DEMOTED))))
 		{
 			char message[BUFSIZE] = { 0 };
@@ -2005,11 +2004,8 @@ IsDrainTimeExpired(AutoFailoverNode *pgAutoFailoverNode)
 {
 	bool drainTimeExpired = false;
 
-	List *drainingStates = list_make2_int(REPLICATION_STATE_DEMOTE_TIMEOUT,
-										  REPLICATION_STATE_DRAINING);
-
 	if (pgAutoFailoverNode == NULL ||
-		!IsStateIn(pgAutoFailoverNode->goalState, drainingStates))
+		pgAutoFailoverNode->goalState != REPLICATION_STATE_DEMOTE_TIMEOUT)
 	{
 		return false;
 	}

--- a/src/monitor/group_state_machine.c
+++ b/src/monitor/group_state_machine.c
@@ -1384,9 +1384,10 @@ BuildCandidateList(List *nodesGroupList, CandidateList *candidateList)
 			 * LSN, then it's not "missing": we have its LSN and are able to
 			 * continue with the election mechanism.
 			 *
-			 * Otherwise, we didn't get its LSN and this node might be the most
-			 * advanced LSN. Picking it now might lead to loosing commited data
-			 * that was reported to the client connection.
+			 * Otherwise, we didn't get its LSN and this node might be (one of)
+			 * the most advanced LSN. Picking it now might lead to loosing
+			 * commited data that was reported to the client connection, if
+			 * this node is the only one with the most advanted LSN.
 			 *
 			 * Only the nodes that participate in the quorum are required to
 			 * report their LSN, because only those nodes are waited by
@@ -1434,8 +1435,7 @@ BuildCandidateList(List *nodesGroupList, CandidateList *candidateList)
 
 		/*
 		 * Nodes in SECONDARY or CATCHINGUP states are candidates due to report
-		 * their LSN. Previous primary nodes that come back up online and just
-		 * reached DRAINING now are due to report their LSN too.
+		 * their LSN.
 		 */
 		if (IsStateIn(node->reportedState, secondaryStates) &&
 			IsStateIn(node->goalState, secondaryStates))

--- a/src/monitor/node_metadata.c
+++ b/src/monitor/node_metadata.c
@@ -1208,7 +1208,8 @@ ReportAutoFailoverNodeState(char *nodeHost, int nodePort,
 		"reportedpgisrunning = $2, reportedrepstate = $3, "
 		"reportedlsn = CASE $4 WHEN '0/0'::pg_lsn THEN reportedlsn ELSE $4 END, "
 		"walreporttime = CASE $4 WHEN '0/0'::pg_lsn THEN walreporttime ELSE now() END, "
-		"statechangetime = now() WHERE nodehost = $5 AND nodeport = $6";
+		"statechangetime = CASE WHEN reportedstate <> $1 THEN now() ELSE statechangetime END "
+		"WHERE nodehost = $5 AND nodeport = $6";
 
 	SPI_connect();
 

--- a/src/monitor/node_metadata.c
+++ b/src/monitor/node_metadata.c
@@ -1552,7 +1552,7 @@ bool
 IsBeingDemotedPrimary(AutoFailoverNode *node)
 {
 	return node != NULL &&
-		   (node->reportedState == REPLICATION_STATE_PRIMARY &&
+		   (StateBelongsToPrimary(node->reportedState) &&
 			(node->goalState == REPLICATION_STATE_DRAINING ||
 			 node->goalState == REPLICATION_STATE_DEMOTE_TIMEOUT ||
 			 node->goalState == REPLICATION_STATE_PREPARE_MAINTENANCE));
@@ -1567,8 +1567,9 @@ bool
 IsDemotedPrimary(AutoFailoverNode *node)
 {
 	return node != NULL &&
-		   (node->reportedState == REPLICATION_STATE_PRIMARY &&
-			node->goalState == REPLICATION_STATE_DEMOTED);
+		   (node->goalState == REPLICATION_STATE_DEMOTED &&
+			(StateBelongsToPrimary(node->reportedState) ||
+			 node->reportedState == REPLICATION_STATE_DEMOTED));
 }
 
 

--- a/tests/test_multi_alternate_primary_failures.py
+++ b/tests/test_multi_alternate_primary_failures.py
@@ -101,6 +101,10 @@ def test_003_002_stop_primary():
     assert node2.wait_until_assigned_state(target_state="draining")
     assert node3.wait_until_state(target_state="report_lsn")
 
+    # check that node3 stays at report_lsn and doesn't go to wait_primary
+    node3.sleep(5)
+    assert node3.wait_until_state(target_state="report_lsn")
+
 
 def test_004_001_bringup_last_failed_primary():
     # Restart node2

--- a/tests/test_multi_alternate_primary_failures.py
+++ b/tests/test_multi_alternate_primary_failures.py
@@ -110,9 +110,9 @@ def test_004_001_bringup_last_failed_primary():
     # Restart node2
     node2.run()
 
-    # Now node 2 should become secondary
-    assert node2.wait_until_state(target_state="secondary")
-    assert node3.wait_until_state(target_state="primary")
+    # Now node 2 should become primary
+    assert node2.wait_until_state(target_state="primary")
+    assert node3.wait_until_state(target_state="secondary")
 
 
 def test_004_002_bringup_last_failed_primary():
@@ -122,8 +122,8 @@ def test_004_002_bringup_last_failed_primary():
 
     # Now node 1 should become secondary
     assert node1.wait_until_state(target_state="secondary")
-    assert node2.get_state().assigned == "secondary"
-    assert node3.get_state().assigned == "primary"
+    assert node2.get_state().assigned == "primary"
+    assert node3.get_state().assigned == "secondary"
 
     assert node1.has_needed_replication_slots()
     assert node2.has_needed_replication_slots()
@@ -131,17 +131,17 @@ def test_004_002_bringup_last_failed_primary():
 
 
 def test_005_001_fail_primary_again():
-    # verify that node3 is primary and stop it
-    assert node3.get_state().assigned == "primary"
-    node3.fail()
+    # verify that node2 is primary and stop it
+    assert node2.get_state().assigned == "primary"
+    node2.fail()
 
-    assert node3.wait_until_assigned_state(
+    assert node2.wait_until_assigned_state(
         target_state="demote_timeout", timeout=120
     )
-    assert node3.wait_until_assigned_state(target_state="demoted", timeout=120)
+    assert node2.wait_until_assigned_state(target_state="demoted", timeout=120)
     assert node1.wait_until_assigned_state(target_state="primary", timeout=120)
     assert node1.wait_until_state(target_state="primary", timeout=120)
-    assert node2.wait_until_state(target_state="secondary", timeout=120)
+    assert node3.wait_until_state(target_state="secondary", timeout=120)
 
 
 def test_005_002_fail_primary_again():
@@ -149,23 +149,18 @@ def test_005_002_fail_primary_again():
     assert node1.get_state().assigned == "primary"
     node1.fail()
 
-    assert node1.wait_until_assigned_state(
-        target_state="demote_timeout", timeout=120
-    )
-    assert node1.wait_until_assigned_state(target_state="demoted", timeout=120)
-    assert node2.wait_until_assigned_state(
-        target_state="wait_primary", timeout=120
-    )
+    assert node1.wait_until_assigned_state(target_state="draining")
+    assert node3.wait_until_assigned_state(target_state="report_lsn")
 
 
 def test_006_001_bring_up_first_failed_primary():
-    # Restart node3
-    node3.run()
-    node3.wait_until_pg_is_running()
+    # Restart node2
+    node2.run()
+    assert node2.wait_until_state(target_state="demoted")
 
-    # Now node 3 should become secondary
-    assert node3.wait_until_state(target_state="secondary")
-    assert node2.wait_until_state(target_state="primary")
+    # Now node 2 should become secondary
+    assert node2.wait_until_state(target_state="secondary")
+    assert node3.wait_until_state(target_state="primary")
 
 
 def test_006_002_bring_up_first_failed_primary():
@@ -175,5 +170,5 @@ def test_006_002_bring_up_first_failed_primary():
 
     # Now node 3 should become secondary
     assert node1.wait_until_state(target_state="secondary")
-    assert node3.get_state().assigned == "secondary"
-    assert node2.get_state().assigned == "primary"
+    assert node3.get_state().assigned == "primary"
+    assert node2.get_state().assigned == "secondary"

--- a/tests/test_multi_alternate_primary_failures.py
+++ b/tests/test_multi_alternate_primary_failures.py
@@ -97,15 +97,14 @@ def test_003_002_stop_primary():
     assert node2.get_state().assigned == "primary"
     node2.fail()
 
-    # wait for node3 to become the new write node
-    assert node2.wait_until_assigned_state(target_state="demoted")
-    assert node3.wait_until_state(target_state="wait_primary")
+    # node3 can't be promoted when it's the only one reporting its LSN
+    assert node2.wait_until_assigned_state(target_state="draining")
+    assert node3.wait_until_state(target_state="report_lsn")
 
 
 def test_004_001_bringup_last_failed_primary():
     # Restart node2
     node2.run()
-    node2.wait_until_pg_is_running()
 
     # Now node 2 should become secondary
     assert node2.wait_until_state(target_state="secondary")

--- a/tests/test_multi_async.py
+++ b/tests/test_multi_async.py
@@ -214,31 +214,35 @@ def test_013_drop_node4():
     assert node2.wait_until_state(target_state="secondary")
     assert node3.wait_until_state(target_state="secondary")
 
+    # we have only one standby participating in the quorum now
+    eq_(node1.get_number_sync_standbys(), 0)
+
 
 #
 # A series of test where we fail primary and candidate secondary node and
 # all is left is a secondary that is not a candidate for failover.
 #
-# In the first series 014_0xx the demoted primary comes back first and can't
-# be chosen as a new primary because it might have missed some transactions.
+# In the first series 014_0xx the demoted primary comes back first and needs
+# to fetch missing LSNs from node3 because it might have missed some
+# transactions.
 #
-#   node1     node2        node3
-#   primary   secondary    secondary
+#   node1         node2        node3
+#   primary       secondary    secondary
 #   <down>
-#   demoted   wait_primary secondary
-#             <down>
-#   demoted   demoted      report_lsn
+#   demoted       wait_primary secondary
+#                 <down>
+#   demoted       demoted      report_lsn
 #   <up>
-#   demoted   demoted      report_lsn
-#             <up>
-#   secondary primary      secondary
+#   wait_primary  demoted      secondary   (fast_forward → primary)
+#                 <up>
+#   primary       secondary    secondary
 #
 def test_014_001_fail_node1():
     node1.fail()
 
     # first we have a 30s timeout for the monitor to decide that node1 is
     # down; then we have another 30s timeout at stop_replication waiting for
-    # demote_timout, so let's give it 120s there and step in the middle first
+    # demote_timeout, so let's give it 120s there and step in the middle first
     assert node2.wait_until_state(target_state="stop_replication", timeout=120)
     assert node2.wait_until_state(target_state="wait_primary", timeout=120)
     assert node3.wait_until_state(target_state="secondary")
@@ -257,24 +261,20 @@ def test_014_003_restart_node1():
     node1.run()
 
     # node1 used to be primary, now demoted, and meanwhile node2 was primary
-    # so we can't decide to promote node1 now, it's stuck demoted
-    assert node1.wait_until_state(target_state="demoted")
-    assert node3.wait_until_state(target_state="report_lsn")
-
-    # ensure that node1 stays demoted
-    time.sleep(5)
-    assert node1.wait_until_state(target_state="demoted")
+    # node1 is assigned report_lsn and then is selected (only node with
+    # candidate priority > 0) ; and thus needs to go through fast_forward
+    assert node1.wait_until_state(target_state="fast_forward")
+    assert node1.wait_until_state(target_state="stop_replication")
+    assert node1.wait_until_state(target_state="wait_primary")
+    assert node3.wait_until_state(target_state="secondary")
 
 
 def test_014_004_restart_node2():
     node2.run()
 
-    assert node2.wait_until_state(target_state="wait_primary")
-
+    assert node2.wait_until_state(target_state="secondary")
     assert node3.wait_until_state(target_state="secondary")
-    assert node1.wait_until_state(target_state="secondary")
-
-    assert node2.wait_until_state(target_state="primary")
+    assert node1.wait_until_state(target_state="primary")
 
 
 #
@@ -282,6 +282,18 @@ def test_014_004_restart_node2():
 # nodes, first the new primary and then very old primary.
 #
 #   node1        node2        node3
+#   primary      secondary    secondary
+#   <down>
+#   demoted      wait_primary secondary
+#                <down>
+#   demoted      demoted      report_lsn
+#                <up>
+#   demoted      wait_primary secondary
+#   <up>
+#   secondary    primary      secondary
+#
+#   ~~~
+#
 #   secondary    primary      secondary
 #                <down>
 #   wait_primary demoted      secondary
@@ -292,43 +304,43 @@ def test_014_004_restart_node2():
 #                <up>
 #   primary      secondary    secondary
 #
-def test_015_001_fail_node2():
-    node2.fail()
+def test_015_001_fail_primary_node1():
+    node1.fail()
 
     # first we have a 30s timeout for the monitor to decide that node1 is
     # down; then we have another 30s timeout at stop_replication waiting for
     # demote_timout, so let's give it 120s there
-    assert node1.wait_until_state(target_state="wait_primary", timeout=120)
+    assert node2.wait_until_state(target_state="wait_primary", timeout=120)
     assert node3.wait_until_state(target_state="secondary")
 
-    node1.check_synchronous_standby_names(ssn="")
+    node2.check_synchronous_standby_names(ssn="")
 
 
-def test_015_002_stop_new_primary_node1():
-    node1.fail()
+def test_015_002_fail_new_primary_node2():
+    node2.fail()
 
     print()
     assert node3.wait_until_state(target_state="report_lsn")
 
 
-def test_015_003_restart_node1():
-    node1.run()
+def test_015_003_restart_node2():
+    node2.run()
 
     # restart the previous primary, it re-joins as a (wannabe) primary
     # because the only secondary has candidatePriority = 0, it's wait_primary
-    assert node1.wait_until_state(target_state="wait_primary")
+    assert node2.wait_until_state(target_state="wait_primary")
     assert node3.wait_until_state(target_state="secondary")
 
     time.sleep(5)
-    assert not node1.get_state().assigned == "primary"
+    assert not node2.get_state().assigned == "primary"
 
 
-def test_015_004_restart_node2():
-    node2.run()
+def test_015_004_restart_node1():
+    node1.run()
 
     assert node3.wait_until_state(target_state="secondary")
-    assert node2.wait_until_state(target_state="secondary")
-    assert node1.wait_until_state(target_state="primary")
+    assert node2.wait_until_state(target_state="primary")
+    assert node1.wait_until_state(target_state="secondary")
 
 
 #
@@ -341,37 +353,37 @@ def test_016_001_fail_node3():
     assert node3.wait_until_assigned_state(target_state="catchingup")
 
 
-def test_016_002_fail_node2():
-    node2.fail()
-    assert node1.wait_until_state(target_state="wait_primary")
+def test_016_002_fail_node1():
+    node1.fail()
+    assert node2.wait_until_state(target_state="wait_primary")
 
 
 def test_016_003_restart_node3():
     node3.run()
 
     assert node3.wait_until_assigned_state(target_state="secondary")
-    assert node1.wait_until_state(target_state="wait_primary")
+    assert node2.wait_until_state(target_state="wait_primary")
 
     time.sleep(5)
-    assert not node1.get_state().assigned == "primary"
+    assert not node2.get_state().assigned == "primary"
 
 
-def test_016_004_restart_node2():
-    node2.run()
+def test_016_004_restart_node1():
+    node1.run()
 
     assert node3.wait_until_state(target_state="secondary")
-    assert node2.wait_until_state(target_state="secondary")
-    assert node1.wait_until_state(target_state="primary")
+    assert node2.wait_until_state(target_state="primary")
+    assert node1.wait_until_state(target_state="secondary")
 
 
 #
 # When a node with candidate-priority zero (here, node3) fails while the
-# primary node (here, node1) is already in wait_primary, the non-candidate
+# primary node (here, node2) is already in wait_primary, the non-candidate
 # node (here, node3) should still be assigned catchingup.
 #
-def test_017_001_fail_node2():
-    node2.fail()
-    assert node1.wait_until_state(target_state="wait_primary")
+def test_017_001_fail_node1():
+    node1.fail()
+    assert node2.wait_until_state(target_state="wait_primary")
 
 
 def test_017_002_fail_node3():
@@ -381,8 +393,8 @@ def test_017_002_fail_node3():
 
 def test_017_003_restart_nodes():
     node3.run()
-    node2.run()
+    node1.run()
 
     assert node3.wait_until_state(target_state="secondary")
-    assert node2.wait_until_state(target_state="secondary")
-    assert node1.wait_until_state(target_state="primary")
+    assert node2.wait_until_state(target_state="primary")
+    assert node1.wait_until_state(target_state="secondary")

--- a/tests/test_multi_async.py
+++ b/tests/test_multi_async.py
@@ -292,18 +292,6 @@ def test_014_004_restart_node2():
 #   <up>
 #   secondary    primary      secondary
 #
-#   ~~~
-#
-#   secondary    primary      secondary
-#                <down>
-#   wait_primary demoted      secondary
-#   <down>
-#   demoted      demoted      report_lsn
-#   <up>
-#   wait_primary demoted      secondary
-#                <up>
-#   primary      secondary    secondary
-#
 def test_015_001_fail_primary_node1():
     node1.fail()
 

--- a/tests/test_multi_maintenance.py
+++ b/tests/test_multi_maintenance.py
@@ -96,7 +96,7 @@ def test_005_set_candidate_priorities():
     assert node1.wait_until_state(target_state="primary")
 
     # set priorities in a way that we know the candidate: node3
-    node1.set_candidate_priority(90)  # current primary
+    node1.set_candidate_priority(80)  # current primary
     node2.set_candidate_priority(70)  # remain secondary
     node3.set_candidate_priority(90)  # favorite for failover
 

--- a/tests/test_multi_standbys.py
+++ b/tests/test_multi_standbys.py
@@ -189,7 +189,7 @@ def test_007_create_t1():
 
 def test_008_set_candidate_priorities():
     # set priorities in a way that we know the candidate: node2
-    node1.set_candidate_priority(90)  # current primary
+    node1.set_candidate_priority(80)  # current primary
     node2.set_candidate_priority(90)
     node3.set_candidate_priority(70)
 
@@ -234,6 +234,8 @@ def test_012_fail_primary():
     print("Failing current primary node 2")
     node2.fail()
 
+    # explicitely allow for the 30s timeout in stop_replication
+    assert node1.wait_until_state(target_state="stop_replication")
     assert node1.wait_until_state(target_state="primary")
     assert node3.wait_until_state(target_state="secondary")
 
@@ -380,7 +382,7 @@ def test_016_002_trigger_failover():
 
     assert node3.wait_until_state(target_state="report_lsn")
     assert node2.wait_until_state(target_state="report_lsn")
-    assert node1.wait_until_state(target_state="draining")
+    assert node1.wait_until_state(target_state="report_lsn")
 
 
 def test_016_003_set_candidate_priority_to_one():


### PR DESCRIPTION
With this patch we make sure that all the nodes that participage in the
quorum have reported their LSN before we select a candidate for failover.
Otherwise, we might lose committed data.

Fixes #682 