### PR TITLE
Fix make valgrind-session.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -384,8 +384,8 @@ compose:
 valgrind-session: build-test
 	docker run                             \
 	    --name $(TEST_CONTAINER_NAME) 	   \
-		$(DOCKER_RUN_OPTS)			       \
-		$(TEST_CONTAINER_NAME)			   \
+		$(DOCKER_RUN_OPTS) -it		       \
+		$(TEST_CONTAINER_NAME):pg14		   \
 	    make -C /usr/src/pg_auto_failover  \
 	     VALGRIND=1 					   \
 	     TMUX_TOP_DIR=/tmp/tmux 	       \


### PR DESCRIPTION
After running the valgrind session for quite some time and doing a bunch of failovers, the valgrind report still is empty.

Fixes #914 then.