### PR TITLE
Set the pgautofailover_monitor user's password to NULL.

### DIFF
--- a/src/bin/pg_autoctl/cli_do_misc.c
+++ b/src/bin/pg_autoctl/cli_do_misc.c
@@ -150,7 +150,7 @@ keeper_cli_create_monitor_user(int argc, char **argv)
 
 	if (!primary_create_user_with_hba(&postgres,
 									  PG_AUTOCTL_HEALTH_USERNAME,
-									  PG_AUTOCTL_HEALTH_PASSWORD,
+									  NULL, /* no password */
 									  monitorHostname,
 									  "trust",
 									  HBA_EDIT_MINIMAL,

--- a/src/bin/pg_autoctl/defaults.h
+++ b/src/bin/pg_autoctl/defaults.h
@@ -121,7 +121,6 @@
 
 /* pg_auto_failover monitor related constants */
 #define PG_AUTOCTL_HEALTH_USERNAME "pgautofailover_monitor"
-#define PG_AUTOCTL_HEALTH_PASSWORD "pgautofailover_monitor"
 #define PG_AUTOCTL_REPLICA_USERNAME "pgautofailover_replicator"
 
 #define PG_AUTOCTL_MONITOR_DBNAME "pg_auto_failover"

--- a/src/bin/pg_autoctl/fsm_transition.c
+++ b/src/bin/pg_autoctl/fsm_transition.c
@@ -271,7 +271,7 @@ fsm_init_primary(Keeper *keeper)
 		 */
 		if (!primary_create_user_with_hba(postgres,
 										  PG_AUTOCTL_HEALTH_USERNAME,
-										  PG_AUTOCTL_HEALTH_PASSWORD,
+										  NULL, /* no password */
 										  monitorHostname,
 										  "trust",
 										  pgSetup->hbaLevel,

--- a/src/bin/pg_autoctl/pgsql.c
+++ b/src/bin/pg_autoctl/pgsql.c
@@ -2221,7 +2221,7 @@ pgsql_create_user(PGSQL *pgsql, const char *userName, const char *password,
 	{
 		appendPQExpBuffer(query, " CONNECTION LIMIT %d", connlimit);
 	}
-	if (password)
+	if (password && !IS_EMPTY_STRING_BUFFER(password))
 	{
 		/* show the statement before we append the password */
 		log_debug("Running command on Postgres: %s PASSWORD '*****';", query->data);


### PR DESCRIPTION
We don't actually need to have a password for this user, given that the
monitor doesn't authenticate when doing health checks. Not having a password
to manage also makes it easier to by compliant with password storage
policies of our users (e.g. md5 vs scram-sha-256).

Fixes #763.