### PR TITLE
Include pwd.h in pg_setup.c

### DIFF
--- a/src/bin/pg_autoctl/pgsetup.c
+++ b/src/bin/pg_autoctl/pgsetup.c
@@ -10,6 +10,7 @@
  */
 
 #include <inttypes.h>
+#include <pwd.h>
 #include <signal.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
This is necessary for `make` to run without errors on OSX.

Co-authored-by: Jacob Champion <pchampion@vmware.com>