### PR TITLE
Minor tweaks during the registration of healthcheck workers

### DIFF
--- a/src/monitor/health_check_worker.c
+++ b/src/monitor/health_check_worker.c
@@ -393,9 +393,9 @@ RegisterHealthCheckWorker(DatabaseListEntry *db)
 {
 	BackgroundWorker worker;
 	BackgroundWorkerHandle *handle;
-	StringInfo buf = NULL;
+	StringInfoData buf;
 
-	initStringInfo(buf);
+	initStringInfo(&buf);
 
 	memset(&worker, 0, sizeof(worker));
 
@@ -409,11 +409,10 @@ RegisterHealthCheckWorker(DatabaseListEntry *db)
 			sizeof(worker.bgw_library_name));
 	strlcpy(worker.bgw_function_name, "HealthCheckWorkerMain",
 			sizeof(worker.bgw_function_name));
-	appendStringInfo(buf, "pg_auto_failover monitor healthcheck worker %s",
+	appendStringInfo(&buf, "pg_auto_failover monitor healthcheck worker %s",
 					 db->dbname);
-	strlcpy(worker.bgw_name, buf->data,
+	strlcpy(worker.bgw_name, buf.data,
 			sizeof(worker.bgw_name));
-	free(buf->data);
 
 	if (!RegisterDynamicBackgroundWorker(&worker, &handle))
 	{

--- a/src/monitor/health_check_worker.c
+++ b/src/monitor/health_check_worker.c
@@ -384,8 +384,8 @@ RegisterHealthCheckWorker(DatabaseListEntry *db)
 		ereport(WARNING,
 				(errmsg(
 					 "failed to start worker for pg_auto_failover health checks in \"%s\"",
-					 db->dbname)),
-				errhint("You might need to increase max_worker_processes."));
+					 db->dbname),
+				errhint("You might need to increase max_worker_processes.")));
 		return NULL;
 	}
 


### PR DESCRIPTION
It is possible for a dynamic background worker to fail registration. It is
unlikely, yet possible. If that happens during the monitor's launch of
healthcheck workers, the function StartHealthCheckWorker() will emmit an info
level log message saying to acknowledge the fact. Then the caller of the
function will try again to register that worker until it succeeds or the process
receives a signal to terminate. If the registration is successfull, it will note
the fact and then proceed to start the background worker. Then it will never try
again to register nor restart the worker.

The above works great in most scenarios. However there exists a corner case
where it is not optimal. Assume that a healthcheck worker for a database
receives a SIGTERM. Then the system will never try to restart it. As a
consequence the system will seize to update the health information for the nodes
of that database.

On similar lines, if a health check worker fails to register after a monitor
restart, then the system will use whatever entries where last registered in its
state and database entries. The logs will contain only a info level log line
informing of the failure to register the worker and the system will appear
otherwise healthy.

The current patch takes non intrucive steps in addressing some noticed above.

* It raises the log level of the failure to register a dynamic background worker
  from info to warn.
* It adds a hint to said message in accordance to postgres documentation and
  usage in core, e.g. logical replication launcer
* Improves clarity by renamiing StartHealthCheckWorker to
  RegisterHealthCheckWorker since the function is responsible for registering
  said worker and we do not, nor can we know that the worker has actually
  started.
* Updates the process name of the worker to include that it is a healthcheck
  worker of a named database
* Adds a check that the process has actually started after registration and only
  then proceeds to mark it as active
* Adds a comment in the relevant part to explain the above
* Adds a checking mechanism in the loop and detects if an already registered and
  started background worker is still running. If not it emmits a warn level
  message and tries to register it again.

The above do not address all the problems mentioned, notably updating the health
information of the nodes after N amount of failures to register/start. However
it is believed that this is a sufficient first step to a `right direction.