### PR TITLE
Improve tests stability around wait-until-pg-is-running.

### DIFF
--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -1727,6 +1727,10 @@ class MonitorNode(PGNode):
         self.pg_autoctl = PGAutoCtl(self)
         self.pg_autoctl.run(level="-v")
 
+        # avoid a race condition when trying to read the configuration file
+        # before it's ready.
+        time.sleep(2)
+
         # when on the monitor we always want Postgres to be running to continue
         self.wait_until_pg_is_running()
 


### PR DESCRIPTION
In the GitHab Actions testing we see a lot of spurious errors around waiting
for Postgres to be running after creating a monitor node.

When diving in the logs, it seems like the configuration file for the
monitor is still being written and there is a race condition when the client
side command `pg_autoctl do pgsetup wait` tries to parse the pg_autoctl.cfg
file and when the server-side `pg_autoctl run` writes it to disk.

Here we just add a 2 seconds sleep before running the interactive command,
to see if that theory holds. Later, we might want to have a retry loop over
reading the configuration file in the `pg_autoctl do pgsetup ...` commands,
to better handle this race condition.