### PR TITLE
Fix ssl test by ensuring the symlink is owned by root.

### DIFF
--- a/tests/test_enable_ssl.py
+++ b/tests/test_enable_ssl.py
@@ -188,7 +188,22 @@ def test_010_enable_ssl_verify_ca_monitor():
     print("%s" % p.stdout)
 
     # the root user also needs the certificates, tests are connecting with it
-    subprocess.run(["ln", "-s", client_top_directory, "/root/.postgresql"])
+    root_top_directory = "/root/.postgresql"
+    p = subprocess.run(
+        ["sudo", "install", "-d", "-m", "740", root_top_directory]
+    )
+    assert p.returncode == 0
+
+    p = subprocess.run(
+        [
+            "sudo",
+            "cp",
+            clientCert.crt,
+            clientCert.csr,
+            clientCert.key,
+            root_top_directory,
+        ]
+    )
     assert p.returncode == 0
 
     p = subprocess.run(

--- a/tests/test_ssl_cert.py
+++ b/tests/test_ssl_cert.py
@@ -93,7 +93,7 @@ def test_000_create_monitor():
     serverCert.create_signed_certificate(cluster.cert)
 
     # the root user also needs the certificates, tests are connecting with it
-    subprocess.run(
+    p = subprocess.run(
         ["sudo", "ln", "-s", client_top_directory, "/root/.postgresql"]
     )
     assert p.returncode == 0

--- a/tests/test_ssl_cert.py
+++ b/tests/test_ssl_cert.py
@@ -92,11 +92,18 @@ def test_000_create_monitor():
     )
     serverCert.create_signed_certificate(cluster.cert)
 
+    # the root user also needs the certificates, tests are connecting with it
+    subprocess.run(
+        ["sudo", "ln", "-s", client_top_directory, "/root/.postgresql"]
+    )
+    assert p.returncode == 0
+
     p = subprocess.run(
         [
             "ls",
             "-ld",
             client_top_directory,
+            "/root/.postgresql",
             cluster.cert.crt,
             cluster.cert.csr,
             cluster.cert.key,
@@ -111,10 +118,6 @@ def test_000_create_monitor():
         capture_output=True,
     )
     print("%s" % p.stdout)
-
-    # the root user also needs the certificates, tests are connecting with it
-    subprocess.run(["ln", "-s", client_top_directory, "/root/.postgresql"])
-    assert p.returncode == 0
 
     #
     # Now create the monitor Postgres instance with the certificates

--- a/tests/test_ssl_cert.py
+++ b/tests/test_ssl_cert.py
@@ -93,8 +93,21 @@ def test_000_create_monitor():
     serverCert.create_signed_certificate(cluster.cert)
 
     # the root user also needs the certificates, tests are connecting with it
+    root_top_directory = "/root/.postgresql"
     p = subprocess.run(
-        ["sudo", "ln", "-s", client_top_directory, "/root/.postgresql"]
+        ["sudo", "install", "-d", "-m", "740", root_top_directory]
+    )
+    assert p.returncode == 0
+
+    p = subprocess.run(
+        [
+            "sudo",
+            "cp",
+            clientCert.crt,
+            clientCert.csr,
+            clientCert.key,
+            root_top_directory,
+        ]
     )
     assert p.returncode == 0
 
@@ -103,7 +116,10 @@ def test_000_create_monitor():
             "ls",
             "-ld",
             client_top_directory,
-            "/root/.postgresql",
+            root_top_directory,
+            os.path.join(root_top_directory, "postgresql.crt"),
+            os.path.join(root_top_directory, "postgresql.csr"),
+            os.path.join(root_top_directory, "postgresql.key"),
             cluster.cert.crt,
             cluster.cert.csr,
             cluster.cert.key,


### PR DESCRIPTION
It seems that Postgres 14 implement more security checks around ownership of
the client-side root certificate, and our symlink doesn't comply with those
rules anymore in the GitHub Action environment.