### PR TITLE
Fix potential out of bounds array access

### DIFF
--- a/src/bin/pg_autoctl/watch_colspecs.h
+++ b/src/bin/pg_autoctl/watch_colspecs.h
@@ -240,7 +240,7 @@ typedef struct EventColPolicy
 {
 	char name[NAMEDATALEN];
 	int totalSize;
-	EventColSpec specs[MAX_COL_SPECS];
+	EventColSpec specs[MAX_EVENT_COL_SPECS];
 } EventColPolicy;
 
 /*


### PR DESCRIPTION
The specs array member in the EventColPolicy structure is accessed by traversing it from 0 to EVENT_COLUMN_TYPE_LAST, but the array was built using MAX_COL_SPECS from the ColPolicy structure as the array size.

Not sure why this hasn't triggered an error before, am I missing something obvious?