### PR TITLE
Fix incorrect order of arguments in prototype

### DIFF
--- a/src/bin/pg_autoctl/pgctl.h
+++ b/src/bin/pg_autoctl/pgctl.h
@@ -61,8 +61,8 @@ int pg_ctl_status(const char *pg_ctl, const char *pgdata, bool log_output);
 bool pg_ctl_promote(const char *pg_ctl, const char *pgdata);
 
 bool pg_setup_standby_mode(uint32_t pg_control_version,
-						   const char *pg_ctl,
 						   const char *pgdata,
+						   const char *pg_ctl,
 						   ReplicationSource *replicationSource);
 
 bool pg_cleanup_standby_mode(uint32_t pg_control_version,


### PR DESCRIPTION
The prototype of `pg_setup_standby_mode()` in the `pgctl.h` header file listed the argument in the wrong order compared to the implementation. The type of the arguments were equal so it still compiled fine.