### PR TITLE
Bump theme version to fix docs search

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 Sphinx==4.0.2
-sphinx_rtd_theme_citus==0.5.12
+sphinx_rtd_theme_citus==0.5.16
 docutils==0.16
 readthedocs-sphinx-search==0.1.0


### PR DESCRIPTION
@DimCitus I discovered that my theme changes had broken the search page. This version fixes that.