### PR TITLE
Use more cores while installing

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Then build pg_auto_failover from sources with the following instructions:
 
 ~~~ bash
 $ make
-$ sudo make install
+$ sudo make install -j10
 ~~~
 
 For this to work though, the PostgreSQL client (libpq) and server


### PR DESCRIPTION
We can also get the core number dynamically but using `10` is probably sufficient in many cases.

