### PR TITLE
Bug/837 No need to checkpoint and restart if pg is not running

### DIFF
--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -655,16 +655,20 @@ class PGNode:
             out, err, ret = command.execute("show uri", "show", "uri")
         return out
 
-    def logs(self):
+    def logs(self, log_type=""):
         log_string = ""
         if self.running():
             out, err, ret = self.stop_pg_autoctl()
-            log_string += f"STDOUT OF PG_AUTOCTL FOR {self.datadir}:\n"
-            log_string += f"{self.pg_autoctl.cmd}\n{out}\n"
-            log_string += f"STDERR OF PG_AUTOCTL FOR {self.datadir}:\n{err}\n"
-
-        pglogs = self.get_postgres_logs()
-        log_string += f"POSTGRES LOGS FOR {self.datadir}:\n{pglogs}\n"
+            if not log_type or (log_type == "STDOUT"):
+                log_string += f"STDOUT OF PG_AUTOCTL FOR {self.datadir}:\n"
+                log_string += f"{self.pg_autoctl.cmd}\n{out}\n"
+            if not log_type or (log_type == "STDERR"):
+                log_string += (
+                    f"STDERR OF PG_AUTOCTL FOR {self.datadir}:\n{err}\n"
+                )
+        if not log_type or (log_type == "POSTGRES"):
+            pglogs = self.get_postgres_logs()
+            log_string += f"POSTGRES LOGS FOR {self.datadir}:\n{pglogs}\n"
         return log_string
 
     def get_events_str(self):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -97,7 +97,7 @@ def test_005_logging_of_passwords():
     assert "password=****" in logs
     # We are still logging passwords when the pguri is incomplete and when printing settings,
     #  so assert that it's not there in other cases:
-    assert not re.match(
+    assert not re.search(
         "^(?!primary_conninfo|Failed to find).*%s.*$" % replication_password,
         logs,
     )

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -68,6 +68,14 @@ def test_003_init_secondary():
         node1.get_synchronous_standby_names_local(),
         "ANY 1 (pgautofailover_standby_2)",
     )
+    logs = node2.logs("STDERR")
+    match = re.search(
+        "Failed to connect to .*, retrying until the server is ready", logs
+    )
+    if match:
+        print("Found connection failure in logs: ", match[0])
+    assert not match
+    node2.run()
 
 
 def test_004_failover():


### PR DESCRIPTION
When updating replication settings, no need to attempt a checkpoint and
restart when postgres keeper is not running. Just start the service.

Fixes #837