### PR TITLE
Fix replication slot maintenance on secondary nodes.

### DIFF
--- a/src/bin/pg_autoctl/pgsql.c
+++ b/src/bin/pg_autoctl/pgsql.c
@@ -1704,6 +1704,7 @@ pgsql_replication_slot_maintain(PGSQL *pgsql, NodeAddressArray *nodeArray)
 		"  FROM pg_replication_slots s JOIN nodes USING(slot_name), "
 		"       LATERAL pg_replication_slot_advance(slot_name, lsn) a"
 		" WHERE nodes.lsn <> '0/0' and nodes.lsn >= s.restart_lsn "
+		"   and not s.active "
 		"), \n"
 		"created as ("
 		"SELECT c.slot_name, c.lsn "


### PR DESCRIPTION
It might happen that a node continues streaming from a secondary after a
failover, and in that case the streaming replication protocol takes care of
maintaining the replication slot. Trying to use pg_replication_slot_advance
would then fail.

This situation currently can arise when a node is in maintenance a failover
happens, where the node in maintenance stays connected to the old-primary,
now repurposed as a secondary.

This situation could also arise when a cascading replication setup is
considered. We don't have direct support for those architectures at the
moment, though that's something of interest for the future.

Fixes #769 