### PR TITLE
Install btree_gist when upgrade to >= 1.4, not just 1.4.

### DIFF
--- a/src/bin/pg_autoctl/monitor.c
+++ b/src/bin/pg_autoctl/monitor.c
@@ -4054,13 +4054,22 @@ bool
 monitor_extension_update(Monitor *monitor, const char *targetVersion)
 {
 	PGSQL *pgsql = &monitor->pgsql;
+	int targetVersionNum = 0;
+
+	/* the test suite upgrades to a "dummy" version */
+	if (strcmp(targetVersion, "dummy") != 0 &&
+		!parse_pgaf_extension_version_string(targetVersion, &targetVersionNum))
+	{
+		/* errors have already been logged */
+		return false;
+	}
 
 	/*
 	 * When upgrading to version 1.4 we now require btree_gist. It does not
 	 * seem like Postgres knows how to handle changes in extension control
 	 * requires, so let's do that manually here.
 	 */
-	if (strcmp(targetVersion, "1.4") == 0)
+	if (targetVersionNum >= 104)
 	{
 		/*
 		 * Ensure "btree_gist" is available in the server extension dir used to

--- a/src/bin/pg_autoctl/parsing.c
+++ b/src/bin/pg_autoctl/parsing.c
@@ -149,11 +149,12 @@ parse_version_number(const char *version_string,
 
 
 /*
- * parse_pg_version_string parses a Postgres version string such as "12.6" into
- * a single number in the same format as the pg_control_version, such as 1206.
+ * parse_dotted_version_string parses a major.minor dotted version string such
+ * as "12.6" into a single number in the same format as the pg_control_version,
+ * such as 1206.
  */
 bool
-parse_pg_version_string(const char *pg_version_string, int *pg_version)
+parse_dotted_version_string(const char *pg_version_string, int *pg_version)
 {
 	/* now, parse the numbers into an integer, ala pg_control_version */
 	bool dotFound = false;
@@ -209,6 +210,29 @@ parse_pg_version_string(const char *pg_version_string, int *pg_version)
 	*pg_version = (maj * 100) + min;
 
 	return true;
+}
+
+
+/*
+ * parse_pg_version_string parses a Postgres version string such as "12.6" into
+ * a single number in the same format as the pg_control_version, such as 1206.
+ */
+bool
+parse_pg_version_string(const char *pg_version_string, int *pg_version)
+{
+	return parse_dotted_version_string(pg_version_string, pg_version);
+}
+
+
+/*
+ * parse_pgaf_version_string parses a pg_auto_failover version string such as
+ * "1.4" into a single number in the same format as the pg_control_version,
+ * such as 104.
+ */
+bool
+parse_pgaf_extension_version_string(const char *version_string, int *version)
+{
+	return parse_dotted_version_string(version_string, version);
 }
 
 

--- a/src/bin/pg_autoctl/parsing.h
+++ b/src/bin/pg_autoctl/parsing.h
@@ -22,7 +22,12 @@ bool parse_version_number(const char *version_string,
 						  char *pg_version_string,
 						  int *pg_version);
 
-bool parse_pg_version_string(const char *pg_version_string, int *pg_version);
+bool parse_dotted_version_string(const char *pg_version_string,
+								 int *pg_version);
+bool parse_pg_version_string(const char *pg_version_string,
+							 int *pg_version);
+bool parse_pgaf_extension_version_string(const char *version_string,
+										 int *version);
 
 bool parse_controldata(PostgresControlData *pgControlData,
 					   const char *control_data_string);

--- a/tests/test_extension_update.py
+++ b/tests/test_extension_update.py
@@ -38,6 +38,10 @@ def test_001_update_extension():
             WHERE name = 'pgautofailover'
         """
     )
+
+    if results[0][0] != "dummy":
+        cluster.monitor.print_debug_logs()
+
     eq_(results, [("dummy",)])
 
     del os.environ["PG_AUTOCTL_EXTENSION_VERSION"]


### PR DESCRIPTION
See #645.