### PR TITLE
Fix Docker tutorial build failing on fresh clone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -111,7 +111,6 @@ COPY Makefile ./
 COPY Makefile.azure ./
 COPY Makefile.citus ./
 COPY ./src/ ./src
-COPY ./src/bin/pg_autoctl/git-version.h ./src/bin/pg_autoctl/git-version.h
 RUN make -s clean && make -s install -j8
 
 

--- a/Makefile
+++ b/Makefile
@@ -24,11 +24,15 @@ TOP := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 # Get pg_auto_failover version from header file
 VERSION_FILE = src/bin/pg_autoctl/git-version.h
 ifeq ("$(wildcard $(VERSION_FILE))","")
+ifneq ("$(wildcard .git)","")
 DUMMY := $(shell git update-index -q --refresh)
 GIT_DIRTY := $(shell test -z "`git diff-index --name-only HEAD --`" || echo "-dirty")
 GIT_VVERSION := $(shell git describe --match "v[0-9]*" HEAD 2>/dev/null)
 GIT_DVERSION := $(shell echo $(GIT_VVERSION) | awk -Fv '{print $$2"$(GIT_DIRTY)"}')
 GIT_VERSION := $(shell echo $(GIT_DVERSION) | sed -e 's/-/./g')
+else
+GIT_VERSION := unknown
+endif
 else
 GIT_VERSION := $(shell awk -F '[ "]' '{print $$4}' $(VERSION_FILE))
 endif


### PR DESCRIPTION
## Summary
- Remove explicit COPY of `git-version.h` which doesn't exist in a fresh git clone (the Makefile generates it automatically)
- Add check for `.git` directory before running git commands to avoid "fatal: not a git repository" warnings in Docker builds

Fixes: https://github.com/hapostgres/pg_auto_failover/issues/1109

## Test plan
- [x] `docker compose build` in `docs/tutorial` now succeeds on fresh clone
- [x] Version shows "unknown" in Docker builds (expected, no git repo)
- [x] Local builds with git still get correct version

🤖 Generated with [Claude Code](https://claude.ai/code)