### PR TITLE
Fix monitor postgres not starting up the first time

### DIFF
--- a/src/bin/pg_autoctl/fsm_transition.c
+++ b/src/bin/pg_autoctl/fsm_transition.c
@@ -1464,10 +1464,18 @@ fsm_init_from_standby(Keeper *keeper)
 /*
  * fsm_drop_node is called to finish dropping a node on the client side.
  *
- * Nothing to do here, really.
+ * This stops postgres. It also cleans up any existing init file, which can
+ * confuse a possible future re-init of the node.
  */
 bool
 fsm_drop_node(Keeper *keeper)
 {
-	return true;
+	KeeperConfig *config = &(keeper->config);
+	if (!fsm_stop_postgres(keeper))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return unlink_file(config->pathnames.init);
 }

--- a/src/bin/pg_autoctl/fsm_transition.c
+++ b/src/bin/pg_autoctl/fsm_transition.c
@@ -1463,8 +1463,9 @@ fsm_init_from_standby(Keeper *keeper)
 /*
  * fsm_drop_node is called to finish dropping a node on the client side.
  *
- * This stops postgres. It also cleans up any existing init file, which can
- * confuse a possible future re-init of the node.
+ * This stops postgres and updates the postgres state file to say that postgres
+ * should be stopped. It also cleans up any existing init file. Not doing these
+ * two things can confuse a possible future re-init of the node.
  */
 bool
 fsm_drop_node(Keeper *keeper)

--- a/src/bin/pg_autoctl/fsm_transition.c
+++ b/src/bin/pg_autoctl/fsm_transition.c
@@ -164,7 +164,8 @@ fsm_init_primary(Keeper *keeper)
 			}
 		}
 	}
-	else if (initState->pgInitState >= PRE_INIT_STATE_RUNNING)
+	else if (initState->pgInitState >= PRE_INIT_STATE_RUNNING &&
+			 keeper->state.current_role != DROPPED_STATE)
 	{
 		log_error("PostgreSQL is already running at \"%s\", refusing to "
 				  "initialize a new cluster on-top of the current one.",

--- a/src/bin/pg_autoctl/fsm_transition.c
+++ b/src/bin/pg_autoctl/fsm_transition.c
@@ -164,8 +164,7 @@ fsm_init_primary(Keeper *keeper)
 			}
 		}
 	}
-	else if (initState->pgInitState >= PRE_INIT_STATE_RUNNING &&
-			 keeper->state.current_role != DROPPED_STATE)
+	else if (initState->pgInitState >= PRE_INIT_STATE_RUNNING)
 	{
 		log_error("PostgreSQL is already running at \"%s\", refusing to "
 				  "initialize a new cluster on-top of the current one.",

--- a/src/bin/pg_autoctl/keeper.c
+++ b/src/bin/pg_autoctl/keeper.c
@@ -1685,6 +1685,7 @@ keeper_register_and_init(Keeper *keeper, NodeState initialState)
 	if (keeper->state.current_role == DROPPED_STATE &&
 		!file_exists(keeper->config.pathnames.init))
 	{
+		log_info("Making sure postgres was stopped, when it was previously dropped");
 		ensure_postgres_service_is_stopped(&keeper->postgres);
 	}
 

--- a/src/bin/pg_autoctl/keeper.c
+++ b/src/bin/pg_autoctl/keeper.c
@@ -1674,6 +1674,21 @@ keeper_register_and_init(Keeper *keeper, NodeState initialState)
 	}
 
 	/*
+	 * If we dropped a primary using --force, it's possible that the postgres
+	 * state file still says that postgres should be running. In that case
+	 * postgres would probably be running now. The problem is that our
+	 * fsm_init_primary transation errors out when a postgres is running during
+	 * initialization. So if we were dropped and this is the first time
+	 * create is run after that, then we first stop postgres and record this
+	 * in our postgres state file.
+	 */
+	if (keeper->state.current_role == DROPPED_STATE &&
+		!file_exists(keeper->config.pathnames.init))
+	{
+		ensure_postgres_service_is_stopped(&keeper->postgres);
+	}
+
+	/*
 	 * Leave a track record that we're ok to initialize in PGDATA, so that in
 	 * case of `pg_autoctl create` being interrupted, we may resume operations
 	 * and accept to work on already running PostgreSQL primary instances.

--- a/src/bin/pg_autoctl/service_postgres_ctl.c
+++ b/src/bin/pg_autoctl/service_postgres_ctl.c
@@ -188,16 +188,6 @@ service_postgres_ctl_loop(LocalPostgresServer *postgres)
 	/* make sure to initialize the expected Postgres status to unknown */
 	pgStatus->pgExpectedStatus = PG_EXPECTED_STATUS_UNKNOWN;
 
-	if (pg_setup_pgdata_exists(pgSetup))
-	{
-		if (!local_postgres_set_status_path(postgres, true))
-		{
-			log_error("Failed to clean-up postgres state file pathname, "
-					  "see above for details.");
-			exit(EXIT_CODE_BAD_STATE);
-		}
-	}
-
 	for (;;)
 	{
 		int status;


### PR DESCRIPTION
The removal of the postgres state file had the unintended consequence that
postgres would not start on the monitor right away. This removal was done 
to fix some errors during rejoining after a node was dropped. 

This fixes those errors in another way, that don't impacting starting of
the monitor.