### PR TITLE
Add support for tablespaces

### DIFF
--- a/docs/ref/pg_autoctl_create_postgres.rst
+++ b/docs/ref/pg_autoctl_create_postgres.rst
@@ -41,6 +41,7 @@ registered too, and is known to be healthy).
      --candidate-priority    priority of the node to be promoted to become primary
      --replication-quorum    true if node participates in write quorum
      --maximum-backup-rate   maximum transfer rate of data transferred from the server during initial sync
+     --tablespace-mappings   tablespace mapping options for pg_basebackup; semicolon separated
 
 Description
 -----------
@@ -303,3 +304,14 @@ The following options are available to ``pg_autoctl create postgres``:
 --server-cert
 
   Set the Postgres ``ssl_cert_file`` to that file path.
+
+--tablespace-mappings
+
+  Sets the tablespace mapping options for ``pg_basebackup``.
+  Tablespace mappings should be semicolon separated.
+
+  This option should be used when creating nodes for a cluster with additional tablespaces.
+  To add additional an additional tablespace after the fact, see the Postgres documentation.
+
+  __ https://www.postgresql.org/docs/current/manage-ag-tablespaces.html
+  __ https://www.postgresql.org/docs/current/warm-standby.html#STANDBY-SERVER-OPERATION

--- a/src/bin/pg_autoctl/cli_common.c
+++ b/src/bin/pg_autoctl/cli_common.c
@@ -573,6 +573,20 @@ cli_common_keeper_getopts(int argc, char **argv,
 				break;
 			}
 
+			case 'T':
+			{
+				strlcpy(LocalOptionConfig.tablespaceMappingsStr, optarg,
+						PG_AUTOCTL_MAX_TABLESPACES_STR);
+				log_trace("--tablespace-mappings %s",
+						  LocalOptionConfig.tablespaceMappingsStr);
+				if (!parse_tablespace_mappings(&LocalOptionConfig))
+				{
+					/* error has already been logged */
+					errors++;
+				}
+				break;
+			}
+
 			default:
 			{
 				/* getopt_long already wrote an error message */
@@ -705,6 +719,7 @@ cli_common_keeper_getopts(int argc, char **argv,
  *      { "server-crt", required_argument, &ssl_flag, SSL_SERVER_CRT_FLAG },
  *      { "server-key", required_argument, &ssl_flag, SSL_SERVER_KEY_FLAG },
  *      { "ssl-mode", required_argument, &ssl_flag, SSL_MODE_FLAG },
+ *      { "tablespace-mappings", no_argument, NULL, 'T' },
  *		{ NULL, 0, NULL, 0 }
  *	};
  *

--- a/src/bin/pg_autoctl/cli_create_node.c
+++ b/src/bin/pg_autoctl/cli_create_node.c
@@ -92,7 +92,8 @@ CommandLine create_postgres_command =
 		KEEPER_CLI_SSL_OPTIONS
 		"  --candidate-priority    priority of the node to be promoted to become primary\n"
 		"  --replication-quorum    true if node participates in write quorum\n"
-		"  --maximum-backup-rate   maximum transfer rate of data transferred from the server during initial sync\n",
+		"  --maximum-backup-rate   maximum transfer rate of data transferred from the server during initial sync\n"
+		"  --tablespace-mappings   tablespace mapping options for pg_basebackup; semicolon separated\n",
 		cli_create_postgres_getopts,
 		cli_create_postgres);
 
@@ -282,12 +283,13 @@ cli_create_postgres_getopts(int argc, char **argv)
 		{ "ssl-crl-file", required_argument, &ssl_flag, SSL_CRL_FILE_FLAG },
 		{ "server-cert", required_argument, &ssl_flag, SSL_SERVER_CRT_FLAG },
 		{ "server-key", required_argument, &ssl_flag, SSL_SERVER_KEY_FLAG },
+		{ "tablespace-mappings", required_argument, NULL, 'T' },
 		{ NULL, 0, NULL, 0 }
 	};
 
 	int optind =
 		cli_create_node_getopts(argc, argv, long_options,
-								"C:D:H:p:l:U:A:SLd:a:n:f:m:MI:RVvqhP:r:xsN",
+								"C:D:H:p:l:U:A:SLd:a:n:f:m:MI:RVvqhP:r:xsN:T",
 								&options);
 
 	/* publish our option parsing in the global variable */

--- a/src/bin/pg_autoctl/cli_do_misc.c
+++ b/src/bin/pg_autoctl/cli_do_misc.c
@@ -440,7 +440,8 @@ keeper_cli_init_standby(int argc, char **argv)
 										 config.backupDirectory,
 										 NULL, /* no targetLSN */
 										 config.pgSetup.ssl,
-										 0))
+										 0,
+										 &config.mappings))
 	{
 		/* can't happen at the moment */
 		exit(EXIT_CODE_INTERNAL_ERROR);
@@ -499,7 +500,8 @@ keeper_cli_rewind_old_primary(int argc, char **argv)
 										 config.backupDirectory,
 										 NULL, /* no targetLSN */
 										 config.pgSetup.ssl,
-										 0))
+										 0,
+										 &config.mappings))
 	{
 		/* can't happen at the moment */
 		exit(EXIT_CODE_INTERNAL_ERROR);
@@ -535,7 +537,8 @@ keeper_cli_maybe_do_crash_recovery(int argc, char **argv)
 										 config.backupDirectory,
 										 NULL, /* no targetLSN */
 										 config.pgSetup.ssl,
-										 0))
+										 0,
+										 &config.mappings))
 	{
 		/* can't happen at the moment */
 		exit(EXIT_CODE_INTERNAL_ERROR);

--- a/src/bin/pg_autoctl/fsm_transition.c
+++ b/src/bin/pg_autoctl/fsm_transition.c
@@ -760,7 +760,8 @@ fsm_stop_postgres_and_setup_standby(Keeper *keeper)
 										 config->backupDirectory,
 										 NULL, /* no targetLSN */
 										 config->pgSetup.ssl,
-										 keeper->state.current_node_id))
+										 keeper->state.current_node_id,
+										 &config->mappings))
 	{
 		/* can't happen at the moment */
 		return false;
@@ -937,7 +938,8 @@ fsm_init_standby(Keeper *keeper)
 										 config->backupDirectory,
 										 NULL, /* no targetLSN */
 										 config->pgSetup.ssl,
-										 keeper->state.current_node_id))
+										 keeper->state.current_node_id,
+										 &config->mappings))
 	{
 		/* can't happen at the moment */
 		return false;
@@ -977,7 +979,8 @@ fsm_rewind_or_init(Keeper *keeper)
 										 config->backupDirectory,
 										 NULL, /* no targetLSN */
 										 config->pgSetup.ssl,
-										 keeper->state.current_node_id))
+										 keeper->state.current_node_id,
+										 &config->mappings))
 	{
 		/* can't happen at the moment */
 		return false;
@@ -1248,7 +1251,8 @@ fsm_report_lsn(Keeper *keeper)
 										 config->backupDirectory,
 										 NULL, /* no targetLSN */
 										 config->pgSetup.ssl,
-										 keeper->state.current_node_id))
+										 keeper->state.current_node_id,
+										 &config->mappings))
 	{
 		/* can't happen at the moment */
 		return false;
@@ -1349,7 +1353,8 @@ fsm_fast_forward(Keeper *keeper)
 										 config->backupDirectory,
 										 upstreamNode.lsn,
 										 config->pgSetup.ssl,
-										 keeper->state.current_node_id))
+										 keeper->state.current_node_id,
+										 &config->mappings))
 	{
 		/* can't happen at the moment */
 		return false;
@@ -1421,7 +1426,8 @@ fsm_follow_new_primary(Keeper *keeper)
 										 config->backupDirectory,
 										 NULL, /* no targetLSN */
 										 config->pgSetup.ssl,
-										 keeper->state.current_node_id))
+										 keeper->state.current_node_id,
+										 &config->mappings))
 	{
 		/* can't happen at the moment */
 		return false;
@@ -1489,7 +1495,8 @@ fsm_init_from_standby(Keeper *keeper)
 										 config->backupDirectory,
 										 upstreamNode.lsn,
 										 config->pgSetup.ssl,
-										 keeper->state.current_node_id))
+										 keeper->state.current_node_id,
+										 &config->mappings))
 	{
 		/* can't happen at the moment */
 		return false;

--- a/src/bin/pg_autoctl/keeper.c
+++ b/src/bin/pg_autoctl/keeper.c
@@ -934,7 +934,8 @@ keeper_ensure_configuration(Keeper *keeper, bool postgresNotRunningIsOk)
 											 config->backupDirectory,
 											 NULL, /* no targetLSN */
 											 config->pgSetup.ssl,
-											 state->current_node_id))
+											 state->current_node_id,
+											 &config->mappings))
 		{
 			/* can't happen at the moment */
 			free(currentConfContents);

--- a/src/bin/pg_autoctl/keeper_config.h
+++ b/src/bin/pg_autoctl/keeper_config.h
@@ -55,6 +55,8 @@ typedef struct KeeperConfig
 	char replication_password[MAXCONNINFO];
 	char maximum_backup_rate[MAXIMUM_BACKUP_RATE_LEN];
 	char backupDirectory[MAXPGPATH];
+	char tablespaceMappingsStr[PG_AUTOCTL_MAX_TABLESPACES_STR];
+	TablespaceMappings mappings;
 
 	/* Citus specific options and settings */
 	char citusRoleStr[NAMEDATALEN];
@@ -103,5 +105,7 @@ bool keeper_config_set_setting(KeeperConfig *config,
 bool keeper_config_merge_options(KeeperConfig *config, KeeperConfig *options);
 bool keeper_config_update(KeeperConfig *config, int64_t nodeId, int groupId);
 bool keeper_config_update_with_absolute_pgdata(KeeperConfig *config);
+
+bool parse_tablespace_mappings(KeeperConfig *config);
 
 #endif /* KEEPER_CONFIG_H */

--- a/src/bin/pg_autoctl/keeper_pg_init.c
+++ b/src/bin/pg_autoctl/keeper_pg_init.c
@@ -774,7 +774,8 @@ wait_until_primary_has_created_our_replication_slot(Keeper *keeper,
 										 config->backupDirectory,
 										 NULL, /* no targetLSN */
 										 config->pgSetup.ssl,
-										 assignedState->nodeId))
+										 assignedState->nodeId,
+										 &config->mappings))
 	{
 		/* can't happen at the moment */
 		return false;

--- a/src/bin/pg_autoctl/pgsql.c
+++ b/src/bin/pg_autoctl/pgsql.c
@@ -2970,7 +2970,7 @@ pgsql_identify_system(PGSQL *pgsql, IdentifySystem *system)
 
 
 /*
- * parsePgMetadata parses the result from a PostgreSQL query fetching
+ * parseIdentifySystemResult parses the result from a PostgreSQL query fetching
  * two columns from pg_stat_replication: sync_state and currentLSN.
  */
 static void

--- a/src/bin/pg_autoctl/pgsql.h
+++ b/src/bin/pg_autoctl/pgsql.h
@@ -225,6 +225,28 @@ typedef struct IdentifySystem
 
 
 /*
+ * The --tablespace-mappings can be up to PG_AUTOCTL_MAX_TABLESPACES
+ * mappings long,
+ * Each mapping can be MAXPGPATH*2 + 1 (e.g. `/original/dir=/backup/dir`)
+ * with up to PG_AUTOCTL_MAX_TABLESPACES semicolon separators.
+ */
+#define PG_AUTOCTL_MAX_TABLESPACES 16
+#define PG_AUTOCTL_MAX_TABLESPACES_STR ((PG_AUTOCTL_MAX_TABLESPACES * (MAXPGPATH * 2 + 1)) \
+										+ PG_AUTOCTL_MAX_TABLESPACES)
+typedef struct BackupDirectory
+{
+	char original[MAXPGPATH];
+	char backup[MAXPGPATH];
+} BackupDirectory;
+
+typedef struct TablespaceMappings
+{
+	int count;
+	BackupDirectory dirs[PG_AUTOCTL_MAX_TABLESPACES];
+} TablespaceMappings;
+
+
+/*
  * The replicationSource structure is used to pass the bits of a connection
  * string to the primary node around in several function calls. All the
  * information stored in there must fit in a connection string, so MAXCONNINFO
@@ -244,6 +266,7 @@ typedef struct ReplicationSource
 	char targetTimeline[NAMEDATALEN];
 	SSLOptions sslOptions;
 	IdentifySystem system;
+	TablespaceMappings mappings;
 } ReplicationSource;
 
 

--- a/src/bin/pg_autoctl/primary_standby.c
+++ b/src/bin/pg_autoctl/primary_standby.c
@@ -804,7 +804,8 @@ standby_init_replication_source(LocalPostgresServer *postgres,
 								const char *backupDirectory,
 								const char *targetLSN,
 								SSLOptions sslOptions,
-								int currentNodeId)
+								int currentNodeId,
+								TablespaceMappings *mappings)
 {
 	ReplicationSource *upstream = &(postgres->replicationSource);
 
@@ -846,6 +847,19 @@ standby_init_replication_source(LocalPostgresServer *postgres,
 			"%s%d",
 			REPLICATION_APPLICATION_NAME_PREFIX,
 			currentNodeId);
+
+	if (mappings != NULL)
+	{
+		upstream->mappings.count = mappings->count;
+		int i;
+		for (i = 0; i < mappings->count; i++)
+		{
+			strlcpy(upstream->mappings.dirs[i].backup, mappings->dirs[i].backup,
+					MAXPGPATH);
+			strlcpy(upstream->mappings.dirs[i].original,
+					mappings->dirs[i].original, MAXPGPATH);
+		}
+	}
 
 	return true;
 }

--- a/src/bin/pg_autoctl/primary_standby.h
+++ b/src/bin/pg_autoctl/primary_standby.h
@@ -96,7 +96,8 @@ bool standby_init_replication_source(LocalPostgresServer *postgres,
 									 const char *backupDirectory,
 									 const char *targetLSN,
 									 SSLOptions sslOptions,
-									 int currentNodeId);
+									 int currentNodeId,
+									 TablespaceMappings *mappings);
 bool standby_init_database(LocalPostgresServer *postgres,
 						   const char *hostname,
 						   bool skipBaseBackup);

--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -364,6 +364,19 @@ class PGNode:
         else:
             time.sleep(secs)
 
+    def run_psql(self, query):
+        """
+        Run sql query with psql
+        """
+        command = [
+            shutil.which("psql"),
+            "-d",
+            self.database,
+            "-c",
+            query,
+        ]
+        self.vnode.run_and_wait(command, name="psql query")
+
     def run_sql_query(self, query, *args):
         """
         Runs the given sql query with the given arguments in this postgres node

--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -958,6 +958,7 @@ class DataNode(PGNode):
         nodeId=None,
         citusSecondary=False,
         citusClusterName="default",
+        tablespaceMappings=None,
     ):
         """
         Runs "pg_autoctl create"
@@ -1051,6 +1052,9 @@ class DataNode(PGNode):
             assert nodeId is not None
             create_args += ["--disable-monitor"]
             create_args += ["--node-id", str(nodeId)]
+
+        if tablespaceMappings:
+            create_args += ["--tablespace-mappings", tablespaceMappings]
 
         if run:
             create_args += ["--run"]

--- a/tests/test_tablespaces.py
+++ b/tests/test_tablespaces.py
@@ -1,0 +1,64 @@
+import pgautofailover_utils as pgautofailover
+from nose.tools import raises, eq_
+
+import time
+
+cluster = None
+monitor = None
+node1 = None
+node2 = None
+node3 = None
+
+
+def setup_module():
+    global cluster
+    cluster = pgautofailover.Cluster()
+
+
+def teardown_module():
+    cluster.destroy()
+
+
+def test_000_create_monitor():
+    global monitor
+    monitor = cluster.create_monitor("/tmp/tablespaces/monitor")
+    monitor.run()
+
+def test_001_init_primary():
+    global node1
+    node1 = cluster.create_datanode("/tmp/tablespaces/node1")
+    node1.create(run=True)
+    assert node1.wait_until_state(target_state="single")
+
+def test_002_create_t1():
+    node1.run_sql_query("CREATE TABLE t1(a int)")
+    node1.run_sql_query("INSERT INTO t1 VALUES (1), (2)")
+
+def test_003_create_tablespace():
+    pgautofailover.sudo_mkdir_p('/tmp/tablespaces/node1-extended')
+    node1.run_psql("CREATE TABLESPACE extended LOCATION '/tmp/tablespaces/node1-extended';")
+    node1.run_sql_query("CREATE TABLE t2(i int) TABLESPACE extended;")
+    node1.run_sql_query("INSERT INTO t2 VALUES (3), (4)")
+
+def test_004_init_secondary():
+    global node2
+    node2 = cluster.create_datanode("/tmp/tablespaces/node2")
+    node2.create(run=True)
+    assert node2.wait_until_state(target_state="secondary")
+    assert node1.wait_until_state(target_state="primary")
+
+def test_005_read_from_secondary():
+    results = node2.run_sql_query("SELECT * FROM t1")
+    assert results == [(1,), (2,)]
+    results = node2.run_sql_query("SELECT * FROM t2")
+    assert results == [(3,), (4,)]
+
+def test_006_create_tablespace_while_streaming():
+    pgautofailover.sudo_mkdir_p('/tmp/tablespaces/node1-extended2')
+    node1.run_psql("CREATE TABLESPACE extended2 LOCATION '/tmp/tablespaces/node1-extended2';")
+    node1.run_sql_query("CREATE TABLE t3(i int) TABLESPACE extended2;")
+    node1.run_sql_query("INSERT INTO t3 VALUES (5), (6)")
+
+def test_007_read_from_secondary_again():
+    results = node2.run_sql_query("SELECT * FROM t3")
+    assert results == [(5,), (6,)]

--- a/tests/test_tablespaces.py
+++ b/tests/test_tablespaces.py
@@ -24,28 +24,39 @@ def test_000_create_monitor():
     monitor = cluster.create_monitor("/tmp/tablespaces/monitor")
     monitor.run()
 
+
 def test_001_init_primary():
     global node1
     node1 = cluster.create_datanode("/tmp/tablespaces/node1")
     node1.create(run=True)
     assert node1.wait_until_state(target_state="single")
 
+
 def test_002_create_t1():
     node1.run_sql_query("CREATE TABLE t1(a int)")
     node1.run_sql_query("INSERT INTO t1 VALUES (1), (2)")
 
+
 def test_003_create_tablespace():
-    pgautofailover.sudo_mkdir_p('/tmp/tablespaces/node1-extended')
-    node1.run_psql("CREATE TABLESPACE extended LOCATION '/tmp/tablespaces/node1-extended';")
+    pgautofailover.sudo_mkdir_p("/tmp/tablespaces/extended")
+    node1.run_psql(
+        "CREATE TABLESPACE extended LOCATION '/tmp/tablespaces/extended';"
+    )
     node1.run_sql_query("CREATE TABLE t2(i int) TABLESPACE extended;")
-    node1.run_sql_query("INSERT INTO t2 VALUES (3), (4)")
+    node1.run_sql_query("INSERT INTO t2 VALUES (3), (4);")
+
 
 def test_004_init_secondary():
     global node2
     node2 = cluster.create_datanode("/tmp/tablespaces/node2")
-    node2.create(run=True)
+    node2.create(
+        run=False,
+        tablespaceMappings="/tmp/tablespaces/extended=/tmp/tablespaces/extended_backup",
+    )
+    node2.run()
     assert node2.wait_until_state(target_state="secondary")
     assert node1.wait_until_state(target_state="primary")
+
 
 def test_005_read_from_secondary():
     results = node2.run_sql_query("SELECT * FROM t1")
@@ -53,12 +64,57 @@ def test_005_read_from_secondary():
     results = node2.run_sql_query("SELECT * FROM t2")
     assert results == [(3,), (4,)]
 
+
 def test_006_create_tablespace_while_streaming():
-    pgautofailover.sudo_mkdir_p('/tmp/tablespaces/node1-extended2')
-    node1.run_psql("CREATE TABLESPACE extended2 LOCATION '/tmp/tablespaces/node1-extended2';")
+    pgautofailover.sudo_mkdir_p("/tmp/tablespaces/extended2")
+    node1.run_psql(
+        "CREATE TABLESPACE extended2 LOCATION '/tmp/tablespaces/extended2';"
+    )
     node1.run_sql_query("CREATE TABLE t3(i int) TABLESPACE extended2;")
     node1.run_sql_query("INSERT INTO t3 VALUES (5), (6)")
+
 
 def test_007_read_from_secondary_again():
     results = node2.run_sql_query("SELECT * FROM t3")
     assert results == [(5,), (6,)]
+
+
+def test_008_promote_the_secondary():
+    node2.perform_promotion()
+    assert node2.wait_until_state(target_state="primary")
+    assert node1.wait_until_state(target_state="secondary")
+
+    node2.run_sql_query("INSERT INTO t2 VALUES (7)")
+    results = node1.run_sql_query("SELECT * FROM t2")
+    assert results == [(3,), (4,), (7,)]
+
+    node2.run_sql_query("INSERT INTO t3 VALUES (8)")
+    results = node1.run_sql_query("SELECT * FROM t3")
+    assert results == [(5,), (6,), (8,)]
+
+
+def test_009_old_primary_goes_down():
+    node1.fail()
+    assert node2.wait_until_state(target_state="wait_primary")
+
+    pgautofailover.sudo_mkdir_p("/tmp/tablespaces/extended3")
+    node2.run_psql(
+        "CREATE TABLESPACE extended3 LOCATION '/tmp/tablespaces/extended3';"
+    )
+    node2.run_sql_query("CREATE TABLE t4(i int) TABLESPACE extended3;")
+    node2.run_sql_query("INSERT INTO t4 VALUES (10), (11)")
+    node2.run_sql_query("INSERT INTO t2 VALUES (12)")
+
+    node1.run()
+    assert node1.wait_until_state(target_state="secondary")
+    assert node2.wait_until_state(target_state="primary")
+    results = node1.run_sql_query("SELECT * FROM t4")
+    assert results == [(10,), (11,)]
+    results = node1.run_sql_query("SELECT * FROM t2")
+    assert results == [(3,), (4,), (7,), (12,)]
+
+
+def test_009_promote_the_original_primary():
+    node1.perform_promotion()
+    assert node1.wait_until_state(target_state="primary")
+    assert node2.wait_until_state(target_state="secondary")


### PR DESCRIPTION
This allows up to 16 tablespace-mappings to be defined when creating nodes. 


Fixes #844

Notes: 
- This is not moving the mapped directory after the pg_basebackup as it requires more work than just a simple `mv` to do it. What are the advantages or disadvantages of this technique? 
- Additionally, I'm not in love with `--tablespace-mappings=/mnt/giant=/mnt/giantbackup;/mnt/superfast=/mnt/superfastbackup` as a UX, but it appeared to involve the fewest changes.
 - At first I attempted to detect the existing tablespaces by running a query against the primary, but it's not trivial to get them as a replication type role. In production, I expect the user would want to set up their directory structure by hand and would need to know that the volume mounts need to exist. The python tests don't currently have a way to replicate a more production-like scenario with volume mounts of the same name for each node.

I'll be around a few days next week and this week to make updates from feedback/changes. 🙂