### PR TITLE
Track nodes current timeline on the monitor.

### DIFF
--- a/src/bin/pg_autoctl/cli_do_monitor.c
+++ b/src/bin/pg_autoctl/cli_do_monitor.c
@@ -572,6 +572,7 @@ cli_do_monitor_node_active(int argc, char **argv)
 							 keeper.state.current_group,
 							 keeper.state.current_role,
 							 keeper.postgres.pgIsRunning,
+							 keeper.postgres.postgresSetup.control.timeline_id,
 							 keeper.postgres.currentLSN,
 							 keeper.postgres.pgsrSyncState,
 							 &assignedState))

--- a/src/bin/pg_autoctl/cli_show.c
+++ b/src/bin/pg_autoctl/cli_show.c
@@ -557,6 +557,9 @@ cli_show_local_state()
 					strlcpy(nodeState.node.lsn, "0/0", PG_LSN_MAXLENGTH);
 				}
 
+				nodeState.node.tli =
+					keeper.postgres.postgresSetup.control.timeline_id;
+
 				strlcpy(nodeState.node.lsn,
 						keeper.postgres.currentLSN,
 						PG_LSN_MAXLENGTH);
@@ -569,6 +572,7 @@ cli_show_local_state()
 					/* errors have already been logged, just continue */
 				}
 
+				nodeState.node.tli = config.pgSetup.control.timeline_id;
 				strlcpy(nodeState.node.lsn,
 						config.pgSetup.control.latestCheckpointLSN,
 						PG_LSN_MAXLENGTH);

--- a/src/bin/pg_autoctl/defaults.h
+++ b/src/bin/pg_autoctl/defaults.h
@@ -14,7 +14,7 @@
 #define PG_AUTOCTL_STATE_VERSION 1
 
 /* additional version information for printing version on CLI */
-#define PG_AUTOCTL_VERSION "1.6.0.1"
+#define PG_AUTOCTL_VERSION "1.6.0.2"
 
 /* version of the extension that we requite to talk to on the monitor */
 #define PG_AUTOCTL_EXTENSION_VERSION "1.6"

--- a/src/bin/pg_autoctl/fsm.c
+++ b/src/bin/pg_autoctl/fsm.c
@@ -428,6 +428,7 @@ keeper_fsm_step(Keeper *keeper)
 							 keeperState->current_group,
 							 keeperState->current_role,
 							 postgres->pgIsRunning,
+							 postgres->postgresSetup.control.timeline_id,
 							 postgres->currentLSN,
 							 postgres->pgsrSyncState,
 							 &assignedState))

--- a/src/bin/pg_autoctl/keeper.c
+++ b/src/bin/pg_autoctl/keeper.c
@@ -1608,12 +1608,15 @@ keeper_register_again(Keeper *keeper)
 			return false;
 		}
 
+		int currentTLI = keeper->postgres.postgresSetup.control.timeline_id;
+
 		if (!monitor_node_active(monitor,
 								 config->formation,
 								 assignedState.nodeId,
 								 assignedState.groupId,
 								 assignedState.state,
 								 ReportPgIsRunning(keeper),
+								 currentTLI,
 								 keeper->postgres.currentLSN,
 								 keeper->postgres.pgsrSyncState,
 								 &assignedState))

--- a/src/bin/pg_autoctl/keeper_pg_init.c
+++ b/src/bin/pg_autoctl/keeper_pg_init.c
@@ -551,6 +551,7 @@ wait_until_primary_is_ready(Keeper *keeper,
 							MonitorAssignedState *assignedState)
 {
 	bool pgIsRunning = false;
+	int currentTLI = 1;
 	char currrentLSN[PG_LSN_MAXLENGTH] = "0/0";
 	char *pgsrSyncState = "";
 	int errors = 0, tries = 0;
@@ -593,6 +594,7 @@ wait_until_primary_is_ready(Keeper *keeper,
 								 keeper->state.current_group,
 								 keeper->state.current_role,
 								 pgIsRunning,
+								 currentTLI,
 								 currrentLSN,
 								 pgsrSyncState,
 								 assignedState))
@@ -1068,6 +1070,7 @@ keeper_pg_init_node_active(Keeper *keeper)
 							 keeper->state.current_group,
 							 keeper->state.current_role,
 							 ReportPgIsRunning(keeper),
+							 keeper->postgres.postgresSetup.control.timeline_id,
 							 keeper->postgres.currentLSN,
 							 keeper->postgres.pgsrSyncState,
 							 &assignedState))

--- a/src/bin/pg_autoctl/monitor.h
+++ b/src/bin/pg_autoctl/monitor.h
@@ -107,7 +107,7 @@ bool monitor_register_node(Monitor *monitor,
 bool monitor_node_active(Monitor *monitor,
 						 char *formation, int64_t nodeId,
 						 int groupId, NodeState currentState,
-						 bool pgIsRunning,
+						 bool pgIsRunning, int currentTLI,
 						 char *currentLSN, char *pgsrSyncState,
 						 MonitorAssignedState *assignedState);
 bool monitor_get_node_replication_settings(Monitor *monitor,

--- a/src/bin/pg_autoctl/nodestate_utils.c
+++ b/src/bin/pg_autoctl/nodestate_utils.c
@@ -29,7 +29,7 @@ nodestatePrepareHeaders(CurrentNodeStateArray *nodesArray,
 	nodesArray->headers.maxNameSize = 4;  /* "Name" */
 	nodesArray->headers.maxHostSize = 10; /* "Host:Port" */
 	nodesArray->headers.maxNodeSize = 5;  /* "Node" */
-	nodesArray->headers.maxLSNSize = 3;   /* "LSN" */
+	nodesArray->headers.maxLSNSize = 9;   /* "TLI:  LSN" */
 	nodesArray->headers.maxStateSize = MAX_NODE_STATE_LEN;
 	nodesArray->headers.maxHealthSize = strlen("read-write *");
 
@@ -117,38 +117,21 @@ void
 nodestateAdjustHeaders(NodeAddressHeaders *headers,
 					   NodeAddress *node, int groupId)
 {
+	char hostport[BUFSIZE] = { 0 };
+	char composedId[BUFSIZE] = { 0 };
+	char tliLSN[BUFSIZE] = { 0 };
+
+	(void) nodestatePrepareNode(headers,
+								node,
+								groupId,
+								hostport,
+								composedId,
+								tliLSN);
+
 	int nameLen = strlen(node->name);
-
-	/* compute strlen of host:port */
-	IntString portString = intToString(node->port);
-	int hostLen =
-		strlen(node->host) + strlen(portString.strValue) + 1;
-
-	/* compute strlen of groupId/nodeId, as in "0/1" */
-	IntString nodeIdString = intToString(node->nodeId);
-	int nodeLen = 0;
-
-	int lsnLen = strlen(node->lsn);
-
-	switch (headers->nodeKind)
-	{
-		case NODE_KIND_STANDALONE:
-		{
-			nodeLen = strlen(nodeIdString.strValue);
-			break;
-		}
-
-		default:
-		{
-			IntString groupIdString = intToString(groupId);
-
-			nodeLen =
-				strlen(groupIdString.strValue) +
-				strlen(nodeIdString.strValue) + 1;
-
-			break;
-		}
-	}
+	int hostLen = strlen(hostport);
+	int nodeLen = strlen(composedId);
+	int lsnLen = strlen(tliLSN);
 
 	/*
 	 * In order to have a static nice table output even when using
@@ -178,8 +161,8 @@ nodestateAdjustHeaders(NodeAddressHeaders *headers,
 
 	if (headers->maxLSNSize == 0)
 	{
-		/* Unknown LSN is going to be "0/0" */
-		headers->maxLSNSize = 3;
+		/* Unknown LSN is going to be "  1: 0/0" */
+		headers->maxLSNSize = 9;
 	}
 
 	if (headers->maxHealthSize == 0)
@@ -224,7 +207,7 @@ nodestatePrintHeader(NodeAddressHeaders *headers)
 			headers->maxNameSize, "Name",
 			headers->maxNodeSize, "Node",
 			headers->maxHostSize, "Host:Port",
-			headers->maxLSNSize, "LSN",
+			headers->maxLSNSize, "TLI: LSN",
 			headers->maxHealthSize, "Connection",
 			headers->maxStateSize, "Current State",
 			headers->maxStateSize, "Assigned State");
@@ -250,6 +233,7 @@ nodestatePrintNodeState(NodeAddressHeaders *headers,
 {
 	char hostport[BUFSIZE] = { 0 };
 	char composedId[BUFSIZE] = { 0 };
+	char tliLSN[BUFSIZE] = { 0 };
 	char connection[BUFSIZE] = { 0 };
 	char healthChar = nodestateHealthToChar(nodeState->health);
 
@@ -257,7 +241,8 @@ nodestatePrintNodeState(NodeAddressHeaders *headers,
 								&(nodeState->node),
 								nodeState->groupId,
 								hostport,
-								composedId);
+								composedId,
+								tliLSN);
 
 	if (healthChar == ' ')
 	{
@@ -273,7 +258,7 @@ nodestatePrintNodeState(NodeAddressHeaders *headers,
 			headers->maxNameSize, nodeState->node.name,
 			headers->maxNodeSize, composedId,
 			headers->maxHostSize, hostport,
-			headers->maxLSNSize, nodeState->node.lsn,
+			headers->maxLSNSize, tliLSN,
 			headers->maxHealthSize, connection,
 			headers->maxStateSize, NodeStateToString(nodeState->reportedState),
 			headers->maxStateSize, NodeStateToString(nodeState->goalState));
@@ -287,9 +272,11 @@ nodestatePrintNodeState(NodeAddressHeaders *headers,
  */
 void
 nodestatePrepareNode(NodeAddressHeaders *headers, NodeAddress *node,
-					 int groupId, char *hostport, char *composedId)
+					 int groupId, char *hostport,
+					 char *composedId, char *tliLSN)
 {
 	sformat(hostport, BUFSIZE, "%s:%d", node->host, node->port);
+	sformat(tliLSN, BUFSIZE, "%3d: %s", node->tli, node->lsn);
 
 	switch (headers->nodeKind)
 	{
@@ -352,6 +339,8 @@ nodestateAsJSON(CurrentNodeState *nodeState, JSON_Value *js)
 
 	json_object_set_string(jsobj, "assigned_group_state",
 						   NodeStateToString(nodeState->goalState));
+
+	json_object_set_number(jsobj, "timeline", (double) nodeState->node.tli);
 
 	json_object_set_string(jsobj, "Minimum Recovery Ending LSN",
 						   nodeState->node.lsn);
@@ -551,14 +540,14 @@ printNodeArray(NodeAddressArray *nodesArray)
 void
 printNodeHeader(NodeAddressHeaders *headers)
 {
-	fformat(stdout, "%*s | %*s | %*s | %18s | %8s\n",
+	fformat(stdout, "%*s | %*s | %*s | %21s | %8s\n",
 			headers->maxNameSize, "Name",
 			headers->maxNodeSize, "Node",
 			headers->maxHostSize, "Host:Port",
-			"LSN",
+			"TLI: LSN",
 			"Primary?");
 
-	fformat(stdout, "%*s-+-%*s-+-%*s-+-%18s-+-%8s\n",
+	fformat(stdout, "%*s-+-%*s-+-%*s-+-%21s-+-%8s\n",
 			headers->maxNameSize, headers->nameSeparatorHeader,
 			headers->maxNodeSize, headers->nodeSeparatorHeader,
 			headers->maxHostSize, headers->hostSeparatorHeader,
@@ -574,13 +563,14 @@ printNodeEntry(NodeAddressHeaders *headers, NodeAddress *node)
 {
 	char hostport[BUFSIZE] = { 0 };
 	char composedId[BUFSIZE] = { 0 };
+	char tliLSN[BUFSIZE] = { 0 };
 
-	(void) nodestatePrepareNode(headers, node, 0, hostport, composedId);
+	(void) nodestatePrepareNode(headers, node, 0, hostport, composedId, tliLSN);
 
-	fformat(stdout, "%*s | %*s | %*s | %18s | %8s\n",
+	fformat(stdout, "%*s | %*s | %*s | %21s | %8s\n",
 			headers->maxNameSize, node->name,
 			headers->maxNodeSize, composedId,
 			headers->maxHostSize, hostport,
-			node->lsn,
+			tliLSN,
 			node->isPrimary ? "yes" : "no");
 }

--- a/src/bin/pg_autoctl/nodestate_utils.h
+++ b/src/bin/pg_autoctl/nodestate_utils.h
@@ -83,7 +83,9 @@ void nodestatePrintNodeState(NodeAddressHeaders *headers,
 							 CurrentNodeState *nodeState);
 
 void nodestatePrepareNode(NodeAddressHeaders *headers, NodeAddress *node,
-						  int groupId, char *hostport, char *composedId);
+						  int groupId, char *hostport,
+						  char *composedId, char *tliLSN);
+
 void prepareHostNameSeparator(char nameSeparatorHeader[], int size);
 
 bool nodestateAsJSON(CurrentNodeState *nodeState, JSON_Value *js);

--- a/src/bin/pg_autoctl/parsing.c
+++ b/src/bin/pg_autoctl/parsing.c
@@ -272,7 +272,11 @@ parse_controldata(PostgresControlData *pgControlData,
 
 		!parse_controldata_field_lsn(control_data_string,
 									 "Latest checkpoint location",
-									 pgControlData->latestCheckpointLSN))
+									 pgControlData->latestCheckpointLSN) ||
+
+		!parse_controldata_field_uint32(control_data_string,
+										"Latest checkpoint's TimeLineID",
+										&(pgControlData->timeline_id)))
 	{
 		log_error("Failed to parse pg_controldata output");
 		return false;

--- a/src/bin/pg_autoctl/pgsql.c
+++ b/src/bin/pg_autoctl/pgsql.c
@@ -2488,7 +2488,8 @@ typedef struct PgMetadata
 bool
 pgsql_get_postgres_metadata(PGSQL *pgsql,
 							bool *pg_is_in_recovery,
-							char *pgsrSyncState, char *currentLSN,
+							char *pgsrSyncState,
+							char *currentLSN,
 							PostgresControlData *control)
 {
 	PgMetadata context = { 0 };

--- a/src/bin/pg_autoctl/pgsql.h
+++ b/src/bin/pg_autoctl/pgsql.h
@@ -159,6 +159,7 @@ typedef struct NodeAddress
 	char name[_POSIX_HOST_NAME_MAX];
 	char host[_POSIX_HOST_NAME_MAX];
 	int port;
+	int tli;
 	char lsn[PG_LSN_MAXLENGTH];
 	bool isPrimary;
 } NodeAddress;

--- a/src/bin/pg_autoctl/service_keeper.c
+++ b/src/bin/pg_autoctl/service_keeper.c
@@ -737,6 +737,7 @@ keeper_node_active(Keeper *keeper, bool doInit)
 							 keeperState->current_group,
 							 keeperState->current_role,
 							 reportPgIsRunning,
+							 postgres->postgresSetup.control.timeline_id,
 							 postgres->currentLSN,
 							 postgres->pgsrSyncState,
 							 &assignedState))

--- a/src/monitor/expected/monitor.out
+++ b/src/monitor/expected/monitor.out
@@ -123,9 +123,10 @@ opt_secondary        | t
 number_sync_standbys | 1
 
 -- dump the pgautofailover.node table, omitting the timely columns
-select formationid, nodeid, groupid, nodehost, nodeport,
-       goalstate, reportedstate, reportedpgisrunning, reportedrepstate
-  from pgautofailover.node;
+  select formationid, nodeid, groupid, nodehost, nodeport,
+         goalstate, reportedstate, reportedpgisrunning, reportedrepstate
+    from pgautofailover.node
+order by nodeid;
 -[ RECORD 1 ]-------+-------------
 formationid         | default
 nodeid              | 1
@@ -205,20 +206,11 @@ opt_secondary        | t
 number_sync_standbys | 0
 
 -- dump the pgautofailover.node table, omitting the timely columns
-select formationid, nodeid, groupid, nodehost, nodeport,
-       goalstate, reportedstate, reportedpgisrunning, reportedrepstate
-  from pgautofailover.node;
+  select formationid, nodeid, groupid, nodehost, nodeport,
+         goalstate, reportedstate, reportedpgisrunning, reportedrepstate
+    from pgautofailover.node
+order by nodeid;
 -[ RECORD 1 ]-------+-------------
-formationid         | default
-nodeid              | 3
-groupid             | 0
-nodehost            | localhost
-nodeport            | 9879
-goalstate           | report_lsn
-reportedstate       | init
-reportedpgisrunning | t
-reportedrepstate    | async
--[ RECORD 2 ]-------+-------------
 formationid         | default
 nodeid              | 2
 groupid             | 0
@@ -228,6 +220,16 @@ goalstate           | report_lsn
 reportedstate       | wait_standby
 reportedpgisrunning | t
 reportedrepstate    | unknown
+-[ RECORD 2 ]-------+-------------
+formationid         | default
+nodeid              | 3
+groupid             | 0
+nodehost            | localhost
+nodeport            | 9879
+goalstate           | report_lsn
+reportedstate       | init
+reportedpgisrunning | t
+reportedrepstate    | async
 
 select *
   from pgautofailover.set_node_system_identifier(2, 6852685710417058800);

--- a/src/monitor/group_state_machine.c
+++ b/src/monitor/group_state_machine.c
@@ -1878,7 +1878,9 @@ AssignGoalState(AutoFailoverNode *pgAutoFailoverNode,
 /*
  * WalDifferenceWithin returns whether the most recently reported relative log
  * position of the given nodes is within the specified bound. Returns false if
- * neither node has reported a relative xlog position
+ * neither node has reported a relative xlog position.
+ *
+ * Returns false when the nodes are not on the same reported timeline.
  */
 static bool
 WalDifferenceWithin(AutoFailoverNode *secondaryNode,
@@ -1887,6 +1889,11 @@ WalDifferenceWithin(AutoFailoverNode *secondaryNode,
 	if (secondaryNode == NULL || otherNode == NULL)
 	{
 		return true;
+	}
+
+	if (secondaryNode->reportedTLI != otherNode->reportedTLI)
+	{
+		return false;
 	}
 
 	XLogRecPtr secondaryLsn = secondaryNode->reportedLSN;

--- a/src/monitor/group_state_machine.c
+++ b/src/monitor/group_state_machine.c
@@ -338,6 +338,7 @@ ProceedGroupState(AutoFailoverNode *activeNode)
 		 IsCurrentState(primaryNode, REPLICATION_STATE_JOIN_PRIMARY) ||
 		 IsCurrentState(primaryNode, REPLICATION_STATE_PRIMARY)) &&
 		IsHealthy(activeNode) &&
+		activeNode->reportedTLI == primaryNode->reportedTLI &&
 		WalDifferenceWithin(activeNode, primaryNode, EnableSyncXlogThreshold))
 	{
 		char message[BUFSIZE] = { 0 };
@@ -1889,11 +1890,6 @@ WalDifferenceWithin(AutoFailoverNode *secondaryNode,
 	if (secondaryNode == NULL || otherNode == NULL)
 	{
 		return true;
-	}
-
-	if (secondaryNode->reportedTLI != otherNode->reportedTLI)
-	{
-		return false;
 	}
 
 	XLogRecPtr secondaryLsn = secondaryNode->reportedLSN;

--- a/src/monitor/group_state_machine.h
+++ b/src/monitor/group_state_machine.h
@@ -25,6 +25,7 @@ typedef struct AutoFailoverNodeState
 	int64 nodeId;
 	int32 groupId;
 	ReplicationState replicationState;
+	int32 reportedTLI;
 	XLogRecPtr reportedLSN;
 	SyncState pgsrSyncState;
 	bool pgIsRunning;

--- a/src/monitor/node_active_protocol.c
+++ b/src/monitor/node_active_protocol.c
@@ -359,9 +359,11 @@ node_active(PG_FUNCTION_ARGS)
 	int32 currentGroupId = PG_GETARG_INT32(2);
 	Oid currentReplicationStateOid = PG_GETARG_OID(3);
 	bool currentPgIsRunning = PG_GETARG_BOOL(4);
-	XLogRecPtr currentLSN = PG_GETARG_LSN(5);
 
-	text *currentPgsrSyncStateText = PG_GETARG_TEXT_P(6);
+	int32 currentTLI = PG_GETARG_INT32(5);
+	XLogRecPtr currentLSN = PG_GETARG_LSN(6);
+
+	text *currentPgsrSyncStateText = PG_GETARG_TEXT_P(7);
 	char *currentPgsrSyncState = text_to_cstring(currentPgsrSyncStateText);
 
 	AutoFailoverNodeState currentNodeState = { 0 };
@@ -370,6 +372,7 @@ node_active(PG_FUNCTION_ARGS)
 	currentNodeState.groupId = currentGroupId;
 	currentNodeState.replicationState =
 		EnumGetReplicationState(currentReplicationStateOid);
+	currentNodeState.reportedTLI = currentTLI;
 	currentNodeState.reportedLSN = currentLSN;
 	currentNodeState.pgsrSyncState = SyncStateFromString(currentPgsrSyncState);
 	currentNodeState.pgIsRunning = currentPgIsRunning;
@@ -478,6 +481,7 @@ NodeActive(char *formationId, AutoFailoverNodeState *currentNodeState)
 									currentNodeState->replicationState,
 									currentNodeState->pgIsRunning,
 									currentNodeState->pgsrSyncState,
+									currentNodeState->reportedTLI,
 									currentNodeState->reportedLSN);
 	}
 

--- a/src/monitor/node_metadata.c
+++ b/src/monitor/node_metadata.c
@@ -1222,7 +1222,7 @@ ReportAutoFailoverNodeState(char *nodeHost, int nodePort,
 		"UPDATE " AUTO_FAILOVER_NODE_TABLE
 		" SET reportedstate = $1, reporttime = now(), "
 		"reportedpgisrunning = $2, reportedrepstate = $3, "
-		"reportedtli = case $4 WHEN 0 THEN reportedtli ELSE $4 END, "
+		"reportedtli = CASE $4 WHEN 0 THEN reportedtli ELSE $4 END, "
 		"reportedlsn = CASE $5 WHEN '0/0'::pg_lsn THEN reportedlsn ELSE $5 END, "
 		"walreporttime = CASE $5 WHEN '0/0'::pg_lsn THEN walreporttime ELSE now() END, "
 		"statechangetime = CASE WHEN reportedstate <> $1 THEN now() ELSE statechangetime END "

--- a/src/monitor/node_metadata.c
+++ b/src/monitor/node_metadata.c
@@ -685,9 +685,9 @@ pgautofailover_node_reportedlsn_compare(const void *a, const void *b)
 		return -1;
 	}
 
-	if (node1->reportedTLI > node2->reportedTLI ||
+	if (node1->reportedTLI < node2->reportedTLI ||
 		(node1->reportedTLI == node2->reportedTLI &&
-		 node1->reportedLSN > node2->reportedLSN))
+		 node1->reportedLSN < node2->reportedLSN))
 	{
 		return 1;
 	}

--- a/src/monitor/node_metadata.h
+++ b/src/monitor/node_metadata.h
@@ -39,14 +39,15 @@
 #define Anum_pgautofailover_node_reportedpgisrunning 10
 #define Anum_pgautofailover_node_reportedrepstate 11
 #define Anum_pgautofailover_node_reporttime 12
-#define Anum_pgautofailover_node_reportedLSN 13
-#define Anum_pgautofailover_node_walreporttime 14
-#define Anum_pgautofailover_node_health 15
-#define Anum_pgautofailover_node_healthchecktime 16
-#define Anum_pgautofailover_node_statechangetime 17
-#define Anum_pgautofailover_node_candidate_priority 18
-#define Anum_pgautofailover_node_replication_quorum 19
-#define Anum_pgautofailover_node_nodecluster 20
+#define Anum_pgautofailover_node_reportedTLI 13
+#define Anum_pgautofailover_node_reportedLSN 14
+#define Anum_pgautofailover_node_walreporttime 15
+#define Anum_pgautofailover_node_health 16
+#define Anum_pgautofailover_node_healthchecktime 17
+#define Anum_pgautofailover_node_statechangetime 18
+#define Anum_pgautofailover_node_candidate_priority 19
+#define Anum_pgautofailover_node_replication_quorum 20
+#define Anum_pgautofailover_node_nodecluster 21
 
 #define AUTO_FAILOVER_NODE_TABLE_ALL_COLUMNS \
 	"formationid, " \
@@ -61,6 +62,7 @@
 	"reportedpgisrunning, " \
 	"reportedrepstate, " \
 	"reporttime, " \
+	"reportedtli, " \
 	"reportedlsn, " \
 	"walreporttime, " \
 	"health, " \
@@ -126,6 +128,7 @@ typedef struct AutoFailoverNode
 	NodeHealthState health;
 	TimestampTz healthCheckTime;
 	TimestampTz stateChangeTime;
+	int reportedTLI;
 	XLogRecPtr reportedLSN;
 	int candidatePriority;
 	bool replicationQuorum;
@@ -197,6 +200,7 @@ extern void ReportAutoFailoverNodeState(char *nodeHost, int nodePort,
 										ReplicationState reportedState,
 										bool pgIsRunning,
 										SyncState pgSyncState,
+										int reportedTLI,
 										XLogRecPtr reportedLSN);
 extern void ReportAutoFailoverNodeHealth(char *nodeHost, int nodePort,
 										 ReplicationState goalState,

--- a/src/monitor/pgautofailover--1.5--1.6.sql
+++ b/src/monitor/pgautofailover--1.5--1.6.sql
@@ -4,6 +4,96 @@
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "CREATE EXTENSION pgautofailover" to load this file. \quit
 
+ALTER TABLE pgautofailover.node
+	RENAME TO node_upgrade_old;
+
+ALTER TABLE pgautofailover.node_upgrade_old
+      RENAME CONSTRAINT system_identifier_is_null_at_init_only
+                     TO system_identifier_is_null_at_init_only_old;
+
+ALTER TABLE pgautofailover.node_upgrade_old
+      RENAME CONSTRAINT same_system_identifier_within_group
+                     TO same_system_identifier_within_group_old;
+
+CREATE TABLE pgautofailover.node
+ (
+    formationid          text not null default 'default',
+    nodeid               bigserial,
+    groupid              int not null,
+    nodename             text not null,
+    nodehost             text not null,
+    nodeport             int not null,
+    sysidentifier        bigint,
+    goalstate            pgautofailover.replication_state not null default 'init',
+    reportedstate        pgautofailover.replication_state not null,
+    reportedpgisrunning  bool default true,
+    reportedrepstate     text default 'async',
+    reporttime           timestamptz not null default now(),
+    reportedtli          int not null default 1 check (reportedtli > 0),
+    reportedlsn          pg_lsn not null default '0/0',
+    walreporttime        timestamptz not null default now(),
+    health               integer not null default -1,
+    healthchecktime      timestamptz not null default now(),
+    statechangetime      timestamptz not null default now(),
+    candidatepriority	 int not null default 100,
+    replicationquorum	 bool not null default true,
+    nodecluster          text not null default 'default',
+
+    -- node names must be unique in a given formation
+    UNIQUE (formationid, nodename),
+    -- any nodehost:port can only be a unique node in the system
+    UNIQUE (nodehost, nodeport),
+    --
+    -- The EXCLUDE constraint only allows the same sysidentifier for all the
+    -- nodes in the same group. The system_identifier is a property that is
+    -- kept when implementing streaming replication and should be unique per
+    -- Postgres instance in all other cases.
+    --
+    -- We allow the sysidentifier column to be NULL when registering a new
+    -- primary server from scratch, because we have not done pg_ctl initdb
+    -- at the time we call the register_node() function.
+    --
+    CONSTRAINT system_identifier_is_null_at_init_only
+         CHECK (  (    sysidentifier IS NULL
+                   AND reportedstate in ('init', 'wait_standby', 'catchingup') )
+                OR sysidentifier IS NOT NULL),
+
+    CONSTRAINT same_system_identifier_within_group
+       EXCLUDE USING gist(formationid with =,
+                          groupid with =,
+                          sysidentifier with <>)
+    DEFERRABLE INITIALLY DEFERRED,
+
+    PRIMARY KEY (nodeid),
+    FOREIGN KEY (formationid) REFERENCES pgautofailover.formation(formationid)
+ )
+ -- we expect few rows and lots of UPDATE, let's benefit from HOT
+ WITH (fillfactor = 25);
+
+ALTER SEQUENCE pgautofailover.node_nodeid_seq OWNED BY pgautofailover.node.nodeid;
+
+INSERT INTO pgautofailover.node
+ (
+  formationid, nodeid, groupid, nodename, nodehost, nodeport, sysidentifier,
+  goalstate, reportedstate, reportedpgisrunning, reportedrepstate,
+  reporttime, reportedtli, reportedlsn, walreporttime,
+  health, healthchecktime, statechangetime,
+  candidatepriority, replicationquorum, nodecluster
+ )
+ SELECT formationid, nodeid, groupid,
+        nodename, nodehost, nodeport, sysidentifier,
+        goalstate, reportedstate, reportedpgisrunning, reportedrepstate, reporttime,
+        1 as reportedtli,
+        reportedlsn, walreporttime, health, healthchecktime, statechangetime,
+        candidatepriority, replicationquorum, nodecluster
+   FROM pgautofailover.node_upgrade_old;
+
+DROP TABLE pgautofailover.node_upgrade_old;
+
+GRANT SELECT ON ALL TABLES IN SCHEMA pgautofailover TO autoctl_node;
+
+
+
 DROP FUNCTION
      pgautofailover.register_node(text,text,int,name,text,bigint,int,int,
                                   pgautofailover.replication_state,text,
@@ -52,6 +142,7 @@ CREATE FUNCTION pgautofailover.node_active
     IN group_id       		        int,
     IN current_group_role     		pgautofailover.replication_state default 'init',
     IN current_pg_is_running  		bool default true,
+    IN current_tli			  		integer default 1,
     IN current_lsn			  		pg_lsn default '0/0',
     IN current_rep_state      		text default '',
    OUT assigned_node_id       		bigint,
@@ -65,7 +156,7 @@ AS 'MODULE_PATHNAME', $$node_active$$;
 
 grant execute on function
       pgautofailover.node_active(text,bigint,int,
-                          pgautofailover.replication_state,bool,pg_lsn,text)
+                          pgautofailover.replication_state,bool,int,pg_lsn,text)
    to autoctl_node;
 
 
@@ -230,3 +321,80 @@ begin
     return new;
 end
 $$;
+
+
+DROP FUNCTION pgautofailover.current_state(text);
+
+CREATE FUNCTION pgautofailover.current_state
+ (
+    IN formation_id         text default 'default',
+   OUT formation_kind       text,
+   OUT nodename             text,
+   OUT nodehost             text,
+   OUT nodeport             int,
+   OUT group_id             int,
+   OUT node_id              bigint,
+   OUT current_group_state  pgautofailover.replication_state,
+   OUT assigned_group_state pgautofailover.replication_state,
+   OUT candidate_priority	int,
+   OUT replication_quorum	bool,
+   OUT reported_tli         int,
+   OUT reported_lsn         pg_lsn,
+   OUT health               integer
+ )
+RETURNS SETOF record LANGUAGE SQL STRICT
+AS $$
+   select kind, nodename, nodehost, nodeport, groupid, nodeid,
+          reportedstate, goalstate,
+   		  candidatepriority, replicationquorum,
+          reportedtli, reportedlsn, health
+     from pgautofailover.node
+     join pgautofailover.formation using(formationid)
+    where formationid = formation_id
+ order by groupid, nodeid;
+$$;
+
+grant execute on function pgautofailover.current_state(text)
+   to autoctl_node;
+
+comment on function pgautofailover.current_state(text)
+        is 'get the current state of both nodes of a formation';
+
+DROP FUNCTION pgautofailover.current_state(text, int);
+
+CREATE FUNCTION pgautofailover.current_state
+ (
+    IN formation_id         text,
+    IN group_id             int,
+   OUT formation_kind       text,
+   OUT nodename             text,
+   OUT nodehost             text,
+   OUT nodeport             int,
+   OUT group_id             int,
+   OUT node_id              bigint,
+   OUT current_group_state  pgautofailover.replication_state,
+   OUT assigned_group_state pgautofailover.replication_state,
+   OUT candidate_priority	int,
+   OUT replication_quorum	bool,
+   OUT reported_tli         int,
+   OUT reported_lsn         pg_lsn,
+   OUT health               integer
+ )
+RETURNS SETOF record LANGUAGE SQL STRICT
+AS $$
+   select kind, nodename, nodehost, nodeport, groupid, nodeid,
+          reportedstate, goalstate,
+   		  candidatepriority, replicationquorum,
+          reportedtli, reportedlsn, health
+     from pgautofailover.node
+     join pgautofailover.formation using(formationid)
+    where formationid = formation_id
+      and groupid = group_id
+ order by groupid, nodeid;
+$$;
+
+grant execute on function pgautofailover.current_state(text, int)
+   to autoctl_node;
+
+comment on function pgautofailover.current_state(text, int)
+        is 'get the current state of both nodes of a group in a formation';

--- a/src/monitor/pgautofailover--1.5--1.6.sql
+++ b/src/monitor/pgautofailover--1.5--1.6.sql
@@ -18,7 +18,7 @@ ALTER TABLE pgautofailover.node_upgrade_old
 CREATE TABLE pgautofailover.node
  (
     formationid          text not null default 'default',
-    nodeid               bigserial,
+    nodeid               bigint not null DEFAULT nextval('pgautofailover.node_nodeid_seq'::regclass),
     groupid              int not null,
     nodename             text not null,
     nodehost             text not null,

--- a/src/monitor/sql/monitor.sql
+++ b/src/monitor/sql/monitor.sql
@@ -48,9 +48,10 @@ select formationid, nodename, goalstate, reportedstate
 table pgautofailover.formation;
 
 -- dump the pgautofailover.node table, omitting the timely columns
-select formationid, nodeid, groupid, nodehost, nodeport,
-       goalstate, reportedstate, reportedpgisrunning, reportedrepstate
-  from pgautofailover.node;
+  select formationid, nodeid, groupid, nodehost, nodeport,
+         goalstate, reportedstate, reportedpgisrunning, reportedrepstate
+    from pgautofailover.node
+order by nodeid;
 
 select * from pgautofailover.get_primary('unknown formation');
 select * from pgautofailover.get_primary(group_id => -10);
@@ -65,9 +66,10 @@ select pgautofailover.remove_node(1);
 table pgautofailover.formation;
 
 -- dump the pgautofailover.node table, omitting the timely columns
-select formationid, nodeid, groupid, nodehost, nodeport,
-       goalstate, reportedstate, reportedpgisrunning, reportedrepstate
-  from pgautofailover.node;
+  select formationid, nodeid, groupid, nodehost, nodeport,
+         goalstate, reportedstate, reportedpgisrunning, reportedrepstate
+    from pgautofailover.node
+order by nodeid;
 
 select *
   from pgautofailover.set_node_system_identifier(2, 6852685710417058800);


### PR DESCRIPTION
This allows comparing the LSN with the added notion of the current time for
the nodes, avoiding some advanced data loss hazard if a node makes progress
while being in a network split with the application nodes, and when
rejoining later we should detect if a failover happened on the other nodes
on the system.

Fixes #726.