### PR TITLE
Avoid re-electing primary during a switchover.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,7 @@ test:
 	sudo -E env "PATH=${PATH}" USER=$(shell whoami) \
 		$(NOSETESTS)			\
 		--verbose				\
+		--nologcapture			\
 		--nocapture				\
 		--stop					\
 		${TEST_ARGUMENT}

--- a/src/monitor/group_state_machine.c
+++ b/src/monitor/group_state_machine.c
@@ -1922,7 +1922,14 @@ PromoteSelectedNode(AutoFailoverNode *selectedNode,
 		{
 			AutoFailoverNode *node = (AutoFailoverNode *) lfirst(nodeCell);
 
-			if (node && node->candidatePriority < 0)
+			if (node == NULL)
+			{
+				/* shouldn't happen */
+				ereport(ERROR, (errmsg("BUG: node is NULL")));
+				continue;
+			}
+
+			if (node->candidatePriority < 0)
 			{
 				char message[BUFSIZE] = { 0 };
 
@@ -1937,7 +1944,7 @@ PromoteSelectedNode(AutoFailoverNode *selectedNode,
 
 				LogAndNotifyMessage(
 					message, BUFSIZE,
-					"Updating candidate priority to %d for " NODE_FORMAT,
+					"Updating candidate priority back to %d for " NODE_FORMAT,
 					node->candidatePriority,
 					NODE_FORMAT_ARGS(node));
 

--- a/src/monitor/node_active_protocol.c
+++ b/src/monitor/node_active_protocol.c
@@ -1399,6 +1399,8 @@ perform_failover(PG_FUNCTION_ARGS)
 		 * old primary is often in the best situation to win the election. In
 		 * that case, we trick the candidate priority in a way that makes the
 		 * node lose the election.
+		 *
+		 * We undo this change in priority once the election completes.
 		 */
 		if (primaryNode)
 		{

--- a/src/monitor/node_active_protocol.c
+++ b/src/monitor/node_active_protocol.c
@@ -1268,9 +1268,6 @@ perform_failover(PG_FUNCTION_ARGS)
 	char *formationId = text_to_cstring(formationIdText);
 	int32 groupId = PG_GETARG_INT32(1);
 
-
-	char message[BUFSIZE] = { 0 };
-
 	LockFormation(formationId, ShareLock);
 	LockNodeGroup(formationId, groupId, ExclusiveLock);
 
@@ -1363,6 +1360,8 @@ perform_failover(PG_FUNCTION_ARGS)
 							 "perform a manual failover")));
 		}
 
+		char message[BUFSIZE] = { 0 };
+
 		LogAndNotifyMessage(
 			message, BUFSIZE,
 			"Setting goal state of " NODE_FORMAT
@@ -1381,7 +1380,7 @@ perform_failover(PG_FUNCTION_ARGS)
 	{
 		List *standbyNodesGroupList = AutoFailoverOtherNodesList(primaryNode);
 		AutoFailoverNode *firstStandbyNode = linitial(standbyNodesGroupList);
-		char message[BUFSIZE];
+		char message[BUFSIZE] = { 0 };
 
 		/* so we have at least one candidate, let's get started */
 		LogAndNotifyMessage(
@@ -1404,6 +1403,8 @@ perform_failover(PG_FUNCTION_ARGS)
 		 */
 		if (primaryNode)
 		{
+			char message[BUFSIZE] = { 0 };
+
 			primaryNode->candidatePriority -= CANDIDATE_PRIORITY_INCREMENT;
 
 			ReportAutoFailoverNodeReplicationSetting(

--- a/src/monitor/node_metadata.c
+++ b/src/monitor/node_metadata.c
@@ -695,9 +695,7 @@ GroupListCandidates(List *groupNodeList)
 	List *sortedNodeList = list_copy(groupNodeList);
 
 	#if (PG_VERSION_NUM >= 130000)
-	sortedNodeList =
-		list_sort(sortedNodeList,
-				  pgautofailover_node_candidate_priority_compare);
+	list_sort(sortedNodeList, pgautofailover_node_candidate_priority_compare);
 	#else
 	sortedNodeList =
 		list_qsort(sortedNodeList,

--- a/src/monitor/node_metadata.c
+++ b/src/monitor/node_metadata.c
@@ -692,12 +692,15 @@ GroupListCandidates(List *groupNodeList)
 	ListCell *nodeCell = NULL;
 	List *candidateNodesList = NIL;
 
-	#if (PG_VERSION_NUM >= 130000)
 	List *sortedNodeList = list_copy(groupNodeList);
-	list_sort(sortedNodeList, pgautofailover_node_candidate_priority_compare);
+
+	#if (PG_VERSION_NUM >= 130000)
+	sortedNodeList =
+		list_sort(sortedNodeList,
+				  pgautofailover_node_candidate_priority_compare);
 	#else
-	List *sortedNodeList =
-		list_qsort(groupNodeList,
+	sortedNodeList =
+		list_qsort(sortedNodeList,
 				   pgautofailover_node_candidate_priority_compare);
 	#endif
 

--- a/tests/test_multi_standbys.py
+++ b/tests/test_multi_standbys.py
@@ -189,7 +189,7 @@ def test_007_create_t1():
 
 def test_008_set_candidate_priorities():
     # set priorities in a way that we know the candidate: node2
-    node1.set_candidate_priority(80)  # current primary
+    node1.set_candidate_priority(90)  # current primary
     node2.set_candidate_priority(90)
     node3.set_candidate_priority(70)
 


### PR DESCRIPTION
When all the nodes are up and running, including the primary, a switchover
has a great chance of finding that the current primary is then the best
candidate to with the primary election, making the operation a no-op.

In this PR we tweak the current primary node's candidate priority in a way
that should make it lose the election, and reset the priority when the
election is over.

Fixes #770.