### PR TITLE
Remove dead code

### DIFF
--- a/src/bin/pg_autoctl/monitor.c
+++ b/src/bin/pg_autoctl/monitor.c
@@ -1329,12 +1329,6 @@ monitor_remove_by_nodename(Monitor *monitor,
 	if (!context.parsedOK)
 	{
 		log_error("Failed to remove node \"%s\" in formation \"%s\" "
-				  "from the monitor", name, formation);
-		return false;
-	}
-	else if (!context.parsedOK)
-	{
-		log_error("Failed to remove node \"%s\" in formation \"%s\" "
 				  "from the monitor: could not parse monitor's result.",
 				  name, formation);
 		return false;


### PR DESCRIPTION
Commit 5304068d4 changed the conditionals in the if statement making the conditions equal. Remove the dead code block. If the changes in that commit which led to this dead block weren't intentional then a different fix might be required.