### PR TITLE
Minor: Remove duplication add error handling

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,8 +26,6 @@ services:
       - 5432
   node2:
     image: citusdata/pg_auto_failover:demo
-    expose:
-      - 5432
     environment:
       PGDATA: /tmp/pgaf
       PG_AUTOCTL_DEBUG: 1


### PR DESCRIPTION
Minor fixups found during #844 

- removing duplicate key from docker-compose.yml
- Handle [non-standard](https://www.gnu.org/software/libc/manual/html_node/Directory-Entries.html) field `d_type` in log file handling