### PR TITLE
Call pg_rewind when creating a secondary from an existing PGDATA.

### DIFF
--- a/src/bin/pg_autoctl/cli_common.h
+++ b/src/bin/pg_autoctl/cli_common.h
@@ -23,6 +23,7 @@ extern KeeperConfig keeperOptions;
 extern bool createAndRun;
 extern bool outputJSON;
 extern bool openAppHBAonLAN;
+extern bool dropAndDestroy;
 
 #define SSL_CA_FILE_FLAG 1      /* root public certificate */
 #define SSL_CRL_FILE_FLAG 2     /* certificates revocation list */
@@ -172,7 +173,14 @@ void cli_set_groupId(Monitor *monitor, KeeperConfig *kconfig);
 bool cli_create_config(Keeper *keeper);
 void cli_create_pg(Keeper *keeper);
 bool check_or_discover_hostname(KeeperConfig *config);
+
+int cli_drop_node_getopts(int argc, char **argv);
+void cli_drop_node(int argc, char **argv);
 void keeper_cli_destroy_node(int argc, char **argv);
+
+void cli_drop_node_from_monitor(KeeperConfig *config,
+								int64_t *nodeId, int *groupId);
+void cli_drop_local_node(KeeperConfig *config, bool dropAndDestroy);
 
 bool cli_getopt_ssl_flags(int ssl_flag, char *optarg, PostgresSetup *pgSetup);
 bool cli_getopt_accept_ssl_options(SSLCommandLineOptions newSSLOption,

--- a/src/bin/pg_autoctl/cli_do_monitor.c
+++ b/src/bin/pg_autoctl/cli_do_monitor.c
@@ -352,7 +352,7 @@ cli_do_monitor_get_coordinator(int argc, char **argv)
 {
 	KeeperConfig config = keeperOptions;
 	Monitor monitor = { 0 };
-	NodeAddress coordinatorNode = { 0 };
+	CoordinatorNodeAddress coordinatorNode = { 0 };
 
 	bool missingPgdataIsOk = true;
 	bool pgIsNotRunningIsOk = true;
@@ -381,7 +381,7 @@ cli_do_monitor_get_coordinator(int argc, char **argv)
 		exit(EXIT_CODE_MONITOR);
 	}
 
-	if (IS_EMPTY_STRING_BUFFER(coordinatorNode.host))
+	if (IS_EMPTY_STRING_BUFFER(coordinatorNode.node.host))
 	{
 		fformat(stdout, "%s has no coordinator ready yet\n", config.formation);
 		exit(EXIT_CODE_QUIT);
@@ -395,8 +395,8 @@ cli_do_monitor_get_coordinator(int argc, char **argv)
 
 		json_object_set_string(root, "formation", config.formation);
 		json_object_set_number(root, "groupId", (double) config.groupId);
-		json_object_set_string(root, "host", coordinatorNode.host);
-		json_object_set_number(root, "port", (double) coordinatorNode.port);
+		json_object_set_string(root, "host", coordinatorNode.node.host);
+		json_object_set_number(root, "port", (double) coordinatorNode.node.port);
 
 		(void) cli_pprint_json(js);
 	}
@@ -405,8 +405,8 @@ cli_do_monitor_get_coordinator(int argc, char **argv)
 		fformat(stdout,
 				"%s %s:%d\n",
 				config.formation,
-				coordinatorNode.host,
-				coordinatorNode.port);
+				coordinatorNode.node.host,
+				coordinatorNode.node.port);
 	}
 }
 

--- a/src/bin/pg_autoctl/cli_drop_node.c
+++ b/src/bin/pg_autoctl/cli_drop_node.c
@@ -45,18 +45,11 @@
  * Global variables that we're going to use to "communicate" in between getopts
  * functions and their command implementation. We can't pass parameters around.
  */
-static bool dropAndDestroy = false;
+bool dropAndDestroy = false;
 static bool dropForce = false;
 
-static int cli_drop_node_getopts(int argc, char **argv);
-static void cli_drop_node(int argc, char **argv);
 static void cli_drop_monitor(int argc, char **argv);
 
-static void cli_drop_node_from_monitor(KeeperConfig *config,
-									   int64_t *nodeId,
-									   int *groupId);
-
-static void cli_drop_local_node(KeeperConfig *config, bool dropAndDestroy);
 static void cli_drop_local_monitor(MonitorConfig *mconfig, bool dropAndDestroy);
 
 static void cli_drop_node_with_monitor_disabled(KeeperConfig *config,
@@ -98,7 +91,7 @@ CommandLine drop_node_command =
  * cli_drop_node_getopts parses the command line options necessary to drop or
  * destroy a local pg_autoctl node.
  */
-static int
+int
 cli_drop_node_getopts(int argc, char **argv)
 {
 	KeeperConfig options = { 0 };
@@ -337,7 +330,7 @@ cli_drop_node_getopts(int argc, char **argv)
  * cli_drop_node removes the local PostgreSQL node from the pg_auto_failover
  * monitor, and when it's a worker, from the Citus coordinator too.
  */
-static void
+void
 cli_drop_node(int argc, char **argv)
 {
 	KeeperConfig config = keeperOptions;
@@ -504,7 +497,7 @@ cli_drop_monitor(int argc, char **argv)
  * for the given --hostname and --pgport, or from the given --formation and
  * --name.
  */
-static void
+void
 cli_drop_node_from_monitor(KeeperConfig *config, int64_t *nodeId, int *groupId)
 {
 	Monitor monitor = { 0 };
@@ -563,7 +556,7 @@ cli_drop_node_from_monitor(KeeperConfig *config, int64_t *nodeId, int *groupId)
  * cli_drop_local_node drops the local node files, maybe including the PGDATA
  * directory (when --destroy has been used).
  */
-static void
+void
 cli_drop_local_node(KeeperConfig *config, bool dropAndDestroy)
 {
 	Keeper keeper = { 0 };

--- a/src/bin/pg_autoctl/fsm.h
+++ b/src/bin/pg_autoctl/fsm.h
@@ -67,7 +67,7 @@ bool fsm_report_lsn(Keeper *keeper);
 bool fsm_fast_forward(Keeper *keeper);
 bool fsm_prepare_cascade(Keeper *keeper);
 bool fsm_follow_new_primary(Keeper *keeper);
-bool fsm_cleanup_and_resume_as_primary(Keeper *keeper);
+bool fsm_cleanup_as_primary(Keeper *keeper);
 
 bool fsm_init_from_standby(Keeper *keeper);
 

--- a/src/bin/pg_autoctl/fsm_transition.c
+++ b/src/bin/pg_autoctl/fsm_transition.c
@@ -1325,11 +1325,11 @@ fsm_fast_forward(Keeper *keeper)
 
 
 /*
- * fsm_cleanup_and_resume_as_primary cleans-up the replication setting and
- * start the local node as primary. It's called after a fast-forward operation.
+ * fsm_cleanup_as_primary cleans-up the replication setting. It's called after
+ * a fast-forward operation.
  */
 bool
-fsm_cleanup_and_resume_as_primary(Keeper *keeper)
+fsm_cleanup_as_primary(Keeper *keeper)
 {
 	LocalPostgresServer *postgres = &(keeper->postgres);
 
@@ -1337,13 +1337,6 @@ fsm_cleanup_and_resume_as_primary(Keeper *keeper)
 	{
 		log_error("Failed to cleanup replication settings and restart Postgres "
 				  "to continue as a primary, see above for details");
-		return false;
-	}
-
-	if (!keeper_restart_postgres(keeper))
-	{
-		log_error("Failed to restart Postgres after changing its "
-				  "primary conninfo, see above for details");
 		return false;
 	}
 

--- a/src/bin/pg_autoctl/keeper_pg_init.c
+++ b/src/bin/pg_autoctl/keeper_pg_init.c
@@ -347,6 +347,7 @@ keeper_pg_init_and_register_primary(Keeper *keeper)
 				  "see above for details",
 				  config->hostname, config->pgSetup.pgport,
 				  config->pgSetup.pgdata, scrubbedConnectionString);
+		return false;
 	}
 
 	log_info("Successfully registered as \"%s\" to the monitor.",

--- a/src/bin/pg_autoctl/monitor.h
+++ b/src/bin/pg_autoctl/monitor.h
@@ -14,6 +14,7 @@
 
 #include "pgsql.h"
 #include "monitor_config.h"
+#include "nodestate_utils.h"
 #include "primary_standby.h"
 #include "state.h"
 
@@ -53,6 +54,12 @@ typedef struct MonitorExtensionVersion
 	char installedVersion[BUFSIZE];
 } MonitorExtensionVersion;
 
+typedef struct CoordinatorNodeAddress
+{
+	bool found;
+	NodeAddress node;
+} CoordinatorNodeAddress;
+
 #define NODE_FORMAT "%" PRId64 " \"%s\" (%s:%d)"
 
 bool monitor_init(Monitor *monitor, char *url);
@@ -84,7 +91,7 @@ bool monitor_print_other_nodes_as_json(Monitor *monitor,
 bool monitor_get_primary(Monitor *monitor, char *formation, int groupId,
 						 NodeAddress *node);
 bool monitor_get_coordinator(Monitor *monitor, char *formation,
-							 NodeAddress *node);
+							 CoordinatorNodeAddress *coordinatorNodeAddress);
 bool monitor_get_most_advanced_standby(Monitor *monitor,
 									   char *formation, int groupId,
 									   NodeAddress *node);
@@ -138,6 +145,8 @@ bool monitor_get_groupId_from_name(Monitor *monitor,
 bool monitor_perform_failover(Monitor *monitor, char *formation, int group);
 bool monitor_perform_promotion(Monitor *monitor, char *formation, char *name);
 
+bool monitor_get_current_state(Monitor *monitor, char *formation, int group,
+							   CurrentNodeStateArray *nodesArray);
 bool monitor_print_state(Monitor *monitor, char *formation, int group);
 bool monitor_print_last_events(Monitor *monitor,
 							   char *formation, int group, int count);

--- a/src/bin/pg_autoctl/nodestate_utils.h
+++ b/src/bin/pg_autoctl/nodestate_utils.h
@@ -24,6 +24,7 @@ typedef struct CurrentNodeState
 	NodeAddress node;
 
 	char formation[NAMEDATALEN];
+	char citusClusterName[NAMEDATALEN];
 	int groupId;
 	PgInstanceKind pgKind;
 
@@ -98,5 +99,8 @@ void nodestate_log(CurrentNodeState *nodeState, int logLevel, int64_t nodeId);
 void printNodeArray(NodeAddressArray *nodesArray);
 void printNodeHeader(NodeAddressHeaders *headers);
 void printNodeEntry(NodeAddressHeaders *headers, NodeAddress *node);
+
+bool nodestateFilterArrayGroup(CurrentNodeStateArray *nodesArray,
+							   const char *name);
 
 #endif /* NODESTATE_H */

--- a/src/bin/pg_autoctl/pgctl.c
+++ b/src/bin/pg_autoctl/pgctl.c
@@ -1890,10 +1890,11 @@ pg_ctl_status(const char *pg_ctl, const char *pgdata, bool log_output)
 bool
 pg_ctl_promote(const char *pg_ctl, const char *pgdata)
 {
-	Program program = run_program(pg_ctl, "promote", "-D", pgdata, "-w", NULL);
+	Program program =
+		run_program(pg_ctl, "promote", "-D", pgdata, "--no-wait", NULL);
 	int returnCode = program.returnCode;
 
-	log_debug("%s promote -D %s", pg_ctl, pgdata);
+	log_debug("%s promote -D %s --no-wait", pg_ctl, pgdata);
 
 	if (program.stdErr != NULL)
 	{

--- a/src/bin/pg_autoctl/pgsql.c
+++ b/src/bin/pg_autoctl/pgsql.c
@@ -32,6 +32,8 @@
 #define ERRCODE_OBJECT_IN_USE "55006"
 #define ERRCODE_UNDEFINED_OBJECT "42704"
 
+#define ERRCODE_EXCLUSION_VIOLATION "23P01"
+
 static char * ConnectionTypeToString(ConnectionType connectionType);
 static void log_connection_error(PGconn *connection, int logLevel);
 static void pgAutoCtlDefaultNoticeProcessor(void *arg, const char *message);

--- a/src/bin/pg_autoctl/primary_standby.c
+++ b/src/bin/pg_autoctl/primary_standby.c
@@ -1303,6 +1303,14 @@ standby_promote(LocalPostgresServer *postgres)
 		log_info("Waiting for postgres to promote");
 		pg_usleep(AWAIT_PROMOTION_SLEEP_TIME_MS * 1000);
 
+		if (asked_to_stop || asked_to_stop_fast)
+		{
+			log_trace("standby_promote: signaled");
+			pgsql_finish(pgsql);
+
+			return false;
+		}
+
 		if (!pgsql_is_in_recovery(pgsql, &inRecovery))
 		{
 			log_error("Failed to determine whether postgres is in "

--- a/src/bin/pg_autoctl/primary_standby.h
+++ b/src/bin/pg_autoctl/primary_standby.h
@@ -100,6 +100,7 @@ bool standby_init_database(LocalPostgresServer *postgres,
 						   const char *hostname,
 						   bool skipBaseBackup);
 bool primary_rewind_to_standby(LocalPostgresServer *postgres);
+bool secondary_rewind(LocalPostgresServer *postgres);
 bool postgres_maybe_do_crash_recovery(LocalPostgresServer *postgres);
 bool standby_promote(LocalPostgresServer *postgres);
 bool check_postgresql_settings(LocalPostgresServer *postgres,

--- a/src/bin/pg_autoctl/service_keeper_init.c
+++ b/src/bin/pg_autoctl/service_keeper_init.c
@@ -121,7 +121,7 @@ service_keeper_init_start(void *context, pid_t *pid)
 			if (!keeper_pg_init_and_register(keeper))
 			{
 				/* errors have already been logged */
-				exit(EXIT_CODE_INTERNAL_ERROR);
+				exit(EXIT_CODE_FATAL);
 			}
 
 			if (keeperInitWarnings)

--- a/src/monitor/node_active_protocol.c
+++ b/src/monitor/node_active_protocol.c
@@ -1124,9 +1124,6 @@ RemoveNode(AutoFailoverNode *currentNode, bool force)
 	/* review the FSM for every other node, when removing the primary */
 	if (currentNodeIsPrimary)
 	{
-		int nodeCount = 0;
-		int candidates = 0;
-
 		foreach(nodeCell, otherNodesGroupList)
 		{
 			char message[BUFSIZE] = { 0 };
@@ -1137,13 +1134,6 @@ RemoveNode(AutoFailoverNode *currentNode, bool force)
 				/* shouldn't happen */
 				ereport(ERROR, (errmsg("BUG: node is NULL")));
 				continue;
-			}
-
-			++nodeCount;
-
-			if (node->candidatePriority > 0)
-			{
-				++candidates;
 			}
 
 			/* skip nodes that are currently in maintenance */
@@ -1159,21 +1149,6 @@ RemoveNode(AutoFailoverNode *currentNode, bool force)
 				NODE_FORMAT_ARGS(node));
 
 			SetNodeGoalState(node, REPLICATION_STATE_REPORT_LSN, message);
-		}
-
-		/*
-		 * Refuse to remove the primary node when there is no candidate, unless
-		 * the primary is the only node left of course.
-		 */
-		if (nodeCount > 0 && candidates == 0)
-		{
-			ereport(NOTICE,
-					(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
-					 errmsg("cannot remove current primary node " NODE_FORMAT,
-							NODE_FORMAT_ARGS(currentNode)),
-					 errdetail("At least one node with candidate priority "
-							   "greater than zero is needed to remove a "
-							   "primary node.")));
 		}
 	}
 

--- a/src/monitor/pgautofailover--1.5--1.6.sql
+++ b/src/monitor/pgautofailover--1.5--1.6.sql
@@ -554,25 +554,26 @@ CREATE FUNCTION pgautofailover.current_state
    OUT replication_quorum	bool,
    OUT reported_tli         int,
    OUT reported_lsn         pg_lsn,
-   OUT health               integer
+   OUT health               integer,
+   OUT nodecluster          text
  )
 RETURNS SETOF record LANGUAGE SQL STRICT
 AS $$
    select kind, nodename, nodehost, nodeport, groupid, nodeid,
           reportedstate, goalstate,
    		  candidatepriority, replicationquorum,
-          reportedtli, reportedlsn, health
+          reportedtli, reportedlsn, health, nodecluster
      from pgautofailover.node
      join pgautofailover.formation using(formationid)
     where formationid = formation_id
  order by groupid, nodeid;
 $$;
 
-grant execute on function pgautofailover.current_state(text)
-   to autoctl_node;
-
 comment on function pgautofailover.current_state(text)
         is 'get the current state of both nodes of a formation';
+
+grant execute on function pgautofailover.current_state(text)
+   to autoctl_node;
 
 CREATE FUNCTION pgautofailover.current_state
  (
@@ -590,20 +591,20 @@ CREATE FUNCTION pgautofailover.current_state
    OUT replication_quorum	bool,
    OUT reported_tli         int,
    OUT reported_lsn         pg_lsn,
-   OUT health               integer
+   OUT health               integer,
+   OUT nodecluster          text
  )
 RETURNS SETOF record LANGUAGE SQL STRICT
 AS $$
    select kind, nodename, nodehost, nodeport, groupid, nodeid,
           reportedstate, goalstate,
    		  candidatepriority, replicationquorum,
-          reportedtli, reportedlsn, health
+          reportedtli, reportedlsn, health, nodecluster
      from pgautofailover.node
      join pgautofailover.formation using(formationid)
     where formationid = formation_id
       and groupid = group_id
  order by groupid, nodeid;
-$$;
 
 grant execute on function pgautofailover.current_state(text, int)
    to autoctl_node;

--- a/src/monitor/pgautofailover.sql
+++ b/src/monitor/pgautofailover.sql
@@ -599,14 +599,15 @@ CREATE FUNCTION pgautofailover.current_state
    OUT replication_quorum	bool,
    OUT reported_tli         int,
    OUT reported_lsn         pg_lsn,
-   OUT health               integer
+   OUT health               integer,
+   OUT nodecluster          text
  )
 RETURNS SETOF record LANGUAGE SQL STRICT
 AS $$
    select kind, nodename, nodehost, nodeport, groupid, nodeid,
           reportedstate, goalstate,
    		  candidatepriority, replicationquorum,
-          reportedtli, reportedlsn, health
+          reportedtli, reportedlsn, health, nodecluster
      from pgautofailover.node
      join pgautofailover.formation using(formationid)
     where formationid = formation_id
@@ -632,14 +633,15 @@ CREATE FUNCTION pgautofailover.current_state
    OUT replication_quorum	bool,
    OUT reported_tli         int,
    OUT reported_lsn         pg_lsn,
-   OUT health               integer
+   OUT health               integer,
+   OUT nodecluster          text
  )
 RETURNS SETOF record LANGUAGE SQL STRICT
 AS $$
    select kind, nodename, nodehost, nodeport, groupid, nodeid,
           reportedstate, goalstate,
    		  candidatepriority, replicationquorum,
-          reportedtli, reportedlsn, health
+          reportedtli, reportedlsn, health, nodecluster
      from pgautofailover.node
      join pgautofailover.formation using(formationid)
     where formationid = formation_id

--- a/tests/test_multi_async.py
+++ b/tests/test_multi_async.py
@@ -263,7 +263,7 @@ def test_014_003_restart_node1():
     # node1 used to be primary, now demoted, and meanwhile node2 was primary
     # node1 is assigned report_lsn and then is selected (only node with
     # candidate priority > 0) ; and thus needs to go through fast_forward
-    assert node1.wait_until_state(target_state="fast_forward")
+    assert node1.wait_until_assigned_state(target_state="fast_forward")
     assert node1.wait_until_state(target_state="stop_replication")
     assert node1.wait_until_state(target_state="wait_primary")
     assert node3.wait_until_state(target_state="secondary")


### PR DESCRIPTION
The existing PGDATA might have come from a former primary that's not in the
new timeline and where pg_rewind is needed to go before the fork LSN. Also,
it could be a standby node that has been used for PITR.

We should decide if we want to add such a process to `fsm_follow_new_primary`...