### PR TITLE
Use -std=c11

### DIFF
--- a/src/bin/pg_autoctl/Makefile
+++ b/src/bin/pg_autoctl/Makefile
@@ -29,7 +29,7 @@ COMMON_LIBS += -I${SRC_DIR}../lib/parson/
 
 CC = $(shell $(PG_CONFIG) --cc)
 
-DEFAULT_CFLAGS = -std=c99 -D_GNU_SOURCE -g
+DEFAULT_CFLAGS = -std=c11 -D_GNU_SOURCE -g
 DEFAULT_CFLAGS += -I $(shell $(PG_CONFIG) --includedir)
 DEFAULT_CFLAGS += -I $(shell $(PG_CONFIG) --includedir-server)
 DEFAULT_CFLAGS += -I $(shell $(PG_CONFIG) --pkgincludedir)/internal

--- a/src/monitor/Makefile
+++ b/src/monitor/Makefile
@@ -12,7 +12,7 @@ DATA = $(EXTENSION)--1.0.sql $(patsubst ${SRC_DIR}%,%,$(wildcard ${SRC_DIR}$(EXT
 # compilation configuration
 MODULE_big = $(EXTENSION)
 OBJS = $(patsubst ${SRC_DIR}%.c,%.o,$(wildcard ${SRC_DIR}*.c))
-PG_CPPFLAGS = -std=c99 -Wall -Werror -Wno-unused-parameter -Iinclude -I$(libpq_srcdir) -g
+PG_CPPFLAGS = -std=c11 -Wall -Werror -Wno-unused-parameter -Iinclude -I$(libpq_srcdir) -g
 SHLIB_LINK = $(libpq)
 REGRESS = create_extension monitor workers dummy_update drop_extension upgrade
 
@@ -22,7 +22,7 @@ USE_PGXS = 1
 
 .PHONY: cleanup-before-install
 
-DEFAULT_CFLAGS = -std=c99 -D_GNU_SOURCE -g
+DEFAULT_CFLAGS = -std=c11 -D_GNU_SOURCE -g
 DEFAULT_CFLAGS += $(shell $(PG_CONFIG) --cflags)
 DEFAULT_CFLAGS += -Wformat
 DEFAULT_CFLAGS += -Wall


### PR DESCRIPTION
`_Static_assert` is not available in older compilers

https://gcc.gnu.org/wiki/C11Status
https://clang.llvm.org/c_status.html#c11