### PR TITLE
Use environment PGDATABASE as the default create node --dbname.

### DIFF
--- a/src/bin/pg_autoctl/cli_common.c
+++ b/src/bin/pg_autoctl/cli_common.c
@@ -959,6 +959,15 @@ bool
 cli_common_getenv_pgsetup(PostgresSetup *pgSetup,
 						  SSLCommandLineOptions *sslCommandLineOptions)
 {
+	if (env_exists("PGDATABASE"))
+	{
+		if (!get_env_copy("PGDATABASE", pgSetup->dbname, sizeof(pgSetup->dbname)))
+		{
+			/* errors have already been logged */
+			exit(EXIT_CODE_BAD_ARGS);
+		}
+	}
+
 	if (env_exists(PG_AUTOCTL_SSL_SELF_SIGNED))
 	{
 		char selfSigned[BUFSIZE] = { 0 };


### PR DESCRIPTION
When creating a node the option --dbname can be used to create a database for the application. When using Citus, that database is where pg_autoctl installs the Citus extensions, which is recommanded to be installed in a single database in your Postgres cluster.

To ease using pg_autoctl docker-compose and kubernetes, use PGDATABASE as the default value for the --dbname option, when set in the environment.

Fixes #953 