### PR TITLE
Make checkPgAutoFailoverVersion void

### DIFF
--- a/src/monitor/metadata.h
+++ b/src/monitor/metadata.h
@@ -44,4 +44,4 @@ extern Oid pgAutoFailoverSchemaId(void);
 extern Oid pgAutoFailoverExtensionOwner(void);
 extern void LockFormation(char *formationId, LOCKMODE lockMode);
 extern void LockNodeGroup(char *formationId, int groupId, LOCKMODE lockMode);
-extern bool checkPgAutoFailoverVersion(void);
+extern void checkPgAutoFailoverVersion(void);


### PR DESCRIPTION
The checkPgAutoFailoverVersion() function was defined having a bool return type, but in practice it could only return true as the error paths were using ereport() which doesn't return. No callers of the function inspected the return value for good reason. Refactor to a void function which better match reality.

While there, also make sure that that fast-exit path is taken before any memory is allocated.