### PR TITLE
Edit maintenance nodes out of synchronous_standby_names.

### DIFF
--- a/src/bin/pg_autoctl/fsm_transition.c
+++ b/src/bin/pg_autoctl/fsm_transition.c
@@ -563,7 +563,9 @@ fsm_enable_sync_rep(Keeper *keeper)
 	 * actually enable sync rep here. In that case don't bother making sure the
 	 * standbys have reached a meaningful LSN target before continuing.
 	 */
-	if (streq(postgres->synchronousStandbyNames, ""))
+	if (streq(postgres->synchronousStandbyNames, "") ||
+		streq(postgres->synchronousStandbyNames,
+			  "pgautofailover_maintenance_blocks_writes"))
 	{
 		return true;
 	}

--- a/tests/test_multi_maintenance.py
+++ b/tests/test_multi_maintenance.py
@@ -126,8 +126,8 @@ def test_006a_maintenance_and_failover():
     # assigned and goal state must be the same
     assert node1.wait_until_state(target_state="primary")
 
-    # ssn is not changed during maintenance operations
-    ssn = "ANY 1 (pgautofailover_standby_3, pgautofailover_standby_2)"
+    # ssn is changed during maintenance operations
+    ssn = "ANY 1 (pgautofailover_standby_3)"
     eq_(node1.get_synchronous_standby_names(), ssn)
     eq_(node1.get_synchronous_standby_names_local(), ssn)
 
@@ -137,7 +137,7 @@ def test_006a_maintenance_and_failover():
     assert node1.wait_until_state(target_state="secondary")
 
     # now that node3 is primary, synchronous_standby_names has changed
-    ssn = "ANY 1 (pgautofailover_standby_1, pgautofailover_standby_2)"
+    ssn = "ANY 1 (pgautofailover_standby_1)"
     node3.check_synchronous_standby_names(ssn)
 
     print("Disabling maintenance on node2, should connect to the new primary")
@@ -165,7 +165,8 @@ def test_006a_maintenance_and_failover():
     assert node2.wait_until_state(target_state="secondary")
     assert node3.wait_until_state(target_state="primary")
 
-    # ssn is not changed during maintenance operations
+    # ssn is changed during maintenance operations
+    ssn = "ANY 1 (pgautofailover_standby_1, pgautofailover_standby_2)"
     node3.check_synchronous_standby_names(ssn)
 
     assert node1.has_needed_replication_slots()
@@ -199,7 +200,7 @@ def test_007b_node2_to_maintenance():
 
     # when both secondaries are put to maintenance, writes are blocked on
     # the primary
-    ssn = "ANY 1 (pgautofailover_standby_1, pgautofailover_standby_2)"
+    ssn = "pgautofailover_maintenance_blocks_writes"
     node3.check_synchronous_standby_names(ssn)
 
 


### PR DESCRIPTION
When a node is ongoing maintenance, the operator can use our maintenance
state to avoid our automation to continue driving the node. We're asked to
get pg_auto_failover out of the wheel.

In that situation, we want to avoid the node in maintenance to be connected
to the primary and acknowledge transaction commits: if then later we would
have to failover to a new node, we would open the hazard of selecting a node
that doesn't have all the reported commits. Because a commit could have made
it to a node in maintenance, and this node will not be taking part of the
failover process, neither as a candidate, not as a WAL source.

To ensure that commits won't get accepted by nodes in maintenance, we now
set synchronous_standby_names to 'pgautofailover_maintenance_blocks_writes',
a standby name that is otherwise never used. That ensures blocking all the
commits on the primary while every single one of the standby nodes is
ongoing maintenance.

To unblock the situation, it is possible to either pg_autoctl disable
maintenance on a standby node, or to pg_autoctl set formation
number-sync-standbys 0.