### PR TITLE
Fix check for negative pid

### DIFF
--- a/src/bin/pg_autoctl/pidfile.c
+++ b/src/bin/pg_autoctl/pidfile.c
@@ -193,7 +193,7 @@ read_pidfile(const char *pidfile, pid_t *pid)
 
 	free(fileContents);
 
-	if (pid <= 0)
+	if (*pid <= 0)
 	{
 		log_debug("Read negative pid %d in file \"%s\", removing it",
 				  *pid, pidfile);


### PR DESCRIPTION
The `pid` variable is a pointer, and pointers cannot be negative. Fix the check to test the value of the pid rather than the address of the pointer.