### PR TITLE
Fix command-line parsing on Alpine Linux (#905)

### DIFF
--- a/src/bin/pg_autoctl/cli_root.c
+++ b/src/bin/pg_autoctl/cli_root.c
@@ -162,7 +162,7 @@ root_options(int argc, char **argv)
 
 	optind = 0;
 
-	while ((c = getopt_long(argc, argv, "JVvqh",
+	while ((c = getopt_long(argc, argv, "+JVvqh",
 							long_options, &option_index)) != -1)
 	{
 		switch (c)


### PR DESCRIPTION
Add POSIX mode prefix (+) to root option string to ensure consistent getopt behavior between glibc and musl libc. This fixes an issue where subcommand options like `pg_autoctl create postgres --help` were not being recognized on Alpine Linux due to musl's different handling of unknown options when `POSIXLY_CORRECT=1` is set.

Fixes #905

Tested the fix by compiling against both the official `postgres:17` (Debian Bookworm / **glibc**) and `postgres:17-alpine` (Alpine 3.22 / **musl**) Docker containers and macOS 15.5 Homebrew `postgresql@17`.

Without this fix `pg_autoctl` is unusable on Alpine Linux and other musl libc based systems.