### PR TITLE
Add support for tablespaces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ cache:
   apt: true
   directories:
   - /home/travis/postgresql
+services:
+  - docker
 matrix:
   fast_finish: true
   include:
@@ -30,6 +32,7 @@ matrix:
     - env: PGVERSION=12 TEST=ssl
     - env: PGVERSION=13 TEST=ssl
     - env: PGVERSION=14 TEST=ssl
+    - env: PGVERSION=14 TEST=tablespaces DOCKERTEST=true
     - env: LINTING=true
 before_install:
   - git clone -b v0.7.18 --depth 1 https://github.com/citusdata/tools.git
@@ -60,6 +63,9 @@ script:
   - 'if [ -n "$LINTING" ]; then citus_indent --check; fi'
   - 'if [ -n "$LINTING" ]; then black --check .; fi'
   - 'if [ -n "$LINTING" ]; then ci/banned.h.sh; fi'
-  - 'if [ -z "$LINTING" ]; then make -j5 CFLAGS=-Werror; fi'
-  - 'if [ -z "$LINTING" ]; then sudo make install; fi'
-  - 'if [ -z "$LINTING" ]; then PATH=`pg_config --bindir`:$PATH make test; fi'
+  - 'if [ -z "$LINTING"] && [ -z "$DOCKERTEST" ]; then make -j5 CFLAGS=-Werror; fi'
+  - 'if [ -z "$LINTING"] && [ -z "$DOCKERTEST" ]; then sudo make install; fi'
+  - 'if [ -z "$LINTING"] && [ -z "$DOCKERTEST" ]; then PATH=`pg_config --bindir`:$PATH make test; fi'
+  - 'if [ -n "$LINTING"] && [ -n "$DOCKERTEST" ]; then make test; fi'
+after_script:
+  - 'if [ -n "$LINTING"] && [ -n "$DOCKERTEST" ]; then make -C tests/tablespaces teardown; fi'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,41 @@ make TEST=single run-test      # runs tests _not_ matching tests/test_multi*
 make TEST=test_auth run-test   # runs tests/test_auth.py
 ```
 
+#### Running tablespace tests
+
+The tablespace tests are similarly written using Python and the nose framework,
+with as much shared code as possible. They run using
+[docker compose](https://docs.docker.com/compose/), as postgres assumes that
+tablespaces live in the same location across replicas. This necessitates
+matching directory structures across the nodes, and thus, multiple,
+simultaneously running containers.
+
+Interaction with each node is done using `docker-compose` commands. Refer to
+the [Makefile](tests/tablespaces/Makefile) in the test directory for examples.
+
+To run the tests from the top-level directory:
+
+```bash
+TEST=tablespaces make test
+```
+
+Like the other tests, you can use `PGVERSION` to test against supported versions
+of postgres, for example:
+
+```bash
+PGVERSION=14 TEST=tablespaces make test
+```
+
+If the tests fail, the docker containers may be left around, and there is a
+companion teardown target:
+
+```bash
+make -C tests/tablespaces teardown
+```
+
+Refer to the [Makefile](tests/tablespaces/Makefile) for more potentially
+useful targets to use while developing with tablespaces.
+
 ### Producing the documentation diagrams
 
 The diagrams are TikZ sources, which means they're edited with your usual

--- a/Makefile
+++ b/Makefile
@@ -132,11 +132,11 @@ clean-bin:
 install-bin: bin
 	$(MAKE) -C src/bin/ install
 
-test-tablespaces:
-	$(MAKE) -C tests/tablespaces teardown
-	$(MAKE) -C tests/tablespaces run-test
 
 test:
+ifeq ($(TEST),tablespaces)
+	$(MAKE) -C tests/tablespaces run-test
+else
 	sudo -E env "PATH=${PATH}" USER=$(shell whoami) \
 		$(NOSETESTS)			\
 		--verbose				\
@@ -144,6 +144,7 @@ test:
 		--nocapture				\
 		--stop					\
 		${TEST_ARGUMENT}
+endif
 
 indent:
 	citus_indent

--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,10 @@ clean-bin:
 install-bin: bin
 	$(MAKE) -C src/bin/ install
 
+test-tablespaces:
+	$(MAKE) -C tests/tablespaces teardown
+	$(MAKE) -C tests/tablespaces run-test
+
 test:
 	sudo -E env "PATH=${PATH}" USER=$(shell whoami) \
 		$(NOSETESTS)			\

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+# Initialize the tests package
+# https://docs.python.org/3/tutorial/modules.html#packages

--- a/tests/tablespaces/Dockerfile
+++ b/tests/tablespaces/Dockerfile
@@ -1,0 +1,11 @@
+ARG PGVERSION=10
+
+FROM pg_auto_failover_test:pg${PGVERSION} as test
+
+USER root
+RUN mkdir -p /extra_volumes/extended_a && chown -R docker /extra_volumes/extended_a
+RUN mkdir -p /extra_volumes/extended_b && chown -R docker /extra_volumes/extended_b
+RUN mkdir -p /extra_volumes/extended_c && chown -R docker /extra_volumes/extended_c
+RUN mkdir -p /var/lib/postgres && chown -R docker /var/lib/postgres
+
+USER docker

--- a/tests/tablespaces/Makefile
+++ b/tests/tablespaces/Makefile
@@ -2,23 +2,23 @@ PGVERSION ?= 10
 
 build:
 	$(MAKE) -C ../../ build-test-pg$(PGVERSION)
-	docker compose build --build-arg "PGVERSION=$(PGVERSION)"
+	docker-compose build --build-arg "PGVERSION=$(PGVERSION)"
 
 teardown:
-	docker compose down --volumes --remove-orphans
+	docker-compose down --volumes --remove-orphans
 
 tail:
-	docker compose logs -f
+	docker-compose logs -f
 
 state:
-	docker compose exec monitor pg_autoctl show state
+	docker-compose exec monitor pg_autoctl show state
 
 watch:
-	docker compose exec monitor pg_autoctl watch
+	docker-compose exec monitor pg_autoctl watch
 
 test_01:
-	docker compose up -d node1
-	TEST_NUM="01" docker compose up --exit-code-from=test test
+	docker-compose up -d node1
+	TEST_NUM="01" docker-compose up --exit-code-from=test test
 
 test_02:
 	docker-compose up -d node2
@@ -26,21 +26,21 @@ test_02:
 
 test_03:
 	# Pollute the data dir so pg_rewind fails
-	docker compose exec node2 mkdir '/var/lib/postgres/data/base/1/99999999'
-	docker compose exec monitor pg_autoctl perform failover
-	TEST_NUM="03" docker compose up --exit-code-from=test test
+	docker-compose exec node2 mkdir '/var/lib/postgres/data/base/1/99999999'
+	docker-compose exec monitor pg_autoctl perform failover
+	TEST_NUM="03" docker-compose up --exit-code-from=test test
 
 test_04:
-	docker compose pause node1
-	TEST_NUM="04" docker compose up --exit-code-from=test test
+	docker-compose pause node1
+	TEST_NUM="04" docker-compose up --exit-code-from=test test
 
 test_05:
-	docker compose unpause node1
-	TEST_NUM="05" docker compose up --exit-code-from=test test
+	docker-compose unpause node1
+	TEST_NUM="05" docker-compose up --exit-code-from=test test
 
 test_06:
-	docker compose exec monitor pg_autoctl perform failover
-	TEST_NUM="06" docker compose up --exit-code-from=test test
+	docker-compose exec monitor pg_autoctl perform failover
+	TEST_NUM="06" docker-compose up --exit-code-from=test test
 
 test: build test_01 test_02 test_03 test_04 test_05 test_06
 

--- a/tests/tablespaces/Makefile
+++ b/tests/tablespaces/Makefile
@@ -1,0 +1,55 @@
+PGVERSION ?= 10
+
+build:
+	$(MAKE) -C ../../ build-test-pg$(PGVERSION)
+	docker compose build --build-arg "PGVERSION=$(PGVERSION)"
+
+teardown:
+	docker compose down --volumes --remove-orphans
+
+tail:
+	docker compose logs -f
+
+state:
+	docker compose exec monitor pg_autoctl show state
+
+watch:
+	docker compose exec monitor pg_autoctl watch
+
+test_01:
+	docker compose up -d node1
+	TEST_NUM="01" docker compose up --exit-code-from=test test
+
+test_02:
+	docker-compose up -d node2
+	TEST_NUM="02" docker-compose up --exit-code-from=test test
+
+test_03:
+	# Pollute the data dir so pg_rewind fails
+	docker compose exec node2 mkdir '/var/lib/postgres/data/base/1/99999999'
+	docker compose exec monitor pg_autoctl perform failover
+	TEST_NUM="03" docker compose up --exit-code-from=test test
+
+test_04:
+	docker compose pause node1
+	TEST_NUM="04" docker compose up --exit-code-from=test test
+
+test_05:
+	docker compose unpause node1
+	TEST_NUM="05" docker compose up --exit-code-from=test test
+
+test_06:
+	docker compose exec monitor pg_autoctl perform failover
+	TEST_NUM="06" docker compose up --exit-code-from=test test
+
+test: build test_01 test_02 test_03 test_04 test_05 test_06
+
+#  The test containers only connect to each other via the postgres protocol.
+#    For this reason, the Makefile uses  `docker-compose exec` to perform
+#    `pg_autoctl` commands, such as failover. Starting/stopping the pg_autoctl
+#    process is also done using `docker-compose` so as not to complicate the
+#    command used to run each container.
+#  See CONTRIBUTING.md for more detailed instructions.
+run-test: test teardown
+
+.PHONY: build state watch run-test test tail teardown test_01 test_02 test_03 test_04 test_05 test_06

--- a/tests/tablespaces/docker-compose.yml
+++ b/tests/tablespaces/docker-compose.yml
@@ -1,0 +1,69 @@
+version: "3.9"  # optional since v1.27.0
+services:
+  monitor:
+    build: .
+    environment:
+      PGDATA: /tmp/pgdata
+      PG_AUTOCTL_DEBUG: 1
+    command: pg_autoctl create monitor --ssl-self-signed --auth trust --run
+    expose:
+      - 5432
+    container_name: monitor
+  node1:
+    build: .
+    environment:
+      PGDATA: /var/lib/postgres/data
+      PGPORT: 5433
+      PG_AUTOCTL_MONITOR: "postgresql://autoctl_node@monitor:5432/pg_auto_failover"
+      HOSTNAME: "node1.tablespaces_default"
+    command: pg_autoctl create postgres --ssl-self-signed --auth trust --pg-hba-lan --run
+    expose:
+      - 5433
+    links:
+      - monitor
+    container_name: node1
+    volumes:
+      - node1-volume:/var/lib/postgres:rw
+      - node1-a-volume:/extra_volumes/extended_a:rw
+      - node1-b-volume:/extra_volumes/extended_b:rw
+      - node1-c-volume:/extra_volumes/extended_c:rw
+  node2:
+    build: .
+    environment:
+      PGDATA: /var/lib/postgres/data
+      PGPORT: 5434
+      PG_AUTOCTL_MONITOR: "postgresql://autoctl_node@monitor:5432/pg_auto_failover"
+      HOSTNAME: "node2.tablespaces_default"
+    command: pg_autoctl create postgres --ssl-self-signed --auth trust --pg-hba-lan --run
+    expose:
+      - 5433
+    links:
+      - monitor
+    container_name: node2
+    volumes:
+      - node2-volume:/var/lib/postgres:rw
+      - node2-a-volume:/extra_volumes/extended_a:rw
+      - node2-b-volume:/extra_volumes/extended_b:rw
+      - node2-c-volume:/extra_volumes/extended_c:rw
+  test:
+    build:
+      context: .
+      target: test
+    environment:
+      TEST_NUM:
+    command: [
+    "make", "-C", "/usr/src/pg_auto_failover", "test", "TEST=tablespaces/test_tablespaces_$${TEST_NUM}"
+    ]
+    container_name: pg_auto_failover_tablespaces_test
+    links:
+      - monitor
+
+volumes:
+  node1-volume:
+  node1-a-volume:
+  node1-b-volume:
+  node1-c-volume:
+  node2-volume:
+  node2-a-volume:
+  node2-b-volume:
+  node2-c-volume:

--- a/tests/tablespaces/tablespace_utils.py
+++ b/tests/tablespaces/tablespace_utils.py
@@ -1,0 +1,71 @@
+import time
+from tests.pgautofailover_utils import QueryRunner
+from tests.pgautofailover_utils import StatefulNode
+
+
+class PGNodeTS(QueryRunner):
+    def run_sql_query(self, query, *args):
+        return super().run_sql_query(query, True, *args)
+
+    def connection_string(self):
+        return "postgresql://%s@%s:%s/%s" % (
+            self.username,
+            self.service_name,
+            self.port,
+            self.database,
+        )
+
+
+class MonitorNodeTS(PGNodeTS):
+    def __init__(self, port, service_name):
+        self.port = port
+        self.service_name = service_name
+        self.monitor = self
+        self.username = "autoctl_node"
+        self.database = "pg_auto_failover"
+
+
+class DataNodeTS(PGNodeTS, StatefulNode):
+    def __init__(self, port, service_name, monitor_node):
+        self.port = port
+        self.service_name = service_name
+        self.monitor = monitor_node
+        self.username = "docker"
+        self.database = "postgres"
+
+    def logger_name(self):
+        return self.service_name
+
+    def sleep(self, sleep_time):
+        time.sleep(sleep_time)
+
+    def print_debug_logs(self):
+        # no-op, can't get logs easily in this test-type
+        return
+
+    def get_state(self):
+        return super().get_state(
+            "node with port %s not found on the monitor" % self.port,
+            """
+    SELECT reportedstate, goalstate
+    FROM pgautofailover.node
+    WHERE nodeport=%s
+    """,
+            self.port,
+        )
+
+
+monitor = MonitorNodeTS(
+    "5432",
+    "monitor",
+)
+node1 = DataNodeTS(
+    "5433",
+    "node1",
+    monitor,
+)
+node2 = DataNodeTS(
+    "5434",
+    "node2",
+    monitor,
+)

--- a/tests/tablespaces/test_tablespaces_01.py
+++ b/tests/tablespaces/test_tablespaces_01.py
@@ -1,0 +1,23 @@
+from nose.tools import *
+from tests.tablespaces.tablespace_utils import node1
+
+
+# Node 1 is spun up by Makefile, wait until it's up
+def test_000_init_monitor_and_primary():
+    # Wait a bit longer than normal for start up
+    assert node1.wait_until_state(
+        target_state="single", timeout=90, sleep_time=3
+    )
+
+
+def test_002_create_t1():
+    node1.run_sql_query("CREATE TABLE t1(a int)")
+    node1.run_sql_query("INSERT INTO t1 VALUES (1), (2)")
+
+
+def test_003_create_tablespace():
+    node1.run_sql_query(
+        "CREATE TABLESPACE extended_a LOCATION '/extra_volumes/extended_a';"
+    )
+    node1.run_sql_query("CREATE TABLE t2(i int) TABLESPACE extended_a;")
+    node1.run_sql_query("INSERT INTO t2 VALUES (3), (4);")

--- a/tests/tablespaces/test_tablespaces_02.py
+++ b/tests/tablespaces/test_tablespaces_02.py
@@ -1,0 +1,29 @@
+from nose.tools import *
+from tests.tablespaces.tablespace_utils import node1
+from tests.tablespaces.tablespace_utils import node2
+
+
+# Node 2 is spun up by Makefile, wait until it's up and replicating
+def test_001_init_secondary():
+    assert node2.wait_until_state(target_state="secondary")
+    assert node1.wait_until_state(target_state="primary")
+
+
+def test_002_read_from_secondary():
+    results = node2.run_sql_query("SELECT * FROM t1")
+    assert results == [(1,), (2,)]
+    results = node2.run_sql_query("SELECT * FROM t2")
+    assert results == [(3,), (4,)]
+
+
+def test_003_create_tablespace_while_streaming():
+    node1.run_sql_query(
+        "CREATE TABLESPACE extended_b LOCATION '/extra_volumes/extended_b';"
+    )
+    node1.run_sql_query("CREATE TABLE t3(i int) TABLESPACE extended_b;")
+    node1.run_sql_query("INSERT INTO t3 VALUES (5), (6)")
+
+
+def test_004_read_from_secondary_again():
+    results = node2.run_sql_query("SELECT * FROM t3")
+    assert results == [(5,), (6,)]

--- a/tests/tablespaces/test_tablespaces_03.py
+++ b/tests/tablespaces/test_tablespaces_03.py
@@ -1,0 +1,16 @@
+from nose.tools import *
+from tests.tablespaces.tablespace_utils import node1
+from tests.tablespaces.tablespace_utils import node2
+
+# Failover is performed by the makefile Makefile, wait for it to complete
+def test_001_wait_for_failover_and_insert():
+    assert node2.wait_until_state(target_state="primary")
+    assert node1.wait_until_state(target_state="secondary")
+
+    node2.run_sql_query("INSERT INTO t2 VALUES (7)")
+    results = node1.run_sql_query("SELECT * FROM t2")
+    assert results == [(3,), (4,), (7,)]
+
+    node2.run_sql_query("INSERT INTO t3 VALUES (8)")
+    results = node1.run_sql_query("SELECT * FROM t3")
+    assert results == [(5,), (6,), (8,)]

--- a/tests/tablespaces/test_tablespaces_04.py
+++ b/tests/tablespaces/test_tablespaces_04.py
@@ -1,0 +1,14 @@
+from nose.tools import *
+from tests.tablespaces.tablespace_utils import node2
+
+# Node 1 is paused by the Makefile, wait for pgaf to acknowledge
+def test_001_old_primary_goes_down():
+    assert node2.wait_until_state(target_state="wait_primary")
+
+    node2.run_sql_query(
+        "CREATE TABLESPACE extended_c LOCATION '/extra_volumes/extended_c';"
+    )
+    node2.run_sql_query("CREATE TABLE t4(i int) TABLESPACE extended_c;")
+    node2.run_sql_query("INSERT INTO t4 VALUES (10), (11)")
+    node2.run_sql_query("INSERT INTO t2 VALUES (12)")
+    node2.run_sql_query("INSERT INTO t3 VALUES (13)")

--- a/tests/tablespaces/test_tablespaces_05.py
+++ b/tests/tablespaces/test_tablespaces_05.py
@@ -1,0 +1,15 @@
+from nose.tools import *
+from tests.tablespaces.tablespace_utils import node1
+from tests.tablespaces.tablespace_utils import node2
+
+# Node 1 is brought back online by makefile, wait until it's up and replicating
+def test_001_original_primary_comes_back_up():
+    assert node1.wait_until_state(target_state="secondary")
+    assert node2.wait_until_state(target_state="primary")
+
+    results = node1.run_sql_query("SELECT * FROM t4")
+    assert results == [(10,), (11,)]
+    results = node1.run_sql_query("SELECT * FROM t2")
+    assert results == [(3,), (4,), (7,), (12,)]
+    results = node1.run_sql_query("SELECT * FROM t3")
+    assert results == [(5,), (6,), (8,), (13,)]

--- a/tests/tablespaces/test_tablespaces_06.py
+++ b/tests/tablespaces/test_tablespaces_06.py
@@ -1,0 +1,8 @@
+from nose.tools import *
+from tests.tablespaces.tablespace_utils import node1
+from tests.tablespaces.tablespace_utils import node2
+
+# Failover is performed by the makefile Makefile, wait for it to complete
+def test_001_promote_the_original_primary_successfully():
+    assert node1.wait_until_state(target_state="primary")
+    assert node2.wait_until_state(target_state="secondary")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,4 +1,4 @@
-import pgautofailover_utils as pgautofailover
+import tests.pgautofailover_utils as pgautofailover
 from nose.tools import *
 
 import os

--- a/tests/test_basic_operation.py
+++ b/tests/test_basic_operation.py
@@ -1,4 +1,4 @@
-import pgautofailover_utils as pgautofailover
+import tests.pgautofailover_utils as pgautofailover
 from nose.tools import raises, eq_
 
 import time

--- a/tests/test_basic_operation_listen_flag.py
+++ b/tests/test_basic_operation_listen_flag.py
@@ -1,4 +1,4 @@
-import pgautofailover_utils as pgautofailover
+import tests.pgautofailover_utils as pgautofailover
 from nose.tools import *
 
 cluster = None

--- a/tests/test_config_get_set.py
+++ b/tests/test_config_get_set.py
@@ -1,4 +1,4 @@
-import pgautofailover_utils as pgautofailover
+import tests.pgautofailover_utils as pgautofailover
 from nose.tools import assert_raises, raises, eq_
 
 import os

--- a/tests/test_create_run.py
+++ b/tests/test_create_run.py
@@ -1,4 +1,4 @@
-import pgautofailover_utils as pgautofailover
+import tests.pgautofailover_utils as pgautofailover
 import time
 
 cluster = None

--- a/tests/test_create_standby_with_pgdata.py
+++ b/tests/test_create_standby_with_pgdata.py
@@ -1,4 +1,4 @@
-import pgautofailover_utils as pgautofailover
+import tests.pgautofailover_utils as pgautofailover
 from nose.tools import *
 
 import os

--- a/tests/test_debian_clusters.py
+++ b/tests/test_debian_clusters.py
@@ -1,4 +1,4 @@
-import pgautofailover_utils as pgautofailover
+import tests.pgautofailover_utils as pgautofailover
 import os.path
 import subprocess
 

--- a/tests/test_enable_ssl.py
+++ b/tests/test_enable_ssl.py
@@ -1,5 +1,5 @@
-import pgautofailover_utils as pgautofailover
-import ssl_cert_utils as cert
+import tests.pgautofailover_utils as pgautofailover
+import tests.ssl_cert_utils as cert
 import subprocess
 import os
 import time

--- a/tests/test_ensure.py
+++ b/tests/test_ensure.py
@@ -1,4 +1,4 @@
-import pgautofailover_utils as pgautofailover
+import tests.pgautofailover_utils as pgautofailover
 from nose.tools import *
 
 import time

--- a/tests/test_extension_update.py
+++ b/tests/test_extension_update.py
@@ -1,7 +1,7 @@
 import os
 import time
 
-import pgautofailover_utils as pgautofailover
+import tests.pgautofailover_utils as pgautofailover
 from nose.tools import eq_
 
 cluster = None

--- a/tests/test_installcheck.py
+++ b/tests/test_installcheck.py
@@ -1,4 +1,4 @@
-import pgautofailover_utils as pgautofailover
+import tests.pgautofailover_utils as pgautofailover
 from nose.tools import *
 
 import subprocess

--- a/tests/test_monitor_disabled.py
+++ b/tests/test_monitor_disabled.py
@@ -1,4 +1,4 @@
-import pgautofailover_utils as pgautofailover
+import tests.pgautofailover_utils as pgautofailover
 from nose.tools import *
 
 import os

--- a/tests/test_multi_alternate_primary_failures.py
+++ b/tests/test_multi_alternate_primary_failures.py
@@ -1,4 +1,4 @@
-import pgautofailover_utils as pgautofailover
+import tests.pgautofailover_utils as pgautofailover
 from nose.tools import raises, eq_
 import time
 

--- a/tests/test_multi_async.py
+++ b/tests/test_multi_async.py
@@ -1,4 +1,4 @@
-import pgautofailover_utils as pgautofailover
+import tests.pgautofailover_utils as pgautofailover
 from nose.tools import raises, eq_
 import time
 import subprocess

--- a/tests/test_multi_ifdown.py
+++ b/tests/test_multi_ifdown.py
@@ -1,4 +1,4 @@
-import pgautofailover_utils as pgautofailover
+import tests.pgautofailover_utils as pgautofailover
 from nose.tools import raises, eq_
 import time
 

--- a/tests/test_multi_maintenance.py
+++ b/tests/test_multi_maintenance.py
@@ -1,4 +1,4 @@
-import pgautofailover_utils as pgautofailover
+import tests.pgautofailover_utils as pgautofailover
 from nose.tools import raises, eq_
 import time
 

--- a/tests/test_multi_standbys.py
+++ b/tests/test_multi_standbys.py
@@ -1,4 +1,4 @@
-import pgautofailover_utils as pgautofailover
+import tests.pgautofailover_utils as pgautofailover
 from nose.tools import raises, eq_
 import time
 

--- a/tests/test_replace_monitor.py
+++ b/tests/test_replace_monitor.py
@@ -1,4 +1,4 @@
-import pgautofailover_utils as pgautofailover
+import tests.pgautofailover_utils as pgautofailover
 import time
 
 from nose.tools import eq_

--- a/tests/test_skip_pg_hba.py
+++ b/tests/test_skip_pg_hba.py
@@ -1,4 +1,4 @@
-import pgautofailover_utils as pgautofailover
+import tests.pgautofailover_utils as pgautofailover
 from nose.tools import eq_
 
 import subprocess

--- a/tests/test_ssl_cert.py
+++ b/tests/test_ssl_cert.py
@@ -1,5 +1,5 @@
-import pgautofailover_utils as pgautofailover
-import ssl_cert_utils as cert
+import tests.pgautofailover_utils as pgautofailover
+import tests.ssl_cert_utils as cert
 from nose.tools import *
 
 import subprocess

--- a/tests/test_ssl_self_signed.py
+++ b/tests/test_ssl_self_signed.py
@@ -1,4 +1,4 @@
-import pgautofailover_utils as pgautofailover
+import tests.pgautofailover_utils as pgautofailover
 
 from nose.tools import eq_
 


### PR DESCRIPTION
There is a new folder of tests, using volumes to keep data persistent
against pod restarts and to allow for interaction within and without of
the running containers. Unfortunately, it was non-trivial to re-use some of the existing testing libraries, but the additions were minimal. There are minor changes to the test Dockerfile to add permissions to the additional data directories.

This adds a newly _destructive_ action that removes the data within a tablespace
directory. Perhaps this can be rebased off of the work that will do in-place
restore before merging, depending on the caution of the core team.

Implementation note: this permits tablespace data directories to
created at the top level of mounted volumes.

Fixes #844