### PR TITLE
Use DEBIAN_FRONTEND noninteractive in our Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ARG PGVERSION=10
 FROM debian:buster-slim as base
 
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     build-essential \
     ca-certificates \
 	curl \
@@ -56,7 +56,7 @@ RUN echo "deb http://apt.postgresql.org/pub/repos/apt buster-pgdg main" > /etc/a
 # bypass initdb of a "main" cluster
 RUN echo 'create_main_cluster = false' | sudo tee -a /etc/postgresql-common/createcluster.conf
 RUN apt-get update \
-	&& apt-get install -y --no-install-recommends \
+	&& DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
      postgresql-server-dev-10 \
      postgresql-server-dev-11 \
      postgresql-server-dev-12 \

--- a/tests/tablespaces/Makefile
+++ b/tests/tablespaces/Makefile
@@ -11,10 +11,10 @@ tail:
 	docker-compose logs -f
 
 state:
-	docker-compose exec monitor pg_autoctl show state
+	docker-compose exec -T monitor pg_autoctl show state
 
 watch:
-	docker-compose exec monitor pg_autoctl watch
+	docker-compose exec -T monitor pg_autoctl watch
 
 test_01:
 	docker-compose up -d node1
@@ -26,8 +26,8 @@ test_02:
 
 test_03:
 	# Pollute the data dir so pg_rewind fails
-	docker-compose exec node2 mkdir '/var/lib/postgres/data/base/1/99999999'
-	docker-compose exec monitor pg_autoctl perform failover
+	docker-compose exec -T node2 mkdir '/var/lib/postgres/data/base/1/99999999'
+	docker-compose exec -T monitor pg_autoctl perform failover
 	TEST_NUM="03" docker-compose up --exit-code-from=test test
 
 test_04:
@@ -39,7 +39,7 @@ test_05:
 	TEST_NUM="05" docker-compose up --exit-code-from=test test
 
 test_06:
-	docker-compose exec monitor pg_autoctl perform failover
+	docker-compose exec -T monitor pg_autoctl perform failover
 	TEST_NUM="06" docker-compose up --exit-code-from=test test
 
 test: build test_01 test_02 test_03 test_04 test_05 test_06


### PR DESCRIPTION
This allows avoiding errors from debian when asking the user about their
choice of handling configuration files, when those have been edited manually
like we do on /etc/postgresql-common/createcluster.conf.