### PR TITLE
Fix tutorial docker compose build failure

### DIFF
--- a/docs/tutorial/docker-compose.yml
+++ b/docs/tutorial/docker-compose.yml
@@ -1,7 +1,7 @@
 x-node: &node
   build:
     context: ../..
-    dockerfile: Dockerfile
+    dockerfile: docs/tutorial/Dockerfile
     tags:
       - pg_auto_failover:tutorial
   volumes:


### PR DESCRIPTION
The dockerfile reference in the tutorial's docker-compose was not the tutorial's Dockerfile, but the one at the project root. Running the instructions from [the tutorial](https://pg-auto-failover.readthedocs.io/en/main/tutorial.html) lead to a failed docker build.

Platform: Docker version 28.3.2, build 578ccf6 , Mac OSX 15.6.1