### PR TITLE
Fix pg_autoctl monitor bad memory access

### DIFF
--- a/src/bin/pg_autoctl/monitor.c
+++ b/src/bin/pg_autoctl/monitor.c
@@ -371,13 +371,14 @@ monitor_get_nodes(Monitor *monitor, char *formation, int groupId,
 	int paramCount = 1;
 	Oid paramTypes[2] = { TEXTOID, INT4OID };
 	const char *paramValues[2] = { 0 };
+	IntString myGroupIdString = { 0 };
 	NodeAddressArrayParseContext parseContext = { { 0 }, nodeArray, false };
 
 	paramValues[0] = formation;
 
 	if (groupId > -1)
 	{
-		IntString myGroupIdString = intToString(groupId);
+		myGroupIdString = intToString(groupId);
 
 		++paramCount;
 		paramValues[1] = myGroupIdString.strValue;
@@ -429,12 +430,13 @@ monitor_print_nodes_as_json(Monitor *monitor, char *formation, int groupId)
 	int paramCount = 1;
 	Oid paramTypes[2] = { TEXTOID, INT4OID };
 	const char *paramValues[2] = { 0 };
+	IntString myGroupIdString = { 0 };
 
 	paramValues[0] = formation;
 
 	if (groupId > -1)
 	{
-		IntString myGroupIdString = intToString(groupId);
+		myGroupIdString = intToString(groupId);
 
 		++paramCount;
 		paramValues[1] = myGroupIdString.strValue;


### PR DESCRIPTION
The current code in `src/bin/pg_autoctl/monitor.c` use-after-scope bad memory access because it assigns a pointer inside a block that is then used outside this scope.

The fix is to move the initialization of the referenced value to the beginning of the function, outside the block scope.

The fix can be seen when running `pg_autoctl perform switchover`.

**Before:**
```sh
docker compose exec node1 pg_autoctl perform switchover
18:01:22 60 INFO  Waiting 60 secs for a notification with state "primary" in formation "default" and group 0
18:01:22 60 INFO  Listening monitor notifications about state changes in formation "default" and group 0
18:01:22 60 INFO  Following table displays times when notifications are received
18:01:22 60 ERROR Monitor ERROR:  invalid byte sequence for encoding "UTF8": 0x9a
18:01:22 60 ERROR Monitor CONTEXT:  unnamed portal parameter $2
18:01:22 60 ERROR SQL query: SELECT * FROM pgautofailover.get_nodes($1, $2) ORDER BY node_id
18:01:22 60 ERROR SQL params: 'default', 'ges in formation&�����'
18:01:22 60 ERROR Failed to get other nodes from the monitor while running "SELECT * FROM pgautofailover.get_nodes($1, $2) ORDER BY node_id" with formation default and group 0
18:01:22 60 WARN  Failed to get_nodes() on the monitor
```

**After:**
```sh
docker compose exec node1 pg_autoctl perform switchover
17:58:13 144 INFO  Waiting 60 secs for a notification with state "primary" in formation "default" and group 0
17:58:13 144 INFO  Listening monitor notifications about state changes in formation "default" and group 0
17:58:13 144 INFO  Following table displays times when notifications are received
```