### PR TITLE
Have drop node --force --destroy work as expected again

### DIFF
--- a/src/bin/pg_autoctl/cli_drop_node.c
+++ b/src/bin/pg_autoctl/cli_drop_node.c
@@ -623,6 +623,12 @@ cli_drop_local_node(KeeperConfig *config, bool dropAndDestroy)
 
 	if (!wait_for_pid_to_exit(config->pathnames.pid, quit_timeout, &pid))
 	{
+		if (pid == 0)
+		{
+			/* errors have already been logged */
+			exit(EXIT_CODE_INTERNAL_ERROR);
+		}
+
 		/* if the service isn't terminated, signal it to quit now */
 		log_info("Sending signal %s to pg_autoctl process %d",
 				 signal_to_string(SIGQUIT),

--- a/src/bin/pg_autoctl/cli_drop_node.c
+++ b/src/bin/pg_autoctl/cli_drop_node.c
@@ -617,7 +617,8 @@ cli_drop_local_node(KeeperConfig *config, bool dropAndDestroy)
 	 * If --force is used, we skip the transition to "dropped". So a currently
 	 * running process won't realise it's dropped, so it will not exit by
 	 * itself. So there's no point in waiting for 30 seconds. Instead we
-	 * manually kill it using SIGQUIT right away.
+	 * manually kill it using SIGQUIT right away, because we would still like
+	 * the process to be stopped in that case.
 	 */
 	int quit_timeout = dropForce ? 0 : 30;
 

--- a/src/bin/pg_autoctl/pidfile.c
+++ b/src/bin/pg_autoctl/pidfile.c
@@ -511,14 +511,16 @@ wait_for_pid_to_exit(const char *pidfile, int timeout, pid_t *pid)
 		if (read_pidfile(pidfile, pid))
 		{
 			/*
-			 * If we have a timeout of 0 passed in, this log message doesn't
-			 * make sense. We are not waiting for the process to stop.
+			 * If we have a timeout of 0 passed in, we can fail right away if
+			 * there is a pidfile.
 			 */
-			if (timeout > 0)
+			if (timeout == 0)
 			{
-				log_info("An instance of pg_autoctl is running with PID %d, "
-						 "waiting for it to stop.", *pid);
+				return false;
 			}
+
+			log_info("An instance of pg_autoctl is running with PID %d, "
+					 "waiting for it to stop.", *pid);
 
 			int timeout_counter = timeout;
 

--- a/src/bin/pg_autoctl/pidfile.c
+++ b/src/bin/pg_autoctl/pidfile.c
@@ -499,56 +499,59 @@ pidfile_as_json(JSON_Value *js, const char *pidfile, bool includeStatus)
 }
 
 
+bool
+is_process_stopped(const char *pidfile, bool *stopped, pid_t *pid)
+{
+	if (!file_exists(pidfile))
+	{
+		*stopped = true;
+		return true;
+	}
+
+	if (!read_pidfile(pidfile, pid))
+	{
+		log_error("Failed to read PID file \"%s\"", pidfile);
+		return false;
+	}
+
+	*stopped = false;
+	return true;
+}
+
+
 /*
- * wait_for_pid_to_exit waits until the PID found in the pidfile is not running
+ * wait_for_process_to_stop waits until the PID found in the pidfile is not running
  * anymore.
  */
 bool
-wait_for_pid_to_exit(const char *pidfile, int timeout, pid_t *pid)
+wait_for_process_to_stop(const char *pidfile, int timeout, bool *stopped, pid_t *pid)
 {
-	if (file_exists(pidfile))
+	if (!is_process_stopped(pidfile, stopped, pid))
 	{
-		if (read_pidfile(pidfile, pid))
-		{
-			/*
-			 * If we have a timeout of 0 passed in, we can fail right away if
-			 * there is a pidfile.
-			 */
-			if (timeout == 0)
-			{
-				return false;
-			}
-
-			log_info("An instance of pg_autoctl is running with PID %d, "
-					 "waiting for it to stop.", *pid);
-
-			int timeout_counter = timeout;
-
-			while (timeout_counter > 0)
-			{
-				if (kill(*pid, 0) == -1 && errno == ESRCH)
-				{
-					log_info("The pg_autoctl instance with pid %d "
-							 "has now terminated.",
-							 *pid);
-					break;
-				}
-
-				sleep(1);
-				--timeout_counter;
-			}
-
-			return timeout_counter > 0;
-		}
-		else
-		{
-			log_error("Failed to read PID file \"%s\"", pidfile);
-			return false;
-		}
+		/* errors have already been logged */
+		return false;
 	}
-	else
+
+	log_info("An instance of pg_autoctl is running with PID %d, "
+			 "waiting for it to stop.", *pid);
+
+	int timeout_counter = timeout;
+
+	while (timeout_counter > 0)
 	{
-		/* when the pidfile doesn't exist, assume the service is not running */
-		return true;
+		if (kill(*pid, 0) == -1 && errno == ESRCH)
+		{
+			log_info("The pg_autoctl instance with pid %d "
+					 "has now terminated.",
+					 *pid);
+			*stopped = true;
+			return true;
+		}
+
+		sleep(1);
+		--timeout_counter;
 	}
+
+	*stopped = false;
+	return true;
 }

--- a/src/bin/pg_autoctl/pidfile.c
+++ b/src/bin/pg_autoctl/pidfile.c
@@ -510,8 +510,15 @@ wait_for_pid_to_exit(const char *pidfile, int timeout, pid_t *pid)
 	{
 		if (read_pidfile(pidfile, pid))
 		{
-			log_info("An instance of pg_autoctl is running with PID %d, "
-					 "waiting for it to stop.", *pid);
+			/*
+			 * If we have a timeout of 0 passed in, this log message doesn't
+			 * make sense. We are not waiting for the process to stop.
+			 */
+			if (timeout > 0)
+			{
+				log_info("An instance of pg_autoctl is running with PID %d, "
+						 "waiting for it to stop.", *pid);
+			}
 
 			int timeout_counter = timeout;
 

--- a/src/bin/pg_autoctl/pidfile.h
+++ b/src/bin/pg_autoctl/pidfile.h
@@ -67,6 +67,8 @@ void check_pidfile(const char *pidfile, pid_t start_pid);
 
 void pidfile_as_json(JSON_Value *js, const char *pidfile, bool includeStatus);
 
-bool wait_for_pid_to_exit(const char *pidfile, int timeout, pid_t *pid);
+bool is_process_stopped(const char *pidfile, bool *stopped, pid_t *pid);
+bool wait_for_process_to_stop(const char *pidfile, int timeout, bool *stopped,
+							  pid_t *pid);
 
 #endif /* PIDFILE_H */

--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -1113,6 +1113,7 @@ class DataNode(PGNode):
                 "drop",
                 "node",
                 "--destroy",
+                "--force",
                 timeout=3,
             )
         except Exception as e:

--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -1106,6 +1106,9 @@ class DataNode(PGNode):
         """
         Cleans up processes and files created for this data node.
         """
+
+        self.stop_pg_autoctl()
+
         flags = ["--destroy"]
         if force:
             flags.append("--force")

--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -181,12 +181,12 @@ class Cluster:
 
         return abspath
 
-    def destroy(self):
+    def destroy(self, force=True):
         """
         Cleanup whatever was created for this Cluster.
         """
         for datanode in list(reversed(self.datanodes)):
-            datanode.destroy()
+            datanode.destroy(force=force)
         if self.monitor:
             self.monitor.destroy()
         self.vlan.destroy()
@@ -1100,11 +1100,15 @@ class DataNode(PGNode):
 
         return self.name
 
-    def destroy(self):
+    def destroy(self, force=False):
         """
         Cleans up processes and files created for this data node.
         """
         self.stop_pg_autoctl()
+
+        flags = ["--destroy"]
+        if force:
+            flags.append("--force")
 
         try:
             destroy = PGAutoCtl(self)
@@ -1112,8 +1116,7 @@ class DataNode(PGNode):
                 "pg_autoctl drop node --destroy",
                 "drop",
                 "node",
-                "--destroy",
-                "--force",
+                *flags,
                 timeout=3,
             )
         except Exception as e:


### PR DESCRIPTION
The following command would get stuck for 30 seconds when the pg_autoctl service was still running.
```
pg_autoctl drop node --pgdata node1 --force --destroy
```