### PR TITLE
Set candidate priority without waiting for state changes in more cases.

### DIFF
--- a/src/bin/pg_autoctl/cli_get_set_properties.c
+++ b/src/bin/pg_autoctl/cli_get_set_properties.c
@@ -680,10 +680,10 @@ set_node_candidate_priority(Keeper *keeper, int candidatePriority)
 								   config->groupId,
 								   &nodesArray))
 	{
-		log_fatal("Failed to get the list of all the nodes in formation \"%s\" "
-				  "from the monitor, see above for details",
-				  keeper->config.formation);
-		return false;
+		/* ignore the error, just don't wait in that case */
+		log_warn("Failed to get the list of all the nodes in formation \"%s\" "
+				 "from the monitor, see above for details",
+				 keeper->config.formation);
 	}
 
 	/* ignore the result of the filtering, worst case we don't wait */

--- a/src/bin/pg_autoctl/cli_get_set_properties.c
+++ b/src/bin/pg_autoctl/cli_get_set_properties.c
@@ -668,21 +668,26 @@ static bool
 set_node_candidate_priority(Keeper *keeper, int candidatePriority)
 {
 	KeeperConfig *config = &(keeper->config);
-	NodeAddressArray nodesArray = { 0 };
+	CurrentNodeStateArray nodesArray = { 0 };
 
 	/*
 	 * There might be some race conditions here, but it's all to be
 	 * user-friendly so in the worst case we're going to be less friendly that
 	 * we could have.
 	 */
-	if (!monitor_get_nodes(&(keeper->monitor),
-						   config->formation,
-						   config->groupId,
-						   &nodesArray))
+	if (!monitor_get_current_state(&(keeper->monitor),
+								   config->formation,
+								   config->groupId,
+								   &nodesArray))
 	{
-		/* ignore the error, just don't wait in that case */
-		log_warn("Failed to get_nodes() on the monitor");
+		log_fatal("Failed to get the list of all the nodes in formation \"%s\" "
+				  "from the monitor, see above for details",
+				  keeper->config.formation);
+		return false;
 	}
+
+	/* ignore the result of the filtering, worst case we don't wait */
+	(void) nodestateFilterArrayGroup(&nodesArray, config->name);
 
 	/* listen for state changes BEFORE we apply new settings */
 	if (nodesArray.count > 1)

--- a/src/bin/pg_autoctl/pgsql.c
+++ b/src/bin/pg_autoctl/pgsql.c
@@ -1077,6 +1077,7 @@ pgsql_execute_with_params(PGSQL *pgsql, const char *sql, int paramCount,
 		 * with a badly formed SQL query etc.
 		 */
 		if (pgsql->connectionType == PGSQL_CONN_MONITOR &&
+			sqlstate != NULL &&
 			!(strcmp(sqlstate, ERRCODE_INVALID_OBJECT_DEFINITION) == 0 ||
 			  strcmp(sqlstate, ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE) == 0 ||
 			  strcmp(sqlstate, ERRCODE_OBJECT_IN_USE) == 0 ||


### PR DESCRIPTION
When dropping the last node with candidate priority greater than zero, we
might want to change the candidate priority of the last remaining node. The
client-side implementation of the command would wait for the APPLY_SETTINGS
cycle in some cases with dropped nodes, which is unfortunate: this PR fixes
that.