### PR TITLE
An attempt to stabilize multi_async tests

### DIFF
--- a/tests/test_multi_alternate_primary_failures.py
+++ b/tests/test_multi_alternate_primary_failures.py
@@ -51,6 +51,7 @@ def test_002_001_add_two_standbys():
     node2.wait_until_pg_is_running()
 
     assert node2.wait_until_state(target_state="secondary")
+    assert node1.wait_until_state(target_state="primary")
 
     assert node1.has_needed_replication_slots()
     assert node2.has_needed_replication_slots()

--- a/tests/test_multi_async.py
+++ b/tests/test_multi_async.py
@@ -62,6 +62,7 @@ def test_002_add_standby():
     node2.run()
 
     assert node2.wait_until_state(target_state="secondary")
+    assert node1.wait_until_state(target_state="primary")
 
     assert node1.has_needed_replication_slots()
     assert node2.has_needed_replication_slots()

--- a/tests/test_multi_ifdown.py
+++ b/tests/test_multi_ifdown.py
@@ -44,6 +44,7 @@ def test_002_add_standby():
 
     assert node2.wait_until_pg_is_running()
     assert node2.wait_until_state(target_state="secondary")
+    assert node1.wait_until_state(target_state="primary")
 
     assert node1.has_needed_replication_slots()
     assert node2.has_needed_replication_slots()

--- a/tests/test_multi_maintenance.py
+++ b/tests/test_multi_maintenance.py
@@ -44,6 +44,7 @@ def test_002_add_standby():
     node2.run()
 
     assert node2.wait_until_state(target_state="secondary")
+    assert node1.wait_until_state(target_state="primary")
 
     assert node1.has_needed_replication_slots()
     assert node2.has_needed_replication_slots()


### PR DESCRIPTION
CI has shown some instability in multi_async tests. One trace can be seen
frequently:

```
======================================================================
ERROR: test_multi_alternate_primary_failures.test_002_001_add_two_standbys
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/python/3.7.6/lib/python3.7/site-packages/nose/case.py", line 198, in runTest
    self.test(*self.arg)
  File
"/home/travis/build/citusdata/pg_auto_failover/tests/test_multi_alternate_primary_failures.py",
line 56, in test_002_001_add_two_standbys
    assert node2.has_needed_replication_slots()
  File
"/home/travis/build/citusdata/pg_auto_failover/tests/pgautofailover_utils.py",
line 1561, in has_needed_replication_slots
    if self.pgmajor() == 10:
  File
"/home/travis/build/citusdata/pg_auto_failover/tests/pgautofailover_utils.py",
line 607, in pgmajor
    self.pgversion()
  File
"/home/travis/build/citusdata/pg_auto_failover/tests/pgautofailover_utils.py",
line 597, in pgversion
    self.run_sql_query("show server_version_num")[0][0]
  File
"/home/travis/build/citusdata/pg_auto_failover/tests/pgautofailover_utils.py",
line 368, in run_sql_query
    conn = psycopg2.connect(self.connection_string())
  File "/opt/python/3.7.6/lib/python3.7/site-packages/psycopg2/__init__.py",
line 130, in connect
    conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
psycopg2.OperationalError: could not connect to server: Connection refused
	Is the server running on host "172.27.1.4" and accepting
	TCP/IP connections on port 5432?
```

From above it seems that node2.has_needed_replication_slots() requires to check
the postgres version. To do so, the first time such a check is required, a query
is executed on that node via self.run_sql_query(). At the time of the query the
node has been assigned and reached state secondary. However the cluster is not
yet in its final state, as node1 may still have to reach primary state.

In such a case, there exists a time window that the query will be executed while
node2 is consuming the change of node1.

By changing the order of the calls in that test, to call
has_needed_replication_slots() after node1 has finished the transition and the
cluster is in its stable state, the window is eliminated.

Note that an additional and probably superfluous after at the end of the
test_002 to assert the state of primary is maintained in accordance to the
pattern seen in other tests in the same suite. (e.g. test_003_add_standby,
test_009_add_sync_standby, etc).


See discussion #719 