### PR TITLE
Fix incorrect indentation of foreach block

### DIFF
--- a/src/monitor/version_compat.c
+++ b/src/monitor/version_compat.c
@@ -44,7 +44,7 @@ list_qsort(const List *list, list_qsort_comparator cmp)
 	i = 0;
 	list_arr = palloc(sizeof(ListCell *) * len);
 	foreach(cell, list)
-	list_arr[i++] = cell;
+		list_arr[i++] = cell;
 
 	qsort(list_arr, len, sizeof(ListCell *), cmp);
 


### PR DESCRIPTION
The statement in the `foreach()` block was indented on the same level which is confusing for reader (and potentially triggers static analysis tools).