### PR TITLE
Per valgrind, fix some memory leaks.

### DIFF
--- a/src/bin/pg_autoctl/pgsql.c
+++ b/src/bin/pg_autoctl/pgsql.c
@@ -1717,8 +1717,8 @@ pgsql_replication_slot_maintain(PGSQL *pgsql, NodeAddressArray *nodeArray)
 	if (!BuildNodesArrayValues(nodeArray, &sqlParams, values))
 	{
 		/* errors have already been logged */
-		PQfreemem(query);
-		PQfreemem(values);
+		destroyPQExpBuffer(query);
+		destroyPQExpBuffer(values);
 
 		return false;
 	}
@@ -1735,8 +1735,8 @@ pgsql_replication_slot_maintain(PGSQL *pgsql, NodeAddressArray *nodeArray)
 								  &context,
 								  parseReplicationSlotMaintain);
 
-	PQfreemem(query);
-	PQfreemem(values);
+	destroyPQExpBuffer(query);
+	destroyPQExpBuffer(values);
 
 	return success;
 }

--- a/src/bin/pg_autoctl/pgsql.c
+++ b/src/bin/pg_autoctl/pgsql.c
@@ -1640,8 +1640,8 @@ pgsql_replication_slot_create_and_drop(PGSQL *pgsql, NodeAddressArray *nodeArray
 	if (!BuildNodesArrayValues(nodeArray, &sqlParams, values))
 	{
 		/* errors have already been logged */
-		PQfreemem(query);
-		PQfreemem(values);
+		destroyPQExpBuffer(query);
+		destroyPQExpBuffer(values);
 
 		return false;
 	}
@@ -1658,8 +1658,8 @@ pgsql_replication_slot_create_and_drop(PGSQL *pgsql, NodeAddressArray *nodeArray
 								  &context,
 								  parseReplicationSlotMaintain);
 
-	PQfreemem(query);
-	PQfreemem(values);
+	destroyPQExpBuffer(query);
+	destroyPQExpBuffer(values);
 
 	return success;
 }

--- a/src/bin/pg_autoctl/service_keeper.c
+++ b/src/bin/pg_autoctl/service_keeper.c
@@ -661,6 +661,7 @@ keeper_node_active_loop(Keeper *keeper, pid_t start_pid)
 
 	/* One last check that we do not have any connections open */
 	pgsql_finish(&(keeper->monitor.pgsql));
+	pgsql_finish(&(monitor->notificationClient));
 
 	if (nodeHasBeenDroppedFromTheMonitor)
 	{


### PR DESCRIPTION
We would be using PQfreemem on a PQExpBuffer, where it's expected to be
using destroyPQExpBuffer instead.

Also we were short of a call to finish the
connection to the monitor notification client when exiting from the service
keeper process, although adding this clean-up doesn't seem to impact the
valgrind reports.

Fixes #679 (again).