### PR TITLE
Fix incorrect pg_autoctl set command in tutorial

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -242,7 +242,7 @@ order for it to never be a candidate for failover:
 
 ::
 
-   $ docker compose exec node3 pg_autoctl set candidate-priority 0 --name node3
+   $ docker compose exec node3 pg_autoctl set node candidate-priority 0 --name node3
 
 To see the replication settings for all the nodes, the following command can
 be useful, and is described in more details in the :ref:`architecture_setup`


### PR DESCRIPTION
In [`Editing the replication settings while in production` section](https://pg-auto-failover.readthedocs.io/en/main/tutorial.html#editing-the-replication-settings-while-in-production), describing how to set a node’s candidate priority, the command example is missing the node subcommand.

The current example causes an error:
```
$ docker compose exec node3 pg_autoctl set candidate-priority 0 --name node3
pg_autoctl set: candidate-priority: unknown command

Available commands:
  pg_autoctl set
  + node       set a node property on the monitor
  + formation  set a formation property on the monitor
```

This PR updates the tutorial to use the correct command syntax.
