### PR TITLE
Fix problems with bad migration to 1.5

### DIFF
--- a/src/monitor/pgautofailover--1.5--1.6.sql
+++ b/src/monitor/pgautofailover--1.5--1.6.sql
@@ -4,6 +4,13 @@
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "CREATE EXTENSION pgautofailover" to load this file. \quit
 
+-- remove a possible leftover from pg_auto_failover 1.4 that was not correctly
+-- removed in a migration to 1.5
+DROP FUNCTION IF EXISTS
+     pgautofailover.register_node(text,text,int,name,text,bigint,int,
+                                  pgautofailover.replication_state,text,
+                                  int,bool);
+
 DROP FUNCTION
      pgautofailover.register_node(text,text,int,name,text,bigint,int,int,
                                   pgautofailover.replication_state,text,


### PR DESCRIPTION
The script to migrate from 1.4 to 1.5 did not correctly remove the old
`register_node` function. This caused issues for the migration from 1.5
to 1.6, because we remove the old `replication_state` type there. The
old `register_node` function still depended on this version of the
`replication_state` type, so it's removal was blocked.

Fixes #784