### PR TITLE
Fix upgrades

### DIFF
--- a/src/monitor/pgautofailover--1.5--1.6.sql
+++ b/src/monitor/pgautofailover--1.5--1.6.sql
@@ -447,6 +447,9 @@ begin
 end
 $$;
 
+comment on function pgautofailover.update_secondary_check()
+        is 'performs a check when changes to hassecondary on pgautofailover.formation are made, verifying cluster state allows the change';
+
 CREATE TRIGGER disable_secondary_check
 	BEFORE UPDATE
 	ON pgautofailover.formation

--- a/src/monitor/pgautofailover--1.5--1.6.sql
+++ b/src/monitor/pgautofailover--1.5--1.6.sql
@@ -605,6 +605,7 @@ AS $$
     where formationid = formation_id
       and groupid = group_id
  order by groupid, nodeid;
+$$;
 
 grant execute on function pgautofailover.current_state(text, int)
    to autoctl_node;

--- a/src/monitor/pgautofailover.sql
+++ b/src/monitor/pgautofailover.sql
@@ -617,6 +617,9 @@ $$;
 comment on function pgautofailover.current_state(text)
         is 'get the current state of both nodes of a formation';
 
+grant execute on function pgautofailover.current_state(text)
+   to autoctl_node;
+
 CREATE FUNCTION pgautofailover.current_state
  (
     IN formation_id         text,
@@ -651,6 +654,9 @@ $$;
 
 comment on function pgautofailover.current_state(text, int)
         is 'get the current state of both nodes of a group in a formation';
+
+grant execute on function pgautofailover.current_state(text, int)
+   to autoctl_node;
 
 
 CREATE FUNCTION pgautofailover.formation_uri


### PR DESCRIPTION
There was a syntax error in the upgrade scripts, making it impossible to
upgrade. This also alligns the initial sql migration and the upgrade version
with eachother with respect to comments and grants.