### PR TITLE
Allow an old primary node (demoted/catchingup) to join another election.

### DIFF
--- a/src/bin/pg_autoctl/fsm_transition.c
+++ b/src/bin/pg_autoctl/fsm_transition.c
@@ -983,10 +983,10 @@ fsm_rewind_or_init(Keeper *keeper)
 		log_error("Failed to connect to the primary node %d \"%s\" (%s:%d) "
 				  "with a replication connection string. "
 				  "See above for details",
-				  primaryNode->nodeId,
-				  primaryNode->name,
-				  primaryNode->host,
-				  primaryNode->port);
+				  upstream->primaryNode.nodeId,
+				  upstream->primaryNode.name,
+				  upstream->primaryNode.host,
+				  upstream->primaryNode.port);
 		return false;
 	}
 

--- a/tests/test_multi_alternate_primary_failures.py
+++ b/tests/test_multi_alternate_primary_failures.py
@@ -36,6 +36,7 @@ def test_001_init_primary():
     )
     node1.create()
     node1.run()
+    print()
     assert node1.wait_until_state(target_state="single")
 
 
@@ -50,6 +51,7 @@ def test_002_001_add_two_standbys():
 
     node2.wait_until_pg_is_running()
 
+    print()
     assert node2.wait_until_state(target_state="secondary")
     assert node1.wait_until_state(target_state="primary")
 
@@ -71,6 +73,7 @@ def test_002_002_add_two_standbys():
 
     node3.wait_until_pg_is_running()
 
+    print()
     assert node3.wait_until_state(target_state="secondary")
     assert node1.wait_until_state(target_state="primary")
 
@@ -82,12 +85,27 @@ def test_002_002_add_two_standbys():
     assert node1.get_number_sync_standbys() == 1
 
 
+#
+# In this test series, we have
+#
+#   node1         node2        node3
+#   primary       secondary    secondary
+#   <down>
+#   demoted       primary      secondary
+#                 <down>
+#   demoted       draining     report_lsn
+#                 <up>
+#   demoted       primary      secondary
+#   <up>
+#   secondary     primary      secondary
+#
 def test_003_001_stop_primary():
     # verify that node1 is primary and stop it
     assert node1.get_state().assigned == "primary"
     node1.fail()
 
     # wait for node2 to become the new primary
+    print()
     assert node1.wait_until_assigned_state(target_state="demoted")
     assert node2.wait_until_state(target_state="primary")
 
@@ -98,6 +116,7 @@ def test_003_002_stop_primary():
     node2.fail()
 
     # node3 can't be promoted when it's the only one reporting its LSN
+    print()
     assert node2.wait_until_assigned_state(target_state="draining")
     assert node3.wait_until_state(target_state="report_lsn")
 
@@ -106,21 +125,23 @@ def test_003_002_stop_primary():
     assert node3.wait_until_state(target_state="report_lsn")
 
 
-def test_004_001_bringup_last_failed_primary():
+def test_003_003_bringup_last_failed_primary():
     # Restart node2
     node2.run()
 
     # Now node 2 should become primary
+    print()
     assert node2.wait_until_state(target_state="primary")
     assert node3.wait_until_state(target_state="secondary")
 
 
-def test_004_002_bringup_last_failed_primary():
+def test_003_004_bringup_first_failed_primary():
     # Restart node1
     node1.run()
     node3.wait_until_pg_is_running()
 
     # Now node 1 should become secondary
+    print()
     assert node1.wait_until_state(target_state="secondary")
     assert node2.get_state().assigned == "primary"
     assert node3.get_state().assigned == "secondary"
@@ -130,11 +151,26 @@ def test_004_002_bringup_last_failed_primary():
     assert node3.has_needed_replication_slots()
 
 
+#
+# In this test series , we have
+#
+#   node1         node2        node3
+#   secondary     primary      secondary
+#                 <down>
+#   primary       demoted      secondary
+#   <down>
+#   draining      demoted      report_lsn
+#                 <up>
+#   draining      secondary    primary
+#   <up>
+#   secondary     secondary    primary
+#
 def test_005_001_fail_primary_again():
     # verify that node2 is primary and stop it
     assert node2.get_state().assigned == "primary"
     node2.fail()
 
+    print()
     assert node2.wait_until_assigned_state(
         target_state="demote_timeout", timeout=120
     )
@@ -149,13 +185,16 @@ def test_005_002_fail_primary_again():
     assert node1.get_state().assigned == "primary"
     node1.fail()
 
+    print()
     assert node1.wait_until_assigned_state(target_state="draining")
     assert node3.wait_until_assigned_state(target_state="report_lsn")
 
 
-def test_006_001_bring_up_first_failed_primary():
+def test_005_003_bring_up_first_failed_primary():
     # Restart node2
     node2.run()
+
+    print()
     assert node2.wait_until_state(target_state="demoted")
 
     # Now node 2 should become secondary
@@ -163,12 +202,13 @@ def test_006_001_bring_up_first_failed_primary():
     assert node3.wait_until_state(target_state="primary")
 
 
-def test_006_002_bring_up_first_failed_primary():
+def test_005_004_bring_up_last_failed_primary():
     # Restart node1
     node1.run()
     node1.wait_until_pg_is_running()
 
     # Now node 3 should become secondary
+    print()
     assert node1.wait_until_state(target_state="secondary")
     assert node3.get_state().assigned == "primary"
     assert node2.get_state().assigned == "secondary"


### PR DESCRIPTION
When a primary fails, then a new primary is elected, and then the new
primary fails while the old primary is assigned the CATCHINGUP state, then
we need to make it possible for the old primary to join the new election as
a REPORT_LSN node.

Fixes #725 