### PR TITLE
fix: Allow setting maximum-backup-rate on create postgres step

### DIFF
--- a/docs/ref/pg_autoctl_create_postgres.rst
+++ b/docs/ref/pg_autoctl_create_postgres.rst
@@ -40,6 +40,7 @@ registered too, and is known to be healthy).
      --server-cert     set the Postgres ssl_cert_file to that file path
      --candidate-priority    priority of the node to be promoted to become primary
      --replication-quorum    true if node participates in write quorum
+     --maximum-backup-rate    maximum transfer rate of data transferred from the server during initial sync
 
 Description
 -----------
@@ -260,6 +261,12 @@ The following options are available to ``pg_autoctl create postgres``:
   Sets this node replication setting for replication quorum to the given
   value (either ``true`` or ``false``) at node registration on the monitor.
   Defaults to ``true``, which enables synchronous replication.
+
+--maximum-backup-rate
+
+  Sets the maximum transfer rate of data transferred from the server during
+  initial sync. This is used by ``pg_basebackup``.
+  Defaults to ``100M``.
 
 --run
 

--- a/docs/ref/pg_autoctl_create_postgres.rst
+++ b/docs/ref/pg_autoctl_create_postgres.rst
@@ -40,7 +40,7 @@ registered too, and is known to be healthy).
      --server-cert     set the Postgres ssl_cert_file to that file path
      --candidate-priority    priority of the node to be promoted to become primary
      --replication-quorum    true if node participates in write quorum
-     --maximum-backup-rate    maximum transfer rate of data transferred from the server during initial sync
+     --maximum-backup-rate   maximum transfer rate of data transferred from the server during initial sync
 
 Description
 -----------

--- a/src/bin/pg_autoctl/cli_common.c
+++ b/src/bin/pg_autoctl/cli_common.c
@@ -393,8 +393,10 @@ cli_common_keeper_getopts(int argc, char **argv,
 			case 'R':
 			{
 				/* { "maximum-backup-rate", required_argument, NULL, 'R' } */
-				strlcpy(LocalOptionConfig.maximum_backup_rate, optarg, MAXIMUM_BACKUP_RATE_LEN);
-				log_trace("--maximum-backup-rate %s", LocalOptionConfig.maximum_backup_rate);
+				strlcpy(LocalOptionConfig.maximum_backup_rate, optarg,
+						MAXIMUM_BACKUP_RATE_LEN);
+				log_trace("--maximum-backup-rate %s",
+						  LocalOptionConfig.maximum_backup_rate);
 				break;
 			}
 

--- a/src/bin/pg_autoctl/cli_common.c
+++ b/src/bin/pg_autoctl/cli_common.c
@@ -73,6 +73,7 @@ int monitorDisabledNodeId = -1;
  *      { "citus-cluster", required_argument, NULL, 'Z' },
  *		{ "candidate-priority", required_argument, NULL, 'P'},
  *		{ "replication-quorum", required_argument, NULL, 'r'},
+ *		{ "maximum-backup-rate", required_argument, NULL, 'R' },
  *		{ "help", no_argument, NULL, 0 },
  *		{ "run", no_argument, NULL, 'x' },
  *      { "ssl-self-signed", no_argument, NULL, 's' },
@@ -386,6 +387,14 @@ cli_common_keeper_getopts(int argc, char **argv,
 
 				LocalOptionConfig.pgSetup.settings.replicationQuorum = replicationQuorum;
 				log_trace("--replication-quorum %s", boolToString(replicationQuorum));
+				break;
+			}
+
+			case 'R':
+			{
+				/* { "maximum-backup-rate", required_argument, NULL, 'R' } */
+				strlcpy(LocalOptionConfig.maximum_backup_rate, optarg, MAXIMUM_BACKUP_RATE_LEN);
+				log_trace("--maximum-backup-rate %s", LocalOptionConfig.maximum_backup_rate);
 				break;
 			}
 

--- a/src/bin/pg_autoctl/cli_create_node.c
+++ b/src/bin/pg_autoctl/cli_create_node.c
@@ -92,7 +92,7 @@ CommandLine create_postgres_command =
 		KEEPER_CLI_SSL_OPTIONS
 		"  --candidate-priority    priority of the node to be promoted to become primary\n"
 		"  --replication-quorum    true if node participates in write quorum\n"
-		"  --maximum-backup-rate	maximum transfer rate of data transferred from the server during initial sync\n",
+		"  --maximum-backup-rate   maximum transfer rate of data transferred from the server during initial sync\n",
 		cli_create_postgres_getopts,
 		cli_create_postgres);
 

--- a/src/bin/pg_autoctl/cli_create_node.c
+++ b/src/bin/pg_autoctl/cli_create_node.c
@@ -91,7 +91,8 @@ CommandLine create_postgres_command =
 		"  --pg-hba-lan      edit pg_hba.conf rules for --dbname in detected LAN\n"
 		KEEPER_CLI_SSL_OPTIONS
 		"  --candidate-priority    priority of the node to be promoted to become primary\n"
-		"  --replication-quorum    true if node participates in write quorum\n",
+		"  --replication-quorum    true if node participates in write quorum\n"
+		"  --maximum-backup-rate	maximum transfer rate of data transferred from the server during initial sync\n",
 		cli_create_postgres_getopts,
 		cli_create_postgres);
 
@@ -272,6 +273,7 @@ cli_create_postgres_getopts(int argc, char **argv)
 		{ "help", no_argument, NULL, 'h' },
 		{ "candidate-priority", required_argument, NULL, 'P' },
 		{ "replication-quorum", required_argument, NULL, 'r' },
+		{ "maximum-backup-rate", required_argument, NULL, 'R' },
 		{ "run", no_argument, NULL, 'x' },
 		{ "no-ssl", no_argument, NULL, 'N' },
 		{ "ssl-self-signed", no_argument, NULL, 's' },


### PR DESCRIPTION
This PR allows configuring the `maximum-backup-rate` setting when running `pg_autoctl create postgres`.

Fixes #780 