### PR TITLE
Refrain from using PGPASSWORD for pg_basebackup connection.

### DIFF
--- a/src/bin/pg_autoctl/pgctl.c
+++ b/src/bin/pg_autoctl/pgctl.c
@@ -1268,6 +1268,7 @@ pg_basebackup(const char *pgdata,
 	int argsIndex = 0;
 
 	char command[BUFSIZE];
+	char pgpassword[BUFSIZE] = { 0 };
 
 	log_debug("mkdir -p \"%s\"", replicationSource->backupDir);
 	if (!ensure_empty_dir(replicationSource->backupDir, 0700))
@@ -1289,6 +1290,14 @@ pg_basebackup(const char *pgdata,
 
 	if (!IS_EMPTY_STRING_BUFFER(replicationSource->password))
 	{
+		if (env_exists("PGPASSWORD"))
+		{
+			if (!get_env_copy("PGPASSWORD", pgpassword, sizeof(pgpassword)))
+			{
+				/* errors have already been logged. */
+				return false;
+			}
+		}
 		setenv("PGPASSWORD", replicationSource->password, 1);
 	}
 	setenv("PGAPPNAME", replicationSource->applicationName, 1);
@@ -1356,6 +1365,19 @@ pg_basebackup(const char *pgdata,
 
 	(void) execute_subprogram(&program);
 
+	/* clean-up the environment again */
+	if (!IS_EMPTY_STRING_BUFFER(replicationSource->password))
+	{
+		if (IS_EMPTY_STRING_BUFFER(pgpassword))
+		{
+			unsetenv("PGPASSWORD");
+		}
+		else
+		{
+			setenv("PGPASSWORD", pgpassword, 1);
+		}
+	}
+
 	returnCode = program.returnCode;
 	free_program(&program);
 
@@ -1409,6 +1431,7 @@ pg_rewind(const char *pgdata,
 	int argsIndex = 0;
 
 	char command[BUFSIZE];
+	char pgpassword[BUFSIZE] = { 0 };
 
 	/* call pg_rewind*/
 	path_in_same_directory(pg_ctl, "pg_rewind", pg_rewind);
@@ -1417,6 +1440,14 @@ pg_rewind(const char *pgdata,
 
 	if (!IS_EMPTY_STRING_BUFFER(replicationSource->password))
 	{
+		if (env_exists("PGPASSWORD"))
+		{
+			if (!get_env_copy("PGPASSWORD", pgpassword, sizeof(pgpassword)))
+			{
+				/* errors have already been logged. */
+				return false;
+			}
+		}
 		setenv("PGPASSWORD", replicationSource->password, 1);
 	}
 
@@ -1467,6 +1498,19 @@ pg_rewind(const char *pgdata,
 	}
 
 	(void) execute_subprogram(&program);
+
+	/* clean-up the environment again */
+	if (!IS_EMPTY_STRING_BUFFER(replicationSource->password))
+	{
+		if (IS_EMPTY_STRING_BUFFER(pgpassword))
+		{
+			unsetenv("PGPASSWORD");
+		}
+		else
+		{
+			setenv("PGPASSWORD", pgpassword, 1);
+		}
+	}
 
 	returnCode = program.returnCode;
 	free_program(&program);


### PR DESCRIPTION
Using the environment variable allows to omit the replication password from
the logs, though messes with next connection attempts. We should either call
unsetenv() once the pg_basebackup command has finished, or use the password
on the connection string.

In this tentative PR we use the password in the connection string.

Should fix #766.