### PR TITLE
Clear errno before calling strtol()

### DIFF
--- a/src/bin/pg_autoctl/cli_get_set_properties.c
+++ b/src/bin/pg_autoctl/cli_get_set_properties.c
@@ -436,6 +436,7 @@ cli_set_node_candidate_priority(int argc, char **argv)
 		exit(EXIT_CODE_BAD_ARGS);
 	}
 
+	errno = 0;
 	int candidatePriority = strtol(argv[0], NULL, 10);
 
 	if (errno == EINVAL || candidatePriority < 0 || candidatePriority > 100)
@@ -598,6 +599,7 @@ cli_set_formation_number_sync_standbys(int argc, char **argv)
 		exit(EXIT_CODE_BAD_ARGS);
 	}
 
+	errno = 0;
 	int numberSyncStandbys = strtol(argv[0], NULL, 10);
 	if (errno == EINVAL || numberSyncStandbys < 0)
 	{


### PR DESCRIPTION
This fixes two commands that were incorrectly rejecting valid integer values:
- `pg_autoctl set node candidate-priority`
- `pg_autoctl set formation number-sync-standbys`

The strtol() function does not reset errno to 0 on success, so checking errno without clearing it first can detect stale error values from unrelated operations.

refs #1011, #929

---

The current version fails with `Expected a non-negative integer value`. This occured in a monitor node only (if on worker node, works fine). See also https://github.com/hapostgres/pg_auto_failover/issues/1011#issuecomment-1808465925

```
postgres@pg3:~$ /usr/bin/pg_autoctl --version
pg_autoctl version 2.2-2.pgdg24.04+1
pg_autoctl extension version 2.2
compiled with PostgreSQL 17.4 (Ubuntu 17.4-1.pgdg24.04+2) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0, 64-bit
compatible with Postgres 13, 14, 15, 16 and 17

postgres@pg3:~$ /usr/bin/pg_autoctl set formation number-sync-standbys 0
16:20:52 387787 ERROR number-sync-standbys value 0 is not valid. Expected a non-negative integer value. 
```

This fixe works as expected.
```
postgres@pg3:~$ /usr/local/bin/pg_autoctl --version
pg_autoctl version 2.2.8.g5f31d4f.dirty
pg_autoctl extension version 2.2
compiled with PostgreSQL 17.7 (Ubuntu 17.7-3.pgdg24.04+1) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0, 64-bit
compatible with Postgres 13, 14, 15, 16 and 17

postgres@pg3:~$ /usr/local/bin/pg_autoctl set formation number-sync-standbys 0
16:20:55 387816 INFO  Waiting for the settings to have been applied to the monitor and primary node
16:20:55 387816 INFO  New state is reported by node 1 "node_7" (pg1:5432): "apply_settings"
16:20:55 387816 INFO  Setting goal state of node 1 "node_7" (pg1:5432) to primary after it applied replication properties change.
16:20:55 387816 INFO  New state is reported by node 1 "node_7" (pg1:5432): "primary"
16:20:55 387816 INFO  primary node has now set synchronous_standby_names = 'ANY 1 (pgautofailover_standby_2)'
0
```