### PR TITLE
Introduce hooks to implement refreshing the otherNodes array.

### DIFF
--- a/src/bin/pg_autoctl/keeper.h
+++ b/src/bin/pg_autoctl/keeper.h
@@ -81,14 +81,32 @@ bool keeper_config_accept_new(Keeper *keeper, KeeperConfig *newConfig);
  */
 typedef bool (*KeeperReloadFunction)(Keeper *keeper, bool firstLoop, bool doInit);
 
+/*
+ * When updating the list of other nodes (a NodesArray) after calling
+ * node_active, the keeper needs to implement specific actions such as editing
+ * the HBA rules to allow new nodes to connect.
+ */
+typedef bool (*KeeperNodesArrayRefreshFunction)(Keeper *keeper,
+												NodeAddressArray *newNodesArray,
+												bool forceCacheInvalidation);
+
 /* src/bin/pg_autoctl/service_keeper.c */
 extern KeeperReloadFunction *KeeperReloadHooks;
+extern KeeperNodesArrayRefreshFunction *KeeperRefreshHooks;
 
 void keeper_call_reload_hooks(Keeper *keeper, bool firstLoop, bool doInit);
 bool keeper_reload_configuration(Keeper *keeper, bool firstLoop, bool doInit);
 
+bool keeper_call_refresh_hooks(Keeper *keeper,
+							   NodeAddressArray *newNodesArray,
+							   bool forceCacheInvalidation);
+bool keeper_refresh_hba(Keeper *keeper,
+						NodeAddressArray *newNodesArray,
+						bool forceCacheInvalidation);
+
 bool keeper_read_nodes_from_file(Keeper *keeper, NodeAddressArray *nodesArray);
 bool keeper_get_primary(Keeper *keeper, NodeAddress *primaryNode);
 bool keeper_get_most_advanced_standby(Keeper *keeper, NodeAddress *primaryNode);
+
 
 #endif /* KEEPER_H */

--- a/src/bin/pg_autoctl/service_keeper.c
+++ b/src/bin/pg_autoctl/service_keeper.c
@@ -44,6 +44,16 @@ KeeperReloadFunction KeeperReloadHooksArray[] = {
 
 KeeperReloadFunction *KeeperReloadHooks = KeeperReloadHooksArray;
 
+/* list of hooks to run to update a list of nodes, at node active time */
+KeeperNodesArrayRefreshFunction KeeperNodesArrayRefreshArray[] = {
+	&keeper_refresh_hba,
+	NULL
+};
+
+KeeperNodesArrayRefreshFunction *KeeperRefreshHooks =
+	KeeperNodesArrayRefreshArray;
+
+
 static bool service_keeper_node_active(Keeper *keeper, bool doInit);
 static void check_for_network_partitions(Keeper *keeper);
 static bool is_network_healthy(Keeper *keeper);


### PR DESCRIPTION
This way we allow extensions to pg_auto_failover to implement specific
processing when the otherNodes array changes, when that's needed.