### PR TITLE
Check return value of strdup calls

### DIFF
--- a/src/bin/pg_autoctl/debian.c
+++ b/src/bin/pg_autoctl/debian.c
@@ -282,6 +282,11 @@ buildDebianDataAndConfDirectoryNames(PostgresSetup *pgSetup,
 	char clusterDir[MAXPGPATH] = { 0 };
 	char versionDir[MAXPGPATH] = { 0 };
 
+	if (pgmajor == NULL)
+	{
+		log_error(ALLOCATION_FAILED_ERROR);
+		return false;
+	}
 
 	/* we need to work with the absolute pathname of PGDATA */
 	if (!normalize_filename(pgSetup->pgdata, pgdata, MAXPGPATH))
@@ -300,6 +305,12 @@ buildDebianDataAndConfDirectoryNames(PostgresSetup *pgSetup,
 	/* get the names of our version and cluster directories */
 	char *clusterDirName = strdup(basename(clusterDir));
 	char *versionDirName = strdup(basename(versionDir));
+
+	if (clusterDirName == NULL || versionDirName == NULL)
+	{
+		log_error(ALLOCATION_FAILED_ERROR);
+		return false;
+	}
 
 	/* transform pgversion "11.4" to "11" to get the major version part */
 	char *dot = strchr(pgmajor, '.');

--- a/src/bin/pg_autoctl/ini_file.c
+++ b/src/bin/pg_autoctl/ini_file.c
@@ -252,6 +252,11 @@ ini_set_option_value(IniOption *option, const char *value)
 			else
 			{
 				*(option->strValue) = strdup(value);
+				if (*(option->strValue) == NULL)
+				{
+					log_error(ALLOCATION_FAILED_ERROR);
+					return false;
+				}
 			}
 			break;
 		}
@@ -575,6 +580,11 @@ lookup_ini_path_value(IniOption *optionList, const char *path)
 	}
 
 	section_name = strdup(path);                   /* don't scribble on path */
+	if (section_name == NULL)
+	{
+		log_error(ALLOCATION_FAILED_ERROR);
+		return NULL;
+	}
 	option_name = section_name + (ptr - path) + 1; /* apply same offset */
 	*(option_name - 1) = '\0';                     /* split string at the dot */
 
@@ -629,6 +639,11 @@ ini_merge(IniOption *dstOptionList, IniOption *overrideOptionList)
 				if (*(option->strValue) != NULL)
 				{
 					*(dstOption->strValue) = strdup(*(option->strValue));
+					if (*(dstOption->strValue) == NULL)
+					{
+						log_error(ALLOCATION_FAILED_ERROR);
+						return false;
+					}
 				}
 				break;
 			}

--- a/src/bin/pg_autoctl/pgsql.c
+++ b/src/bin/pg_autoctl/pgsql.c
@@ -114,6 +114,11 @@ parseSingleValueResult(void *ctx, PGresult *result)
 			case PGSQL_RESULT_STRING:
 			{
 				context->strVal = strdup(value);
+				if (context->strVal == NULL)
+				{
+					context->parsedOk = false;
+					log_error(ALLOCATION_FAILED_ERROR);
+				}
 				context->parsedOk = true;
 				break;
 			}


### PR DESCRIPTION
Albeit unlikely on modern server systems, memory allocation can still fail and the result, if unchecked, be null pointer dereferences. This adds a check to affected callsites of strdup to ensure allocation was successful, or abort if not.