### PR TITLE
Fix Dockerfile compat for Citus before 11.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -167,8 +167,7 @@ RUN adduser docker sudo
 RUN adduser docker postgres
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
-COPY --from=build /usr/lib/postgresql/${PGVERSION}/lib/citus.so /usr/lib/postgresql/${PGVERSION}/lib
-COPY --from=build /usr/lib/postgresql/${PGVERSION}/lib/citus_columnar.so /usr/lib/postgresql/${PGVERSION}/lib
+COPY --from=build /usr/lib/postgresql/${PGVERSION}/lib/citus*.so /usr/lib/postgresql/${PGVERSION}/lib
 COPY --from=build /usr/share/postgresql/${PGVERSION}/extension/citus* /usr/share/postgresql/${PGVERSION}/extension/
 
 COPY --from=build /usr/lib/postgresql/${PGVERSION}/lib/pgautofailover.so /usr/lib/postgresql/${PGVERSION}/lib


### PR DESCRIPTION
The citus_columnar.so file is only produced starting at Citus 11, not before that. To be compatible with previous versions if Citus, use a wildcard in the filenames in the Dockerfile COPY command.