### PR TITLE
Not require primary node to be up for synchronous_standby_names

### DIFF
--- a/src/monitor/node_active_protocol.c
+++ b/src/monitor/node_active_protocol.c
@@ -2392,13 +2392,6 @@ synchronous_standby_names(PG_FUNCTION_ARGS)
 	/* when we have more than one node, fetch the primary */
 	AutoFailoverNode *primaryNode = GetPrimaryNodeInGroup(formationId, groupId);
 
-	if (primaryNode == NULL)
-	{
-		ereport(ERROR,
-				(errmsg("Couldn't find the primary node in formation \"%s\", "
-						"group %d", formationId, groupId)));
-	}
-
 	List *standbyNodesGroupList = AutoFailoverOtherNodesList(primaryNode);
 
 	/*


### PR DESCRIPTION
We don't need to require the primary to be up to see `synchronous_standby_names`. 

Also there seems to be other places where we require `primary` node to be up. It makes sense to go over them and see if it is a requirement or we can loose the condition.

Fixes https://github.com/citusdata/pg_auto_failover/issues/718