### PR TITLE
Tests: Do not attempt to destroy an already destroyed node/monitor in…

### DIFF
--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -1128,6 +1128,13 @@ class DataNode(PGNode):
         except FileNotFoundError:
             pass
 
+        # Remove self from the cluster if present so that future calls to
+        # cluster.destroy() will not emit errors for the already destroyed node
+        try:
+            self.cluster.datanodes.remove(self)
+        except ValueError:
+            pass
+
     def wait_until_state(
         self,
         target_state,
@@ -1705,6 +1712,10 @@ class MonitorNode(PGNode):
             os.remove(self.state_file_path())
         except FileNotFoundError:
             pass
+
+        # Set self to None in cluster to avoid errors in future calls to
+        # cluster.destroy()
+        self.cluster.monitor = None
 
     def create_formation(
         self, formation_name, kind="pgsql", secondary=None, dbname=None


### PR DESCRIPTION
… cluster

Calls to node.destroy() in test suites will remove the configuration files of
that node. However, the cluster will still keep track of that node and will try
to destroy it again during cleanup of the suite. To do so, it will call
pg_autoctl with that node as an argument. The common pg_autoctl path for common
options will then try to find the config file and upon failure, complain with a
fatal level message, similar to:
"Expected configuration file does not exists:"

The behaviour by itself is not harmful. However it is not neat to see a fatal
message in a succussefull run. It is quite confusing to see that error on an
unsuccussefull run, which in most of the cases is unrelated to the actual cause
of the error.

This commit removes a destroyed node from the cluster. In passing it treats the
monitor node similarly.


[Also mentioned here](https://github.com/citusdata/pg_auto_failover/pull/711#issuecomment-849677443)